### PR TITLE
ci: remove macOS runner (10x cost)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Remove macOS from CI matrix since it costs 10x more than Linux
- CI now runs on ubuntu-latest only

## Testing
- [x] lint passes locally
- [x] typecheck passes locally  
- [x] tests pass locally