### PR TITLE
fix: move FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to workflow level and fix lint warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 # Turborepo local cache is persisted via actions/cache on the .turbo directory.
 name: CI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -23,8 +26,6 @@ jobs:
         os:
           - ubuntu-latest
 
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/tools/src/__tests__/file-edit.test.ts
+++ b/packages/tools/src/__tests__/file-edit.test.ts
@@ -8,7 +8,11 @@ describe("fileEditTool", () => {
   let workspaceRoot: string;
   const emittedEvents: { event: string; payload: unknown }[] = [];
 
-  const makeContext = () => ({
+  const makeContext = (): {
+    workspaceRoot: string;
+    emit: (event: string, payload: unknown) => void;
+    workspace: string;
+  } => ({
     workspaceRoot,
     emit: (event: string, payload: unknown) => {
       emittedEvents.push({ event, payload });

--- a/packages/tools/src/__tests__/file-write.test.ts
+++ b/packages/tools/src/__tests__/file-write.test.ts
@@ -8,7 +8,11 @@ describe("fileWriteTool", () => {
   let workspaceRoot: string;
   const emittedEvents: { event: string; payload: unknown }[] = [];
 
-  const makeContext = () => ({
+  const makeContext = (): {
+    workspaceRoot: string;
+    emit: (event: string, payload: unknown) => void;
+    workspace: string;
+  } => ({
     workspaceRoot,
     emit: (event: string, payload: unknown) => {
       emittedEvents.push({ event, payload });

--- a/packages/tools/src/__tests__/grep.test.ts
+++ b/packages/tools/src/__tests__/grep.test.ts
@@ -8,7 +8,11 @@ describe("grepTool", () => {
   let workspaceRoot: string;
   const emittedEvents: { event: string; payload: unknown }[] = [];
 
-  const makeContext = () => ({
+  const makeContext = (): {
+    workspaceRoot: string;
+    emit: (event: string, payload: unknown) => void;
+    workspace: string;
+  } => ({
     workspaceRoot,
     emit: (event: string, payload: unknown) => {
       emittedEvents.push({ event, payload });


### PR DESCRIPTION
## Summary
- Move `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to workflow level (was at job level)
- Add return types to `makeContext` functions in 3 test files to fix lint warnings

## Testing
- [x] lint passes (0 errors, 0 warnings)