### PR TITLE
fix: opt-in to Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         os:
           - ubuntu-latest
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to opt-in to Node.js 24 for GitHub Actions runners
- Node.js 20 is deprecated and will stop working September 2026

## Testing
- [x] Local CI simulation passes