### PR TITLE
feat(#1): DC-SETUP-001 initialize pnpm workspace with Turborepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "diricode",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@9.15.0",
+  "type": "module",
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "dev": "turbo run dev",
+    "clean": "turbo run clean && rm -rf node_modules"
+  },
+  "devDependencies": {
+    "turbo": "^2.3.0"
+  },
+  "engines": {
+    "node": ">=20",
+    "pnpm": ">=9"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "packages/*"
+  - "apps/*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
+      "cache": true
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "outputs": ["coverage/**"],
+      "cache": true,
+      "inputs": ["src/**", "tests/**", "*.config.*"]
+    },
+    "lint": {
+      "dependsOn": ["build"],
+      "cache": true,
+      "inputs": ["src/**", "*.config.*", ".eslintrc*"]
+    },
+    "typecheck": {
+      "dependsOn": ["build"],
+      "cache": true,
+      "inputs": ["src/**", "tsconfig.json", "*.config.ts"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #18

Implements **DC-SETUP-001** — the foundational monorepo configuration for the DiriCode project as part of Epic #1 (Monorepo Setup [POC]).

## Changes

- **`pnpm-workspace.yaml`** — Defines workspace packages: `packages/*` and `apps/*`
- **`turbo.json`** — Turborepo pipeline configuration with tasks: `build`, `test`, `lint`, `typecheck`, `dev`, `clean`
- **`package.json`** — Root workspace manifest with `pnpm@9.15.0` as packageManager, turbo scripts, and Node >=20 / pnpm >=9 engines

## Quality Checks

| Check | Result |
|-------|--------|
| `pnpm install` | ✅ turbo installed successfully |
| `pnpm build` | ✅ 0 packages (expected — no packages yet) |
| `pnpm lint` | ✅ 0 packages (expected — no packages yet) |
| `pnpm typecheck` | ✅ 0 packages (expected — no packages yet) |

> Note: "No tasks were executed" warnings are expected. The workspace structure is ready for DC-SETUP-002 which will scaffold the actual packages.

## Next Step

DC-SETUP-002 will scaffold the package directories (`packages/`, `apps/`) and add the first real packages, at which point these pipelines will execute fully.