### PR TITLE
feat(agents): add dispatcher agent and registry (#63)

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@diricode/agents",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@diricode/core": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.1.0"
+  }
+}

--- a/packages/agents/src/__tests__/dispatcher.test.ts
+++ b/packages/agents/src/__tests__/dispatcher.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentError, AgentRegistry, createDispatcher } from "../index.js";
+import type { Agent, AgentContext, AgentResult } from "../index.js";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+function makeAgent(name: string, keywords: string[] = []): Agent {
+  return {
+    metadata: {
+      name,
+      description: `${name} agent ${keywords.join(" ")}`,
+      tier: "medium",
+      category: "code",
+      capabilities: keywords,
+      tags: [],
+    },
+    execute: (_input: string, _context: AgentContext): Promise<AgentResult> =>
+      Promise.resolve({ success: true, output: `${name}:done`, toolCalls: 2, tokensUsed: 100 }),
+  };
+}
+
+function makeContext(overrides?: Partial<AgentContext>): { ctx: AgentContext; emit: MockFn } {
+  const emit = vi.fn();
+  const ctx: AgentContext = {
+    workspaceRoot: "/workspace",
+    sessionId: "session-123",
+    tools: [],
+    emit,
+    ...overrides,
+  };
+  return { ctx, emit };
+}
+
+function findEmitCall(emit: MockFn, eventName: string): [string, unknown] | undefined {
+  return (emit.mock.calls as [string, unknown][]).find(([event]) => event === eventName);
+}
+
+describe("createDispatcher", () => {
+  it("returns an Agent with correct metadata", () => {
+    const registry = new AgentRegistry();
+    const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+
+    expect(dispatcher.metadata.name).toBe("dispatcher");
+    expect(dispatcher.metadata.tier).toBe("heavy");
+    expect(dispatcher.metadata.category).toBe("command");
+    expect(dispatcher.metadata.capabilities).toContain("intent-classification");
+    expect(dispatcher.metadata.capabilities).toContain("task-routing");
+    expect(dispatcher.metadata.capabilities).toContain("agent-delegation");
+    expect(dispatcher.metadata.capabilities).toContain("progress-monitoring");
+    expect(dispatcher.metadata.tags).toContain("orchestration");
+  });
+
+  describe("execute", () => {
+    it("emits agent.started at the start of execution", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write", "implement"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(emit).toHaveBeenCalledWith(
+        "agent.started",
+        expect.objectContaining({ agentId: "dispatcher" }),
+      );
+    });
+
+    it("emits dispatcher.intent-classified event", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(emit).toHaveBeenCalledWith(
+        "dispatcher.intent-classified",
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          intent: expect.objectContaining({ category: expect.any(String) }),
+        }),
+      );
+    });
+
+    it("emits dispatcher.candidates-found event", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write", "implement"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(emit).toHaveBeenCalledWith(
+        "dispatcher.candidates-found",
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ candidates: expect.any(Array) }),
+      );
+    });
+
+    it("emits dispatcher.agent-selected event", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write", "code"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(emit).toHaveBeenCalledWith(
+        "dispatcher.agent-selected",
+        expect.objectContaining({ agent: "coder" }),
+      );
+    });
+
+    it("emits agent.completed at the end of execution", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(emit).toHaveBeenCalledWith(
+        "agent.completed",
+        expect.objectContaining({ agentId: "dispatcher", success: true }),
+      );
+    });
+
+    it("delegates to the best matching agent and returns its result", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write", "implement"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx } = makeContext();
+
+      const result = await dispatcher.execute("write some code", ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("coder:done");
+    });
+
+    it("sets parentAgentId to 'dispatcher' in child context", async () => {
+      const registry = new AgentRegistry();
+      let capturedContext: AgentContext | undefined;
+
+      const agent: Agent = {
+        metadata: {
+          name: "coder",
+          description: "write code",
+          tier: "medium",
+          category: "code",
+          capabilities: ["write"],
+          tags: [],
+        },
+        execute: (_input: string, childCtx: AgentContext): Promise<AgentResult> => {
+          capturedContext = childCtx;
+          return Promise.resolve({ success: true, output: "done", toolCalls: 0, tokensUsed: 0 });
+        },
+      };
+
+      registry.register(agent);
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx } = makeContext();
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(capturedContext?.parentAgentId).toBe("dispatcher");
+    });
+
+    it("throws AgentError when no agent matches the intent", async () => {
+      const registry = new AgentRegistry();
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx } = makeContext();
+
+      await expect(dispatcher.execute("xyznonexistent", ctx)).rejects.toThrow(AgentError);
+    });
+
+    it("AgentError has NO_AGENT_FOUND code when no match", async () => {
+      const registry = new AgentRegistry();
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx } = makeContext();
+
+      let caught: AgentError | undefined;
+      try {
+        await dispatcher.execute("xyznonexistent", ctx);
+      } catch (e) {
+        if (e instanceof AgentError) caught = e;
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught?.code).toBe("NO_AGENT_FOUND");
+    });
+
+    it("includes parentAgentId from parent context in agent.started event", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext({ parentAgentId: "orchestrator" });
+
+      await dispatcher.execute("write some code", ctx);
+
+      expect(emit).toHaveBeenCalledWith(
+        "agent.started",
+        expect.objectContaining({ parentAgentId: "orchestrator" }),
+      );
+    });
+
+    it("truncates long input to 200 chars in agent.started event", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["write", "code"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+      const longInput = "write " + "x".repeat(300);
+
+      await dispatcher.execute(longInput, ctx);
+
+      const startedCall = findEmitCall(emit, "agent.started");
+      expect(startedCall).toBeDefined();
+      const payload = startedCall?.[1] as { input: string } | undefined;
+      expect(payload?.input.length).toBeLessThanOrEqual(200);
+    });
+  });
+
+  describe("intent classification", () => {
+    const keywordCases: [string, string][] = [
+      ["write a function", "code"],
+      ["implement the feature", "code"],
+      ["create a new module", "code"],
+      ["add error handling", "code"],
+      ["build the project", "code"],
+      ["review my PR", "quality"],
+      ["check for bugs", "quality"],
+      ["verify the output", "quality"],
+      ["test the logic", "quality"],
+      ["plan the architecture", "strategy"],
+      ["design the system", "strategy"],
+      ["architect the solution", "strategy"],
+      ["find the bug", "research"],
+      ["search for examples", "research"],
+      ["explore the codebase", "research"],
+      ["look for patterns", "research"],
+      ["commit the changes", "utility"],
+      ["deploy to production", "utility"],
+      ["format the file", "utility"],
+      ["lint the code", "utility"],
+    ];
+
+    for (const [input, expectedCategory] of keywordCases) {
+      it(`classifies "${input}" as "${expectedCategory}"`, async () => {
+        const registry = new AgentRegistry();
+        const agent: Agent = {
+          metadata: {
+            name: "target",
+            description: input,
+            tier: "medium",
+            category: expectedCategory as Agent["metadata"]["category"],
+            capabilities: input.split(" "),
+            tags: [],
+          },
+          execute: () =>
+            Promise.resolve({ success: true, output: "done", toolCalls: 0, tokensUsed: 0 }),
+        };
+        registry.register(agent);
+
+        const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+        const { ctx, emit } = makeContext();
+
+        await dispatcher.execute(input, ctx);
+
+        const classifiedCall = findEmitCall(emit, "dispatcher.intent-classified");
+        expect(classifiedCall).toBeDefined();
+        const payload = classifiedCall?.[1] as { intent: { category: string } } | undefined;
+        expect(payload?.intent.category).toBe(expectedCategory);
+      });
+    }
+
+    it("defaults to 'code' category for unrecognized input", async () => {
+      const registry = new AgentRegistry();
+      registry.register(makeAgent("coder", ["xyzrandom", "stuff"]));
+      const dispatcher = createDispatcher({ registry, maxDelegationDepth: 5 });
+      const { ctx, emit } = makeContext();
+
+      try {
+        await dispatcher.execute("xyzrandom stuff", ctx);
+      } catch {
+        // Expected: dispatcher may throw if no agent matches
+      }
+
+      const classifiedCall = findEmitCall(emit, "dispatcher.intent-classified");
+      if (classifiedCall) {
+        const payload = classifiedCall[1] as { intent: { category: string } };
+        expect(payload.intent.category).toBe("code");
+      }
+    });
+  });
+});

