### PR TITLE
feat(server): add Hono HTTP server skeleton with /health and /api/v1 routes (#34)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,5 +13,12 @@
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.19.11",
+    "hono": "^4.12.8"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.11"
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,13 @@
-export {};
+import { createApp } from "./server.js";
+
+export type { ApiEnvelope, ErrorEnvelope, SuccessEnvelope } from "./middleware/error.js";
+export { createApp } from "./server.js";
+
+const PORT = Number(process.env.PORT ?? 3001);
+
+const app = createApp();
+
+export default {
+  port: PORT,
+  fetch: app.fetch,
+};

--- a/packages/server/src/middleware/cors.ts
+++ b/packages/server/src/middleware/cors.ts
@@ -1,0 +1,17 @@
+import { cors } from "hono/cors";
+import type { MiddlewareHandler } from "hono";
+
+const ALLOWED_ORIGINS = [
+  "http://localhost:3000",
+  "http://localhost:5173",
+  "http://localhost:4173",
+] as const;
+
+export const corsMiddleware: MiddlewareHandler = cors({
+  origin: ALLOWED_ORIGINS as unknown as string[],
+  allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allowHeaders: ["Content-Type", "Authorization"],
+  exposeHeaders: ["Content-Length"],
+  maxAge: 86400,
+  credentials: true,
+});

--- a/packages/server/src/middleware/error.ts
+++ b/packages/server/src/middleware/error.ts
@@ -1,0 +1,39 @@
+import { HTTPException } from "hono/http-exception";
+import type { Context, MiddlewareHandler } from "hono";
+
+export interface ErrorDetail {
+  code: string;
+  message: string;
+}
+
+export interface ErrorEnvelope {
+  success: false;
+  error: ErrorDetail;
+}
+
+export interface SuccessEnvelope<T> {
+  success: true;
+  data: T;
+}
+
+export type ApiEnvelope<T> = SuccessEnvelope<T> | ErrorEnvelope;
+
+function buildErrorEnvelope(code: string, message: string): ErrorEnvelope {
+  return { success: false, error: { code, message } };
+}
+
+export const errorMiddleware: MiddlewareHandler = async (c: Context, next): Promise<void> => {
+  try {
+    await next();
+  } catch (err) {
+    if (err instanceof HTTPException) {
+      const envelope = buildErrorEnvelope(`HTTP_${err.status.toString()}`, err.message);
+      c.res = c.json(envelope, err.status);
+      return;
+    }
+
+    const message = err instanceof Error ? err.message : "Internal server error";
+    const envelope = buildErrorEnvelope("INTERNAL_SERVER_ERROR", message);
+    c.res = c.json(envelope, 500);
+  }
+};

--- a/packages/server/src/routes/api/v1.ts
+++ b/packages/server/src/routes/api/v1.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+
+export const v1Router = new Hono();
+
+v1Router.get("/", (c) => {
+  return c.json({ success: true, data: { version: "v1" } });
+});

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import type { SuccessEnvelope } from "../middleware/error.js";
+
+interface HealthResponse {
+  status: "ok";
+  timestamp: number;
+}
+
+export const healthRouter = new Hono();
+
+healthRouter.get("/", (c) => {
+  const response: SuccessEnvelope<HealthResponse> = {
+    success: true,
+    data: {
+      status: "ok",
+      timestamp: Date.now(),
+    },
+  };
+  return c.json(response);
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import { corsMiddleware } from "./middleware/cors.js";
+import { errorMiddleware } from "./middleware/error.js";
+import { healthRouter } from "./routes/health.js";
+import { v1Router } from "./routes/api/v1.js";
+
+export function createApp(): Hono {
+  const app = new Hono();
+
+  app.use("*", corsMiddleware);
+  app.use("*", errorMiddleware);
+
+  app.route("/health", healthRouter);
+  app.route("/api/v1", v1Router);
+
+  return app;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,15 +53,36 @@ importers:
         specifier: ^7.6.13
         version: 7.6.13
 
-  packages/providers: {}
+  packages/providers:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.5.0)
 
-  packages/server: {}
+  packages/server:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.8)
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.8
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.11
+        version: 1.3.11
 
   packages/tools:
     dependencies:
       '@diricode/core':
         specifier: workspace:*
         version: link:../core
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -269,6 +290,12 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -446,6 +473,9 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/bun@1.3.11':
+    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -592,6 +622,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bun-types@1.3.11:
+    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -764,6 +797,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1257,6 +1294,10 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1366,6 +1407,10 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.5.0
+
+  '@types/bun@1.3.11':
+    dependencies:
+      bun-types: 1.3.11
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1560,6 +1605,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bun-types@1.3.11:
+    dependencies:
+      '@types/node': 25.5.0
+
   cac@6.7.14: {}
 
   chai@5.3.3:
@@ -1747,6 +1796,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  hono@4.12.8: {}
 
   ieee754@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- feat(server): add Hono HTTP server skeleton with /health and /api/v1 routes
- Fixes #34

## Details
- Hono app with GET /health endpoint (returns `{ success: true, data: { status: "ok", timestamp: number } }`)
- `/api/v1/*` route group
- CORS middleware for Web UI (localhost:3000/5173/4173)
- Centralized error middleware with typed response envelope
- Bun.serve bootstrap via `export default { port, fetch: app.fetch }`

## Epic
Part of #4 — Server API Foundation [POC]

## Verification
- [x] typecheck passes
- [x] lint passes
- [x] build succeeds