### PR TITLE
feat(agent-core): agent interface and lifecycle (#55)

### DIFF
--- a/src/agent-core/agent.ts
+++ b/src/agent-core/agent.ts
@@ -1,0 +1,56 @@
+export enum AgentLifecycleState {
+  idle = "idle",
+  initializing = "initializing",
+  executing = "executing",
+  completing = "completing",
+  error = "error",
+  completed = "completed",
+}
+
+export interface AgentDefinition {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface AgentExecutionContext {
+  agentId: string;
+  runId: string;
+}
+
+export type AgentResult = {
+  success: boolean;
+  output: unknown;
+  tokensUsed: number;
+  cost: number;
+  errors: string[];
+};
+
+export class AgentStateMachine {
+  private currentState: AgentLifecycleState;
+
+  constructor() {
+    this.currentState = AgentLifecycleState.idle;
+  }
+
+  public getState(): AgentLifecycleState {
+    return this.currentState;
+  }
+
+  public transitionTo(newState: AgentLifecycleState): void {
+    const validTransitions: Record<AgentLifecycleState, AgentLifecycleState[]> = {
+      [AgentLifecycleState.idle]: [AgentLifecycleState.initializing],
+      [AgentLifecycleState.initializing]: [AgentLifecycleState.executing],
+      [AgentLifecycleState.executing]: [AgentLifecycleState.completing, AgentLifecycleState.error],
+      [AgentLifecycleState.completing]: [AgentLifecycleState.completed],
+      [AgentLifecycleState.error]: [AgentLifecycleState.completed],
+      [AgentLifecycleState.completed]: [],
+    };
+
+    if (validTransitions[this.currentState].includes(newState)) {
+      this.currentState = newState;
+    } else {
+      throw new Error(`Invalid state transition from ${this.currentState} to ${newState}`);
+    }
+  }
+}

--- a/src/agent-core/index.ts
+++ b/src/agent-core/index.ts
@@ -1,0 +1,1 @@
+export * from "./agent";


### PR DESCRIPTION
## Summary
- Add `AgentLifecycleState` enum (idle, initializing, executing, completing, error, completed)
- Add `AgentDefinition` interface (id, name, description)
- Add `AgentExecutionContext` interface (agentId, runId)
- Add `AgentResult` type (success, output, tokensUsed, cost, errors)
- Add `AgentStateMachine` class with valid state transitions

## Epic
Part of #7 — Agents Core Execution Framework [POC → MVP-1]

## Closes
Closes #55