--- a/packages/agents/src/__tests__/registry.test.ts
+++ b/packages/agents/src/__tests__/registry.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { AgentAlreadyRegisteredError, AgentNotFoundError, AgentRegistry } from "../index.js";
+import type { Agent, AgentContext, AgentResult } from "../index.js";
+
+function makeAgent(name: string, category: Agent["metadata"]["category"] = "code"): Agent {
+  return {
+    metadata: {
+      name,
+      description: `${name} agent`,
+      tier: "medium",
+      category,
+      capabilities: [name, "test"],
+      tags: ["test"],
+    },
+    execute: (_input: string, _context: AgentContext): Promise<AgentResult> =>
+      Promise.resolve({ success: true, output: `${name}:done`, toolCalls: 0, tokensUsed: 0 }),
+  };
+}
+
+describe("AgentRegistry", () => {
+  describe("register", () => {
+    it("registers an agent and returns this for chaining", () => {
+      const reg = new AgentRegistry();
+      const coder = makeAgent("coder");
+      const result = reg.register(coder);
+      expect(result).toBe(reg);
+      expect(reg.size).toBe(1);
+    });
+
+    it("allows registering multiple distinct agents", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      reg.register(makeAgent("reviewer"));
+      expect(reg.size).toBe(2);
+    });
+
+    it("throws AgentAlreadyRegisteredError on duplicate name", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      expect(() => reg.register(makeAgent("coder"))).toThrow(AgentAlreadyRegisteredError);
+    });
+
+    it("AgentAlreadyRegisteredError message includes agent name", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      expect(() => reg.register(makeAgent("coder"))).toThrow(/coder/);
+    });
+  });
+
+  describe("get", () => {
+    it("returns the registered agent by name", () => {
+      const reg = new AgentRegistry();
+      const coder = makeAgent("coder");
+      reg.register(coder);
+      expect(reg.get("coder")).toBe(coder);
+    });
+
+    it("throws AgentNotFoundError for unknown name", () => {
+      const reg = new AgentRegistry();
+      expect(() => reg.get("unknown")).toThrow(AgentNotFoundError);
+    });
+
+    it("AgentNotFoundError message includes the missing name", () => {
+      const reg = new AgentRegistry();
+      expect(() => reg.get("unknown")).toThrow(/unknown/);
+    });
+  });
+
+  describe("list", () => {
+    it("returns empty array when no agents registered", () => {
+      const reg = new AgentRegistry();
+      expect(reg.list()).toEqual([]);
+    });
+
+    it("returns metadata for all registered agents when no category filter", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder", "code"));
+      reg.register(makeAgent("reviewer", "quality"));
+      expect(reg.list()).toHaveLength(2);
+    });
+
+    it("filters by category", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder", "code"));
+      reg.register(makeAgent("reviewer", "quality"));
+      reg.register(makeAgent("tester", "quality"));
+      const quality = reg.list("quality");
+      expect(quality).toHaveLength(2);
+      expect(quality.every((m) => m.category === "quality")).toBe(true);
+    });
+
+    it("returns empty array when no agents match category", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder", "code"));
+      expect(reg.list("strategy")).toEqual([]);
+    });
+
+    it("returns metadata only, not full agent objects", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      const [item] = reg.list();
+      expect(item).toBeDefined();
+      expect(item).not.toHaveProperty("execute");
+      expect(item).toHaveProperty("name", "coder");
+    });
+  });
+
+  describe("search", () => {
+    it("returns empty array for empty query", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      expect(reg.search("")).toEqual([]);
+    });
+
+    it("returns empty array when no agents match", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      expect(reg.search("xyznonexistent")).toEqual([]);
+    });
+
+    it("returns scored results for matching query", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      const results = reg.search("coder");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]).toHaveProperty("agent");
+      expect(results[0]).toHaveProperty("score");
+    });
+
+    it("matches against agent name", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("code-writer"));
+      reg.register(makeAgent("reviewer"));
+      const results = reg.search("code-writer");
+      expect(results.some((r) => r.agent.name === "code-writer")).toBe(true);
+    });
+
+    it("matches against capabilities", () => {
+      const agent: Agent = {
+        metadata: {
+          name: "specialist",
+          description: "does things",
+          tier: "light",
+          category: "utility",
+          capabilities: ["formatting", "linting"],
+          tags: [],
+        },
+        execute: () => Promise.resolve({ success: true, output: "", toolCalls: 0, tokensUsed: 0 }),
+      };
+      const reg = new AgentRegistry();
+      reg.register(agent);
+      const results = reg.search("formatting");
+      expect(results.some((r) => r.agent.name === "specialist")).toBe(true);
+    });
+
+    it("returns results sorted descending by score", () => {
+      const reg = new AgentRegistry();
+      const highMatch: Agent = {
+        metadata: {
+          name: "code-master",
+          description: "code code code",
+          tier: "heavy",
+          category: "code",
+          capabilities: ["code", "write", "implement"],
+          tags: ["code"],
+        },
+        execute: () => Promise.resolve({ success: true, output: "", toolCalls: 0, tokensUsed: 0 }),
+      };
+      const lowMatch = makeAgent("other-agent", "quality");
+      reg.register(highMatch);
+      reg.register(lowMatch);
+      const results = reg.search("code write implement");
+      expect(results.length).toBeGreaterThan(0);
+      if (results.length > 1) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(results[0]!.score).toBeGreaterThanOrEqual(results[1]!.score);
+      }
+    });
+  });
+
+  describe("has", () => {
+    it("returns false for unregistered name", () => {
+      const reg = new AgentRegistry();
+      expect(reg.has("coder")).toBe(false);
+    });
+
+    it("returns true after registration", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      expect(reg.has("coder")).toBe(true);
+    });
+  });
+
+  describe("size", () => {
+    it("is 0 initially", () => {
+      const reg = new AgentRegistry();
+      expect(reg.size).toBe(0);
+    });
+
+    it("increments with each registration", () => {
+      const reg = new AgentRegistry();
+      reg.register(makeAgent("coder"));
+      expect(reg.size).toBe(1);
+      reg.register(makeAgent("reviewer"));
+      expect(reg.size).toBe(2);
+    });
+  });
+});

