### PR TITLE
feat(server): SSE transport — GET /api/v1/events with connection registry, Last-Event-ID reconnect, typed JSON events, heartbeat (#35)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,17 @@
 import { createApp } from "./server.js";
 
 export type { ApiEnvelope, ErrorEnvelope, SuccessEnvelope } from "./middleware/error.js";
+export type {
+  SseConnection,
+  SseConnectedData,
+  SseData,
+  SseErrorData,
+  SseEventData,
+  SseEventType,
+  SseHeartbeatData,
+  SseMessage,
+} from "./sse/types.js";
+export { SseRegistry, sseRegistry } from "./sse/registry.js";
 export { createApp } from "./server.js";
 
 const PORT = Number(process.env.PORT ?? 3001);

--- a/packages/server/src/routes/api/events.ts
+++ b/packages/server/src/routes/api/events.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { sseRegistry } from "../../sse/registry.js";
+import type { SseConnectedData, SseHeartbeatData, SseMessage } from "../../sse/types.js";
+
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+function buildMessage(event: SseMessage["event"], data: SseMessage["data"]): SseMessage {
+  return { id: generateId(), event, data };
+}
+
+export const eventsRouter = new Hono();
+
+eventsRouter.get("/", (c) => {
+  const lastEventId = c.req.header("Last-Event-ID") ?? null;
+  const connectionId = generateId();
+  const abort = new AbortController();
+
+  sseRegistry.add({
+    id: connectionId,
+    connectedAt: Date.now(),
+    lastEventId,
+    abort,
+  });
+
+  return streamSSE(
+    c,
+    async (stream) => {
+      c.req.raw.signal.addEventListener("abort", () => {
+        abort.abort();
+        sseRegistry.remove(connectionId);
+      });
+
+      const connectedData: SseConnectedData = {
+        type: "connected",
+        timestamp: Date.now(),
+        connectionId,
+        lastEventId,
+      };
+      const connectedMsg = buildMessage("connected", connectedData);
+      await stream.writeSSE({
+        id: connectedMsg.id,
+        event: connectedMsg.event,
+        data: JSON.stringify(connectedMsg.data),
+      });
+
+      while (!abort.signal.aborted) {
+        await stream.sleep(HEARTBEAT_INTERVAL_MS);
+
+        const heartbeatData: SseHeartbeatData = {
+          type: "heartbeat",
+          timestamp: Date.now(),
+        };
+        const heartbeatMsg = buildMessage("heartbeat", heartbeatData);
+        await stream.writeSSE({
+          id: heartbeatMsg.id,
+          event: heartbeatMsg.event,
+          data: JSON.stringify(heartbeatMsg.data),
+        });
+      }
+
+      sseRegistry.remove(connectionId);
+    },
+    async (err, stream) => {
+      await stream.writeSSE({
+        event: "error",
+        data: JSON.stringify({
+          type: "error",
+          timestamp: Date.now(),
+          code: "STREAM_ERROR",
+          message: err.message,
+        }),
+      });
+    },
+  );
+});

--- a/packages/server/src/routes/api/v1.ts
+++ b/packages/server/src/routes/api/v1.ts
@@ -1,7 +1,10 @@
 import { Hono } from "hono";
+import { eventsRouter } from "./events.js";
 
 export const v1Router = new Hono();
 
 v1Router.get("/", (c) => {
   return c.json({ success: true, data: { version: "v1" } });
 });
+
+v1Router.route("/events", eventsRouter);

--- a/packages/server/src/sse/registry.ts
+++ b/packages/server/src/sse/registry.ts
@@ -1,0 +1,23 @@
+import type { SseConnection } from "./types.js";
+
+export class SseRegistry {
+  private readonly connections = new Map<string, SseConnection>();
+
+  add(connection: SseConnection): void {
+    this.connections.set(connection.id, connection);
+  }
+
+  remove(id: string): void {
+    this.connections.delete(id);
+  }
+
+  get(id: string): SseConnection | undefined {
+    return this.connections.get(id);
+  }
+
+  size(): number {
+    return this.connections.size;
+  }
+}
+
+export const sseRegistry = new SseRegistry();

--- a/packages/server/src/sse/types.ts
+++ b/packages/server/src/sse/types.ts
@@ -1,0 +1,51 @@
+/** Union of all typed SSE event types emitted by the server. */
+export type SseEventType =
+  | "connected"
+  | "heartbeat"
+  | "error"
+  | "tool_start"
+  | "tool_end"
+  | "message";
+
+/** Base structure for every SSE event's data payload. */
+export interface SseEventData {
+  type: SseEventType;
+  timestamp: number;
+}
+
+/** Sent immediately after a client connects (or reconnects). */
+export interface SseConnectedData extends SseEventData {
+  type: "connected";
+  connectionId: string;
+  lastEventId: string | null;
+}
+
+/** Periodic heartbeat to keep the connection alive. */
+export interface SseHeartbeatData extends SseEventData {
+  type: "heartbeat";
+}
+
+/** Generic error notification. */
+export interface SseErrorData extends SseEventData {
+  type: "error";
+  code: string;
+  message: string;
+}
+
+/** Discriminated union of all concrete event data shapes. */
+export type SseData = SseConnectedData | SseHeartbeatData | SseErrorData | SseEventData;
+
+/** A fully-formed SSE message ready for serialisation. */
+export interface SseMessage {
+  id: string;
+  event: SseEventType;
+  data: SseData;
+}
+
+/** Metadata stored in the connection registry for one live SSE client. */
+export interface SseConnection {
+  id: string;
+  connectedAt: number;
+  lastEventId: string | null;
+  abort: AbortController;
+}


### PR DESCRIPTION
## Summary

Implements **DC-SRV-002: SSE (Server-Sent Events) transport** as specified in issue #35.

### What's included

- **`GET /api/v1/events`** — persistent SSE stream endpoint via `hono/streaming`'s `streamSSE`
- **Connection registry** (`SseRegistry`) — in-memory map of live connections keyed by UUID; supports `add`, `remove`, `get`, `size`
- **Last-Event-ID reconnect** — reads `Last-Event-ID` request header and propagates `connectionId` + `lastEventId` in the `connected` event payload
- **Typed JSON events** — discriminated union (`SseData`) covering `connected`, `heartbeat`, `error`, `tool_start`, `tool_end`, `message` event shapes; all events serialised as `JSON.stringify(data)`
- **Heartbeat** — 20 s interval loop emitting `heartbeat` events; loop exits on `AbortController` signal
- **Clean teardown** — request abort listener removes connection from registry and fires `AbortController.abort()`

### Files changed

| File | Change |
|------|--------|
| `packages/server/src/sse/types.ts` | New — typed SSE event shapes |
| `packages/server/src/sse/registry.ts` | New — `SseRegistry` class + singleton `sseRegistry` |
| `packages/server/src/routes/api/events.ts` | New — `eventsRouter` Hono router |
| `packages/server/src/routes/api/v1.ts` | Mount `eventsRouter` at `/events` |
| `packages/server/src/index.ts` | Re-export SSE types and registry |

### Quality

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅

Closes #35