### PR TITLE
feat(providers): add Provider interface and registry (#27)

### DIFF
--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -12,6 +12,11 @@
     "build": "tsc --build",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
+    "test": "bun test src/__tests__",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/providers/src/__tests__/registry.test.ts
+++ b/packages/providers/src/__tests__/registry.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  ProviderAlreadyRegisteredError,
+  ProviderNotFoundError,
+  ProviderPriorities,
+  Registry,
+} from "../index.js";
+import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "../index.js";
+
+function makeProvider(name: string, modelId = "test-model"): Provider {
+  const defaultModel: ModelConfig = { modelId };
+  return {
+    name,
+    defaultModel,
+    isAvailable: () => true,
+    generate: (_options: GenerateOptions): Promise<string> =>
+      Promise.resolve(`${name}:response`),
+    stream: (_options: GenerateOptions): AsyncIterable<StreamChunk> => {
+      async function* gen() {
+        yield { delta: `${name}:chunk`, done: false };
+        yield { delta: "", done: true };
+      }
+      return gen();
+    },
+  };
+}
+
+describe("Registry", () => {
+  describe("register", () => {
+    it("registers a provider and returns this for chaining", () => {
+      const reg = new Registry();
+      const copilot = makeProvider("copilot");
+      const result = reg.register(copilot, ProviderPriorities.COPILOT);
+      expect(result).toBe(reg);
+      expect(reg.size).toBe(1);
+    });
+
+    it("allows registering multiple distinct providers", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      reg.register(makeProvider("kimi"), ProviderPriorities.KIMI);
+      expect(reg.size).toBe(2);
+    });
+
+    it("throws ProviderAlreadyRegisteredError on duplicate name", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      expect(() =>
+        reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT),
+      ).toThrow(ProviderAlreadyRegisteredError);
+    });
+
+    it("ProviderAlreadyRegisteredError message includes provider name", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      expect(() =>
+        reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT),
+      ).toThrow(/copilot/);
+    });
+  });
+
+  describe("get", () => {
+    it("returns the registered provider by name", () => {
+      const reg = new Registry();
+      const copilot = makeProvider("copilot");
+      reg.register(copilot, ProviderPriorities.COPILOT);
+      expect(reg.get("copilot")).toBe(copilot);
+    });
+
+    it("throws ProviderNotFoundError for unknown name", () => {
+      const reg = new Registry();
+      expect(() => reg.get("unknown")).toThrow(ProviderNotFoundError);
+    });
+
+    it("ProviderNotFoundError message includes the missing name", () => {
+      const reg = new Registry();
+      expect(() => reg.get("unknown")).toThrow(/unknown/);
+    });
+  });
+
+  describe("list", () => {
+    it("returns empty array when no providers registered", () => {
+      const reg = new Registry();
+      expect(reg.list()).toEqual([]);
+    });
+
+    it("returns entries sorted ascending by priority", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("kimi"), ProviderPriorities.KIMI);
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      const names = reg.list().map((e) => e.name);
+      expect(names).toEqual(["copilot", "kimi"]);
+    });
+
+    it("includes priority in each entry", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      reg.register(makeProvider("kimi"), ProviderPriorities.KIMI);
+      expect(reg.list()).toEqual([
+        { name: "copilot", priority: 1 },
+        { name: "kimi", priority: 2 },
+      ]);
+    });
+
+    it("returns a new sorted snapshot each call", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("kimi"), ProviderPriorities.KIMI);
+      const first = reg.list();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      const second = reg.list();
+      expect(first).toHaveLength(1);
+      expect(second).toHaveLength(2);
+      expect(second[0]?.name).toBe("copilot");
+    });
+  });
+
+  describe("getDefault", () => {
+    it("throws when registry is empty", () => {
+      const reg = new Registry();
+      expect(() => reg.getDefault()).toThrow("No providers are registered");
+    });
+
+    it("returns the sole provider when only one is registered", () => {
+      const reg = new Registry();
+      const copilot = makeProvider("copilot");
+      reg.register(copilot, ProviderPriorities.COPILOT);
+      expect(reg.getDefault()).toBe(copilot);
+    });
+
+    it("returns the provider with the lowest priority number", () => {
+      const reg = new Registry();
+      const kimi = makeProvider("kimi");
+      const copilot = makeProvider("copilot");
+      reg.register(kimi, ProviderPriorities.KIMI);
+      reg.register(copilot, ProviderPriorities.COPILOT);
+      expect(reg.getDefault()).toBe(copilot);
+    });
+
+    it("returns correct default regardless of registration order", () => {
+      const reg = new Registry();
+      const copilot = makeProvider("copilot");
+      const kimi = makeProvider("kimi");
+      reg.register(copilot, ProviderPriorities.COPILOT);
+      reg.register(kimi, ProviderPriorities.KIMI);
+      expect(reg.getDefault()).toBe(copilot);
+    });
+
+    it("handles custom priority numbers", () => {
+      const reg = new Registry();
+      const high = makeProvider("high");
+      const low = makeProvider("low");
+      reg.register(low, 99);
+      reg.register(high, 5);
+      expect(reg.getDefault()).toBe(high);
+    });
+  });
+
+  describe("has", () => {
+    it("returns false for unregistered name", () => {
+      const reg = new Registry();
+      expect(reg.has("copilot")).toBe(false);
+    });
+
+    it("returns true after registration", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      expect(reg.has("copilot")).toBe(true);
+    });
+  });
+
+  describe("size", () => {
+    it("is 0 initially", () => {
+      const reg = new Registry();
+      expect(reg.size).toBe(0);
+    });
+
+    it("increments with each registration", () => {
+      const reg = new Registry();
+      reg.register(makeProvider("copilot"), ProviderPriorities.COPILOT);
+      expect(reg.size).toBe(1);
+      reg.register(makeProvider("kimi"), ProviderPriorities.KIMI);
+      expect(reg.size).toBe(2);
+    });
+  });
+});

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,1 +1,16 @@
-export {};
+export type {
+  GenerateOptions,
+  ModelConfig,
+  Provider,
+  ProviderEntry,
+  ProviderPriority,
+  StreamChunk,
+} from "./types.js";
+
+export { ProviderPriorities } from "./types.js";
+
+export {
+  ProviderAlreadyRegisteredError,
+  ProviderNotFoundError,
+  Registry,
+} from "./registry.js";

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -1,0 +1,62 @@
+import type { Provider, ProviderEntry, ProviderPriority } from "./types.js";
+
+export class ProviderNotFoundError extends Error {
+  constructor(name: string) {
+    super(`Provider "${name}" is not registered`);
+    this.name = "ProviderNotFoundError";
+  }
+}
+
+export class ProviderAlreadyRegisteredError extends Error {
+  constructor(name: string) {
+    super(`Provider "${name}" is already registered`);
+    this.name = "ProviderAlreadyRegisteredError";
+  }
+}
+
+export class Registry {
+  readonly #entries = new Map<string, ProviderEntry>();
+
+  register(provider: Provider, priority: ProviderPriority): this {
+    if (this.#entries.has(provider.name)) {
+      throw new ProviderAlreadyRegisteredError(provider.name);
+    }
+    this.#entries.set(provider.name, { provider, priority });
+    return this;
+  }
+
+  get(name: string): Provider {
+    const entry = this.#entries.get(name);
+    if (entry === undefined) {
+      throw new ProviderNotFoundError(name);
+    }
+    return entry.provider;
+  }
+
+  list(): ReadonlyArray<{ name: string; priority: ProviderPriority }> {
+    return Array.from(this.#entries.values())
+      .sort((a, b) => a.priority - b.priority)
+      .map(({ provider, priority }) => ({ name: provider.name, priority }));
+  }
+
+  getDefault(): Provider {
+    if (this.#entries.size === 0) {
+      throw new Error("No providers are registered");
+    }
+    let best: ProviderEntry | undefined;
+    for (const entry of this.#entries.values()) {
+      if (best === undefined || entry.priority < best.priority) {
+        best = entry;
+      }
+    }
+    return (best as ProviderEntry).provider;
+  }
+
+  has(name: string): boolean {
+    return this.#entries.has(name);
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+}

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Provider interface and related types for @diricode/providers.
+ *
+ * Providers wrap AI model APIs (Copilot, Kimi, etc.) and expose a
+ * uniform streaming/generation interface to the rest of DiriCode.
+ */
+
+// ---------------------------------------------------------------------------
+// Priority
+// ---------------------------------------------------------------------------
+
+/**
+ * Lower number = higher priority.
+ * Copilot = 1, Kimi = 2 (per spec §5 MVP Providers).
+ */
+export type ProviderPriority = number;
+
+/** Well-known priority constants for MVP providers. */
+export const ProviderPriorities = {
+  COPILOT: 1,
+  KIMI: 2,
+} as const satisfies Record<string, ProviderPriority>;
+
+// ---------------------------------------------------------------------------
+// Model configuration
+// ---------------------------------------------------------------------------
+
+/** Identifies a specific model and its generation parameters. */
+export interface ModelConfig {
+  /** Model identifier as understood by the provider (e.g. "gpt-4o", "moonshot-v1-8k"). */
+  readonly modelId: string;
+  /** Maximum tokens to generate. Provider default used when omitted. */
+  readonly maxTokens?: number;
+  /** Sampling temperature in [0, 2]. Provider default used when omitted. */
+  readonly temperature?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Stream chunk
+// ---------------------------------------------------------------------------
+
+/** A single chunk emitted during a streaming completion. */
+export interface StreamChunk {
+  /** Incremental text delta for this chunk. */
+  readonly delta: string;
+  /** Whether this is the final chunk in the stream. */
+  readonly done: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Generation options
+// ---------------------------------------------------------------------------
+
+/** Options passed to {@link Provider.generate} and {@link Provider.stream}. */
+export interface GenerateOptions {
+  /** Prompt / user message content. */
+  readonly prompt: string;
+  /** Override the provider's default model config for this request. */
+  readonly model?: ModelConfig;
+  /** Abort signal to cancel the request. */
+  readonly signal?: AbortSignal;
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstract interface every AI provider adapter must implement.
+ *
+ * Implementations are NOT required here — this is the contract only.
+ * Actual adapters (CopilotProvider, KimiProvider) live in separate modules.
+ */
+export interface Provider {
+  /** Unique name used as the registry key (e.g. "copilot", "kimi"). */
+  readonly name: string;
+
+  /**
+   * The default model configuration for this provider.
+   * Individual calls may override via `GenerateOptions.model`.
+   */
+  readonly defaultModel: ModelConfig;
+
+  /**
+   * Returns true when the provider is ready to accept requests.
+   * Implementations should check API key presence / reachability here.
+   */
+  isAvailable(): boolean;
+
+  /**
+   * Generate a non-streaming completion and return the full text.
+   *
+   * @param options - Generation parameters.
+   * @returns Resolved text output.
+   */
+  generate(options: GenerateOptions): Promise<string>;
+
+  /**
+   * Generate a streaming completion.
+   *
+   * @param options - Generation parameters.
+   * @returns An async iterable of {@link StreamChunk} values.
+   */
+  stream(options: GenerateOptions): AsyncIterable<StreamChunk>;
+}
+
+// ---------------------------------------------------------------------------
+// Registry entry (internal)
+// ---------------------------------------------------------------------------
+
+/** Internal record stored in the {@link Registry} map. */
+export interface ProviderEntry {
+  readonly provider: Provider;
+  readonly priority: ProviderPriority;
+}

--- a/packages/providers/vitest.config.ts
+++ b/packages/providers/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+    environment: "node",
+    include: ["src/**/__tests__/**/*.test.ts"],
+    server: {
+      deps: {
+        inline: [],
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Implements the abstract Provider interface and registry for DiriCode's provider routing layer.

### What was added

- **Provider interface** (`types.ts`) — abstract contract with `generate()`, `stream()`, `isAvailable()`, `name`, `defaultModel`
- **Registry class** (`registry.ts`) — register/get/list/getDefault APIs with priority ordering
- **Typed errors** — `ProviderNotFoundError`, `ProviderAlreadyRegisteredError`
- **Priority constants** — `COPILOT=1`, `KIMI=2` (per spec §5 MVP Providers)
- **20 unit tests** covering all registry methods

### Files

| File | Purpose |
|------|---------|
| `packages/providers/src/types.ts` | Provider interface + types |
| `packages/providers/src/registry.ts` | Registry class |
| `packages/providers/src/index.ts` | Public exports |
| `packages/providers/src/__tests__/registry.test.ts` | Unit tests |
| `tsconfig.base.json` | Base TS config for monorepo |

## Context

- Epic: #3 Provider Router [POC → MVP-1]
- Issue: #27 DC-PROV-001

Closes #27