--- a/packages/agents/src/dispatcher.ts
+++ b/packages/agents/src/dispatcher.ts
@@ -1,0 +1,121 @@
+import type {
+  Agent,
+  AgentCategory,
+  AgentContext,
+  AgentMetadata,
+  AgentResult,
+} from "@diricode/core";
+import { AgentError } from "@diricode/core";
+import type { AgentRegistry } from "./registry.js";
+
+export interface DispatcherConfig {
+  readonly registry: AgentRegistry;
+  readonly maxDelegationDepth: number;
+}
+
+interface ClassifiedIntent {
+  category: AgentCategory;
+  query: string;
+  confidence: number;
+}
+
+const KEYWORD_MAP: readonly (readonly [readonly string[], AgentCategory])[] = [
+  [["write", "implement", "create", "add", "build"], "code"],
+  [["review", "check", "verify", "test"], "quality"],
+  [["plan", "design", "architect"], "strategy"],
+  [["find", "search", "explore", "look"], "research"],
+  [["commit", "deploy", "format", "lint"], "utility"],
+] as const;
+
+function classifyIntent(input: string): ClassifiedIntent {
+  const lower = input.toLowerCase();
+  const words = lower.split(/\s+/);
+
+  for (const [keywords, category] of KEYWORD_MAP) {
+    for (const keyword of keywords) {
+      if (words.includes(keyword)) {
+        return { category, query: input, confidence: 1.0 };
+      }
+    }
+  }
+
+  for (const [keywords, category] of KEYWORD_MAP) {
+    for (const keyword of keywords) {
+      if (lower.includes(keyword)) {
+        return { category, query: input, confidence: 0.5 };
+      }
+    }
+  }
+
+  return { category: "code", query: input, confidence: 0.5 };
+}
+
+export function createDispatcher(config: DispatcherConfig): Agent {
+  const metadata: AgentMetadata = {
+    name: "dispatcher",
+    description: "Central coordinator: interprets user intent and delegates to specialist agents",
+    tier: "heavy",
+    category: "command",
+    capabilities: [
+      "intent-classification",
+      "task-routing",
+      "agent-delegation",
+      "progress-monitoring",
+    ],
+    tags: ["orchestration"],
+  };
+
+  return {
+    metadata,
+    async execute(input: string, context: AgentContext): Promise<AgentResult> {
+      context.emit("agent.started", {
+        agentId: metadata.name,
+        parentAgentId: context.parentAgentId,
+        input: input.substring(0, 200),
+      });
+
+      const intent = classifyIntent(input);
+      context.emit("dispatcher.intent-classified", { intent });
+
+      const candidates = config.registry.search(intent.query);
+      if (candidates.length === 0) {
+        throw new AgentError(
+          "NO_AGENT_FOUND",
+          `No suitable agent found for intent: ${intent.category}`,
+        );
+      }
+
+      context.emit("dispatcher.candidates-found", {
+        candidates: candidates.map((c) => ({ name: c.agent.name, score: c.score })),
+      });
+
+      const selected = candidates[0];
+      if (!selected) {
+        throw new AgentError("NO_AGENT_FOUND", "No candidates available");
+      }
+
+      context.emit("dispatcher.agent-selected", {
+        agent: selected.agent.name,
+        score: selected.score,
+      });
+
+      const agent = config.registry.get(selected.agent.name);
+      const childContext: AgentContext = {
+        ...context,
+        parentAgentId: metadata.name,
+      };
+
+      const result = await agent.execute(input, childContext);
+
+      context.emit("agent.completed", {
+        agentId: metadata.name,
+        delegatedTo: selected.agent.name,
+        success: result.success,
+        toolCalls: result.toolCalls,
+        tokensUsed: result.tokensUsed,
+      });
+
+      return result;
+    },
+  };
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,0 +1,12 @@
+export { AgentRegistry, AgentNotFoundError, AgentAlreadyRegisteredError } from "./registry.js";
+export { createDispatcher } from "./dispatcher.js";
+export type { DispatcherConfig } from "./dispatcher.js";
+export type {
+  Agent,
+  AgentCategory,
+  AgentContext,
+  AgentMetadata,
+  AgentResult,
+  AgentTier,
+} from "@diricode/core";
+export { AgentError } from "@diricode/core";

--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -1,0 +1,86 @@
+import type { Agent, AgentCategory, AgentMetadata } from "@diricode/core";
+
+export class AgentNotFoundError extends Error {
+  constructor(name: string) {
+    super(`Agent "${name}" is not registered`);
+    this.name = "AgentNotFoundError";
+  }
+}
+
+export class AgentAlreadyRegisteredError extends Error {
+  constructor(name: string) {
+    super(`Agent "${name}" is already registered`);
+    this.name = "AgentAlreadyRegisteredError";
+  }
+}
+
+export class AgentRegistry {
+  readonly #entries = new Map<string, Agent>();
+
+  register(agent: Agent): this {
+    if (this.#entries.has(agent.metadata.name)) {
+      throw new AgentAlreadyRegisteredError(agent.metadata.name);
+    }
+    this.#entries.set(agent.metadata.name, agent);
+    return this;
+  }
+
+  get(name: string): Agent {
+    const agent = this.#entries.get(name);
+    if (agent === undefined) {
+      throw new AgentNotFoundError(name);
+    }
+    return agent;
+  }
+
+  list(category?: AgentCategory): readonly AgentMetadata[] {
+    const all = Array.from(this.#entries.values()).map((a) => a.metadata);
+    if (category === undefined) {
+      return all;
+    }
+    return all.filter((m) => m.category === category);
+  }
+
+  search(query: string): readonly { agent: AgentMetadata; score: number }[] {
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) {
+      return [];
+    }
+
+    const results: { agent: AgentMetadata; score: number }[] = [];
+
+    for (const agent of this.#entries.values()) {
+      const { metadata } = agent;
+      const haystack = [
+        metadata.name,
+        metadata.description,
+        ...metadata.capabilities,
+        ...metadata.tags,
+        metadata.category,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      let score = 0;
+      for (const term of terms) {
+        if (haystack.includes(term)) {
+          score += 1.0;
+        }
+      }
+
+      if (score > 0) {
+        results.push({ agent: metadata, score: score / terms.length });
+      }
+    }
+
+    return results.sort((a, b) => b.score - a.score);
+  }
+
+  has(name: string): boolean {
+    return this.#entries.has(name);
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+}

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -1,0 +1,44 @@
+import type { Tool } from "../tools/types.js";
+
+export type AgentTier = "heavy" | "medium" | "light";
+
+export type AgentCategory = "command" | "strategy" | "code" | "quality" | "research" | "utility";
+
+export interface AgentMetadata {
+  readonly name: string;
+  readonly description: string;
+  readonly tier: AgentTier;
+  readonly category: AgentCategory;
+  readonly capabilities: readonly string[];
+  readonly tags: readonly string[];
+}
+
+export interface AgentContext {
+  readonly workspaceRoot: string;
+  readonly sessionId: string;
+  readonly parentAgentId?: string;
+  readonly tools: readonly Tool[];
+  emit: (event: string, payload: unknown) => void;
+}
+
+export interface AgentResult {
+  readonly success: boolean;
+  readonly output: string;
+  readonly toolCalls: number;
+  readonly tokensUsed: number;
+}
+
+export class AgentError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AgentError";
+  }
+}
+
+export interface Agent {
+  readonly metadata: AgentMetadata;
+  execute(input: string, context: AgentContext): Promise<AgentResult>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,13 @@ export type { Tool, ToolAnnotations, ToolContext, ToolResult } from "./tools/typ
 
 export { DiriCodeConfigSchema } from "./config/schema.js";
 export type { DiriCodeConfig } from "./config/schema.js";
+
+export { AgentError } from "./agents/types.js";
+export type {
+  Agent,
+  AgentCategory,
+  AgentContext,
+  AgentMetadata,
+  AgentResult,
+  AgentTier,
+} from "./agents/types.js";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -48,6 +48,8 @@
       "@diricode/github-mcp/*": ["./packages/github-mcp/src/*"],
       "@diricode/tools": ["./packages/tools/src/index.ts"],
       "@diricode/tools/*": ["./packages/tools/src/*"],
+      "@diricode/agents": ["./packages/agents/src/index.ts"],
+      "@diricode/agents/*": ["./packages/agents/src/*"],
       "@diricode/cli": ["./apps/cli/src/index.ts"],
       "@diricode/cli/*": ["./apps/cli/src/*"]
     }


### PR DESCRIPTION
## Summary
- Added `@diricode/agents` package with `AgentRegistry` (register/get/list/search/has/size)
- Added `createDispatcher()` factory producing the dispatcher agent with keyword-based intent classification
- Emits 5 structured EventStream events: `agent.started`, `dispatcher.intent-classified`, `dispatcher.candidates-found`, `dispatcher.agent-selected`, `agent.completed`
- 110 tests passing

## Changes
- `packages/core/src/agents/types.ts` — Agent type system (`AgentTier`, `AgentCategory`, `AgentMetadata`, `AgentContext`, `AgentResult`, `AgentError`, `Agent` interface)
- `packages/agents/` — New package with registry, dispatcher, barrel exports
- `packages/core/src/index.ts` — Re-exported agent types
- `tsconfig.base.json` — Added `@diricode/agents` path alias

Closes #63