### PR TITLE
chore: update to Node.js 24 (latest stable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "24"
           cache: pnpm
 
       # Persist Turborepo local cache (.turbo) between runs.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CI Status](https://img.shields.io/github/actions/workflow/status/radoxtech/diricode/ci.yml?branch=main)](https://github.com/radoxtech/diricode/actions)
-[![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-green.svg)](https://nodejs.org/)
+[![Node.js Version](https://img.shields.io/badge/node-%3E%3D24.0.0-green.svg)](https://nodejs.org/)
 
 An autonomous AI coding framework that manages your project through GitHub Issues and Projects. DiriCode runs sprints, delegates to 40 specialized agents, works in parallel across git worktrees, and reports progress back to you — while you review from your phone.
 
@@ -449,7 +449,7 @@ docs/
 
 ### Prerequisites
 
-- Node.js >= 20
+- Node.js >= 24
 - pnpm >= 9
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vitest": "^4.1.0"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=24",
     "pnpm": ">=9"
   },
   "workspaces": [


### PR DESCRIPTION
## Summary
- Update Node.js from v20 to v24 (latest stable)
- Update CI to use Node 24
- Update `package.json` engine requirement to `>=24`
- Update README Node.js badge and prerequisites

## Testing
- [x] build passes
- [x] typecheck passes
- [x] lint passes (0 errors)
- [x] tests pass (622 tests)