### PR TITLE
fix: upgrade CI actions to Node 24 and correct test context types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@
 # Turborepo local cache is persisted via actions/cache on the .turbo directory.
 name: CI
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches:
@@ -28,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # fetch-depth: 0 required for turborepo to correctly determine
           # which packages/tasks need to be rebuilt. Shallow clones break
@@ -41,14 +38,14 @@ jobs:
           version: 9.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm
 
       # Persist Turborepo local cache (.turbo) between runs.
       - name: Cache Turborepo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml', '**/turbo.json', '**/tsconfig*.json', '**/eslint.config.*') }}

--- a/packages/tools/src/__tests__/file-edit.test.ts
+++ b/packages/tools/src/__tests__/file-edit.test.ts
@@ -3,16 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ToolError, fileEditTool } from "../index.js";
+import type { ToolContext } from "@diricode/core";
 
 describe("fileEditTool", () => {
   let workspaceRoot: string;
   const emittedEvents: { event: string; payload: unknown }[] = [];
 
-  const makeContext = (): {
-    workspaceRoot: string;
-    emit: (event: string, payload: unknown) => void;
-    workspace: string;
-  } => ({
+  const makeContext = (): ToolContext => ({
     workspaceRoot,
     emit: (event: string, payload: unknown) => {
       emittedEvents.push({ event, payload });

--- a/packages/tools/src/__tests__/file-write.test.ts
+++ b/packages/tools/src/__tests__/file-write.test.ts
@@ -3,16 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ToolError, fileWriteTool } from "../index.js";
+import type { ToolContext } from "@diricode/core";
 
 describe("fileWriteTool", () => {
   let workspaceRoot: string;
   const emittedEvents: { event: string; payload: unknown }[] = [];
 
-  const makeContext = (): {
-    workspaceRoot: string;
-    emit: (event: string, payload: unknown) => void;
-    workspace: string;
-  } => ({
+  const makeContext = (): ToolContext => ({
     workspaceRoot,
     emit: (event: string, payload: unknown) => {
       emittedEvents.push({ event, payload });

--- a/packages/tools/src/__tests__/grep.test.ts
+++ b/packages/tools/src/__tests__/grep.test.ts
@@ -3,16 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ToolError, grepTool } from "../index.js";
+import type { ToolContext } from "@diricode/core";
 
 describe("grepTool", () => {
   let workspaceRoot: string;
   const emittedEvents: { event: string; payload: unknown }[] = [];
 
-  const makeContext = (): {
-    workspaceRoot: string;
-    emit: (event: string, payload: unknown) => void;
-    workspace: string;
-  } => ({
+  const makeContext = (): ToolContext => ({
     workspaceRoot,
     emit: (event: string, payload: unknown) => {
       emittedEvents.push({ event, payload });


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions to Node 24-native majors (`checkout@v6`, `setup-node@v6`, `cache@v5`)
- fix tool test helpers to use the real `ToolContext` type instead of a custom shape requiring a fake `workspace` field
- remove the temporary Node 24 force flag workaround from CI

## Verification
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm test`