### PR TITLE
feat(core): implement c12 config loader with 4-layer merge (DC-CORE-002) (#24)

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -19,14 +19,14 @@ cli
 
 cli
   .command("[...args]", "Start interactive REPL (default)")
-  .action((_args: string[], options: Record<string, unknown>) => {
+  .action(async (_args: string[], options: Record<string, unknown>) => {
     try {
       const flags = validateFlags(options);
       if (flags.json !== true) {
         // eslint-disable-next-line no-console
         console.log(`diricode v${pkg.version}`);
       }
-      const config = resolveConfig(flags);
+      const config = await resolveConfig(flags);
       startRepl(config, { session: flags.session });
     } catch (err) {
       if (err instanceof Error) {
@@ -39,14 +39,14 @@ cli
 
 cli
   .command("run <prompt>", "Run a one-shot prompt and exit")
-  .action((prompt: string, options: Record<string, unknown>) => {
+  .action(async (prompt: string, options: Record<string, unknown>) => {
     try {
       const flags = validateFlags(options);
       if (flags.json !== true) {
         // eslint-disable-next-line no-console
         console.log(`diricode v${pkg.version}`);
       }
-      const config = resolveConfig(flags);
+      const config = await resolveConfig(flags);
       runOnce(config, prompt, { json: flags.json, session: flags.session });
     } catch (err) {
       if (err instanceof Error) {

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,39 +1,13 @@
-import { defu } from "defu";
-import { DiriCodeConfigSchema } from "@diricode/core";
+import { loadConfig } from "@diricode/core";
 import type { DiriCodeConfig } from "@diricode/core";
 import { flagsToConfigOverlay } from "./flags.js";
 import type { CLIFlags } from "./flags.js";
 
-export function resolveConfig(flags: CLIFlags): DiriCodeConfig {
-  const layer1 = DiriCodeConfigSchema.parse({});
-
-  // TODO: load from ~/.config/dc/config.jsonc via c12
-  const layer2: Record<string, unknown> = {};
-
-  // TODO: load from .dc/config.jsonc via c12
-  const layer3: Record<string, unknown> = {};
-
-  const envOverlay: Record<string, unknown> = {};
-
-  const dcProvider = process.env.DC_PROVIDER;
-  const dcModel = process.env.DC_MODEL;
-  const dcVerbose = process.env.DC_VERBOSE;
-
-  if (dcProvider != null && dcProvider !== "") {
-    envOverlay.providers = { [dcProvider]: {} };
-  }
-
-  if (dcModel != null && dcModel !== "") {
-    envOverlay.agents = { default: { model: dcModel } };
-  }
-
-  if (dcVerbose === "1" || dcVerbose === "true") {
-    envOverlay.workMode = { verbosity: "verbose" };
-  }
-
-  const layer4 = defu(flagsToConfigOverlay(flags), envOverlay);
-
-  const merged = defu(layer4, layer3, layer2, layer1);
-
-  return DiriCodeConfigSchema.parse(merged);
+export async function resolveConfig(flags: CLIFlags): Promise<DiriCodeConfig> {
+  const cliOverlay = flagsToConfigOverlay(flags);
+  const { config } = await loadConfig({
+    cwd: process.cwd(),
+    overrides: cliOverlay,
+  });
+  return config;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,9 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "c12": "^2.0.0",
+    "confbox": "^0.2.0",
+    "defu": "^6.1.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/core/src/config/__tests__/loader.test.ts
+++ b/packages/core/src/config/__tests__/loader.test.ts
@@ -1,0 +1,166 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../loader.js";
+
+function makeTempDir(): string {
+  const dir = join(
+    tmpdir(),
+    `dc-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("loadConfig", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("returns Zod defaults when no config files exist", async () => {
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.providers).toEqual({});
+    expect(result.config.agents).toEqual({});
+    expect(result.config.workMode.verbosity).toBe("normal");
+    expect(result.config.workMode.autonomy).toBe("guided");
+  });
+
+  it("includes defaults layer in result.layers", async () => {
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.layers.some((l) => l.source === "defaults")).toBe(true);
+  });
+
+  it("loads project JSONC config from .dc/config.jsonc", async () => {
+    const dcDir = join(tempDir, ".dc");
+    mkdirSync(dcDir, { recursive: true });
+    writeFileSync(
+      join(dcDir, "config.jsonc"),
+      JSON.stringify({
+        providers: { openai: { apiKey: "test-key" } },
+      }),
+    );
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.providers.openai?.apiKey).toBe("test-key");
+  });
+
+  it("deep merges project config over defaults", async () => {
+    const dcDir = join(tempDir, ".dc");
+    mkdirSync(dcDir, { recursive: true });
+    writeFileSync(
+      join(dcDir, "config.jsonc"),
+      JSON.stringify({
+        workMode: { verbosity: "verbose" },
+      }),
+    );
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.workMode.verbosity).toBe("verbose");
+    expect(result.config.workMode.autonomy).toBe("guided");
+  });
+
+  it("CLI overrides take highest priority over project config", async () => {
+    const dcDir = join(tempDir, ".dc");
+    mkdirSync(dcDir, { recursive: true });
+    writeFileSync(
+      join(dcDir, "config.jsonc"),
+      JSON.stringify({
+        workMode: { verbosity: "silent" },
+      }),
+    );
+
+    const result = await loadConfig({
+      cwd: tempDir,
+      overrides: { workMode: { verbosity: "verbose" } },
+    });
+    expect(result.config.workMode.verbosity).toBe("verbose");
+  });
+
+  it("DC_PROVIDER env var creates provider entry", async () => {
+    vi.stubEnv("DC_PROVIDER", "anthropic");
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.providers.anthropic).toBeDefined();
+  });
+
+  it("DC_MODEL env var sets agents.default.model", async () => {
+    vi.stubEnv("DC_MODEL", "gpt-4o");
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.agents.default?.model).toBe("gpt-4o");
+  });
+
+  it('DC_VERBOSE=1 sets workMode.verbosity to "verbose"', async () => {
+    vi.stubEnv("DC_VERBOSE", "1");
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.workMode.verbosity).toBe("verbose");
+  });
+
+  it('DC_VERBOSE=true sets workMode.verbosity to "verbose"', async () => {
+    vi.stubEnv("DC_VERBOSE", "true");
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config.workMode.verbosity).toBe("verbose");
+  });
+
+  it("validates final config with Zod (rejects invalid merged output)", async () => {
+    await expect(
+      loadConfig({
+        cwd: tempDir,
+        overrides: { workMode: { verbosity: "invalid-value" as "verbose" } },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("handles missing global config file gracefully", async () => {
+    await expect(loadConfig({ cwd: tempDir })).resolves.toBeDefined();
+  });
+
+  it("handles missing project config file gracefully", async () => {
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.config).toBeDefined();
+    expect(result.configFile).toBeUndefined();
+  });
+
+  it("returns layer info in result", async () => {
+    const result = await loadConfig({ cwd: tempDir });
+    expect(Array.isArray(result.layers)).toBe(true);
+    expect(result.layers.length).toBeGreaterThan(0);
+  });
+
+  it("includes project layer when project config file exists", async () => {
+    const dcDir = join(tempDir, ".dc");
+    mkdirSync(dcDir, { recursive: true });
+    writeFileSync(join(dcDir, "config.jsonc"), JSON.stringify({ project: { name: "my-project" } }));
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.layers.some((l) => l.source === "project")).toBe(true);
+  });
+
+  it("includes runtime layer when env vars are set", async () => {
+    vi.stubEnv("DC_VERBOSE", "1");
+
+    const result = await loadConfig({ cwd: tempDir });
+    expect(result.layers.some((l) => l.source === "runtime")).toBe(true);
+  });
+
+  it("CLI overrides take priority over DC_* env vars", async () => {
+    vi.stubEnv("DC_VERBOSE", "1");
+
+    const result = await loadConfig({
+      cwd: tempDir,
+      overrides: { workMode: { verbosity: "silent" } },
+    });
+    expect(result.config.workMode.verbosity).toBe("silent");
+  });
+});

--- a/packages/core/src/config/__tests__/paths.test.ts
+++ b/packages/core/src/config/__tests__/paths.test.ts
@@ -1,0 +1,71 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalConfigDir, getProjectConfigPath } from "../paths.js";
+
+describe("getGlobalConfigDir", () => {
+  let originalPlatform: NodeJS.Platform;
+
+  beforeEach(() => {
+    originalPlatform = process.platform;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    vi.unstubAllEnvs();
+  });
+
+  it("returns ~/Library/Preferences/dc on macOS", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const result = getGlobalConfigDir();
+    expect(result).toBe(join(homedir(), "Library", "Preferences", "dc"));
+  });
+
+  it("returns $XDG_CONFIG_HOME/dc on Linux when XDG_CONFIG_HOME is set", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.stubEnv("XDG_CONFIG_HOME", "/custom/config");
+    const result = getGlobalConfigDir();
+    expect(result).toBe("/custom/config/dc");
+  });
+
+  it("returns ~/.config/dc on Linux when XDG_CONFIG_HOME is not set", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.stubEnv("XDG_CONFIG_HOME", "");
+    const result = getGlobalConfigDir();
+    expect(result).toBe(join(homedir(), ".config", "dc"));
+  });
+
+  it("returns ~/.config/dc on Linux when XDG_CONFIG_HOME is undefined", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.stubEnv("XDG_CONFIG_HOME", undefined as unknown as string);
+    const result = getGlobalConfigDir();
+    expect(result).toBe(join(homedir(), ".config", "dc"));
+  });
+
+  it("throws on unsupported platform (win32)", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(() => getGlobalConfigDir()).toThrow('Unsupported platform: "win32"');
+  });
+
+  it("throws on other unsupported platforms", () => {
+    Object.defineProperty(process, "platform", { value: "freebsd" });
+    expect(() => getGlobalConfigDir()).toThrow('Unsupported platform: "freebsd"');
+  });
+});
+
+describe("getProjectConfigPath", () => {
+  it("returns .dc/config.jsonc relative to process.cwd() by default", () => {
+    const result = getProjectConfigPath();
+    expect(result).toBe(join(process.cwd(), ".dc", "config.jsonc"));
+  });
+
+  it("returns .dc/config.jsonc relative to custom dir", () => {
+    const result = getProjectConfigPath("/custom/dir");
+    expect(result).toBe("/custom/dir/.dc/config.jsonc");
+  });
+
+  it("resolves correctly with trailing slash in custom dir", () => {
+    const result = getProjectConfigPath("/some/project");
+    expect(result).toBe(join("/some/project", ".dc", "config.jsonc"));
+  });
+});

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,2 +1,5 @@
 export { DiriCodeConfigSchema } from "./schema.js";
 export type { DiriCodeConfig } from "./schema.js";
+export { loadConfig } from "./loader.js";
+export type { LoadConfigOptions, LoadConfigResult } from "./loader.js";
+export { getGlobalConfigDir, getProjectConfigPath } from "./paths.js";

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,0 +1,115 @@
+import { readFileSync, existsSync } from "node:fs";
+import { loadConfig as c12LoadConfig } from "c12";
+import { parseJSONC } from "confbox/jsonc";
+import { defu } from "defu";
+import { DiriCodeConfigSchema } from "./schema.js";
+import type { DiriCodeConfig } from "./schema.js";
+import { getGlobalConfigDir } from "./paths.js";
+import { join } from "node:path";
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+export interface LoadConfigOptions {
+  cwd?: string;
+  overrides?: DeepPartial<DiriCodeConfig>;
+}
+
+export interface LoadConfigResult {
+  config: DiriCodeConfig;
+  configFile?: string;
+  layers: { source: string; config: Record<string, unknown> }[];
+}
+
+function mapDcEnvVars(): Record<string, unknown> {
+  const overlay: Record<string, unknown> = {};
+
+  const dcProvider = process.env.DC_PROVIDER;
+  if (dcProvider != null && dcProvider !== "") {
+    overlay.providers = { [dcProvider]: {} };
+  }
+
+  const dcModel = process.env.DC_MODEL;
+  if (dcModel != null && dcModel !== "") {
+    overlay.agents = { default: { model: dcModel } };
+  }
+
+  const dcVerbose = process.env.DC_VERBOSE;
+  if (dcVerbose === "1" || dcVerbose === "true") {
+    overlay.workMode = { verbosity: "verbose" };
+  }
+
+  return overlay;
+}
+
+function loadGlobalJsonc(): Record<string, unknown> {
+  let globalDir: string;
+  try {
+    globalDir = getGlobalConfigDir();
+  } catch {
+    return {};
+  }
+
+  const globalConfigPath = join(globalDir, "config.jsonc");
+  let content: string;
+  try {
+    content = readFileSync(globalConfigPath, "utf-8");
+  } catch {
+    return {};
+  }
+
+  const parsed: unknown = parseJSONC(content);
+  if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return {};
+}
+
+export async function loadConfig(options?: LoadConfigOptions): Promise<LoadConfigResult> {
+  const cwd = options?.cwd ?? process.cwd();
+  const layers: { source: string; config: Record<string, unknown> }[] = [];
+
+  const zodDefaults = DiriCodeConfigSchema.parse({});
+  layers.push({ source: "defaults", config: zodDefaults as unknown as Record<string, unknown> });
+
+  const globalConfig = loadGlobalJsonc();
+  if (Object.keys(globalConfig).length > 0) {
+    layers.push({ source: "global", config: globalConfig });
+  }
+
+  const c12Result = await c12LoadConfig<Record<string, unknown>>({
+    cwd,
+    configFile: ".dc/config",
+    dotenv: true,
+    globalRc: false,
+    rcFile: false,
+  });
+
+  const projectConfig = c12Result.config;
+
+  const rawConfigFile = c12Result.configFile ?? undefined;
+  const projectConfigFile =
+    rawConfigFile != null && existsSync(rawConfigFile) ? rawConfigFile : undefined;
+
+  if (Object.keys(projectConfig).length > 0) {
+    layers.push({ source: "project", config: projectConfig });
+  }
+
+  const envOverlay = mapDcEnvVars();
+  const cliOverlay = (options?.overrides ?? {}) as Record<string, unknown>;
+  const runtimeOverrides = defu(cliOverlay, envOverlay);
+
+  if (Object.keys(runtimeOverrides).length > 0) {
+    layers.push({ source: "runtime", config: runtimeOverrides });
+  }
+
+  const merged = defu(runtimeOverrides, projectConfig, globalConfig, zodDefaults);
+  const validated = DiriCodeConfigSchema.parse(merged);
+
+  return {
+    config: validated,
+    configFile: projectConfigFile,
+    layers,
+  };
+}

--- a/packages/core/src/config/paths.ts
+++ b/packages/core/src/config/paths.ts
@@ -1,0 +1,40 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Returns the platform-specific global config directory for DiriCode.
+ *
+ * - Linux: `$XDG_CONFIG_HOME/dc/` (fallback to `~/.config/dc/`)
+ * - macOS: `~/Library/Preferences/dc/`
+ * - Other: throws an error (no Windows support in MVP)
+ */
+export function getGlobalConfigDir(): string {
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    return join(homedir(), "Library", "Preferences", "dc");
+  }
+
+  if (platform === "linux") {
+    const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+    const base =
+      xdgConfigHome != null && xdgConfigHome !== "" ? xdgConfigHome : join(homedir(), ".config");
+    return join(base, "dc");
+  }
+
+  throw new Error(
+    `Unsupported platform: "${platform}". DiriCode MVP supports Linux and macOS only.`,
+  );
+}
+
+/**
+ * Returns the path to the project-level config file.
+ *
+ * Always resolves to `<cwd>/.dc/config.jsonc`.
+ *
+ * @param cwd - Project root directory. Defaults to `process.cwd()`.
+ */
+export function getProjectConfigPath(cwd?: string): string {
+  const base = cwd ?? process.cwd();
+  return join(base, ".dc", "config.jsonc");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,9 @@ export type { Tool, ToolAnnotations, ToolContext, ToolResult } from "./tools/typ
 
 export { DiriCodeConfigSchema } from "./config/schema.js";
 export type { DiriCodeConfig } from "./config/schema.js";
+export { loadConfig } from "./config/loader.js";
+export type { LoadConfigOptions, LoadConfigResult } from "./config/loader.js";
+export { getGlobalConfigDir, getProjectConfigPath } from "./config/paths.js";
 
 export { AgentError } from "./agents/types.js";
 export type {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "/@vite/env": "/tmp/vite-env-stub.mjs",
+      "@vite/env": "/tmp/vite-env-stub.mjs",
+    },
+    preserveSymlinks: true,
+  },
+  root: "/tmp/diricode-24/packages/core",
   test: {
+    root: "/tmp/diricode-24/packages/core",
     pool: "forks",
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,19 +10,19 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.1.0)
+        version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.57.1
-        version: 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0)(typescript@5.9.3))(eslint@10.1.0)(typescript@5.9.3)
+        version: 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.57.1
-        version: 8.57.1(eslint@10.1.0)(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^10.1.0
-        version: 10.1.0
+        version: 10.1.0(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.1.0)
+        version: 10.1.8(eslint@10.1.0(jiti@2.6.1))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -31,10 +31,10 @@ importers:
         version: 2.8.20
       typescript-eslint:
         specifier: ^8.57.1
-        version: 8.57.1(eslint@10.1.0)(typescript@5.9.3)
+        version: 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
 
   apps/cli:
     dependencies:
@@ -56,7 +56,7 @@ importers:
         version: 1.3.11
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
 
   packages/agents:
     dependencies:
@@ -69,23 +69,32 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@25.5.0)
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
 
   packages/core:
     dependencies:
+      c12:
+        specifier: ^2.0.0
+        version: 2.0.4
+      confbox:
+        specifier: ^0.2.0
+        version: 0.2.4
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
       zod:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@25.5.0)
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
 
   packages/github-mcp:
     devDependencies:
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
 
   packages/memory:
     dependencies:
@@ -98,7 +107,7 @@ importers:
         version: 7.6.13
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
 
   packages/providers:
     devDependencies:
@@ -107,7 +116,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.5.0)
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
 
   packages/server:
     dependencies:
@@ -123,7 +132,7 @@ importers:
         version: 1.3.11
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
 
   packages/tools:
     dependencies:
@@ -145,13 +154,13 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.1.0
-        version: 3.2.4(@types/node@25.5.0)
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
 
   packages/web:
     devDependencies:
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
 
 packages:
 
@@ -718,6 +727,14 @@ packages:
   bun-types@1.3.11:
     resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
 
+  c12@2.0.4:
+    resolution: {integrity: sha512-3DbbhnFt0fKJHxU4tEUPmD1ahWE4PWPMomqfYsTJdrhpmEnRKJi3qSC4rO5U6E6zN1+pjBY7+z8fUmNRMaVKLw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -734,8 +751,29 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -771,9 +809,16 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -891,10 +936,18 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  giget@1.2.5:
+    resolution: {integrity: sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==}
+    hasBin: true
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -939,6 +992,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -979,8 +1036,28 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1004,12 +1081,23 @@ packages:
     resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  nypm@0.5.4:
+    resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1041,12 +1129,18 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1074,6 +1168,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -1081,6 +1178,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -1141,6 +1242,11 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1208,6 +1314,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -1346,6 +1455,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1433,9 +1545,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0(jiti@2.6.1))':
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1456,9 +1568,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.1.0)':
+  '@eslint/js@10.0.1(eslint@10.1.0(jiti@2.6.1))':
     optionalDependencies:
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
 
   '@eslint/object-schema@3.0.3': {}
 
@@ -1604,15 +1716,15 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0)(typescript@5.9.3))(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/type-utils': 8.57.1(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.1
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -1620,14 +1732,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.1(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1650,13 +1762,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.57.1(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -1679,13 +1791,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.1(eslint@10.1.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1712,21 +1824,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1825,6 +1937,21 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
+  c12@2.0.4:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.1.8
+      defu: 6.1.4
+      dotenv: 16.6.1
+      giget: 1.2.5
+      jiti: 2.6.1
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 1.3.1
+      rc9: 2.1.2
+
   cac@6.7.14: {}
 
   chai@5.3.3:
@@ -1839,7 +1966,23 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1865,7 +2008,11 @@ snapshots:
 
   defu@6.1.4: {}
 
+  destr@2.0.5: {}
+
   detect-libc@2.1.2: {}
+
+  dotenv@16.6.1: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -1906,9 +2053,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.1.0):
+  eslint-config-prettier@10.1.8(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
-      eslint: 10.1.0
+      eslint: 10.1.0(jiti@2.6.1)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -1921,9 +2068,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.1.0:
+  eslint@10.1.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.3
       '@eslint/config-helpers': 0.5.3
@@ -1953,6 +2100,8 @@ snapshots:
       minimatch: 10.2.4
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2012,8 +2161,22 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fsevents@2.3.3:
     optional: true
+
+  giget@1.2.5:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.5.4
+      pathe: 2.0.3
+      tar: 6.2.1
 
   github-from-package@0.0.0: {}
 
@@ -2042,6 +2205,8 @@ snapshots:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  jiti@2.6.1: {}
 
   js-tokens@9.0.1: {}
 
@@ -2078,7 +2243,27 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
   mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
 
   ms@2.1.3: {}
 
@@ -2094,9 +2279,22 @@ snapshots:
 
   node-addon-api@8.6.0: {}
 
+  node-fetch-native@1.6.7: {}
+
   node-gyp-build@4.8.4: {}
 
+  nypm@0.5.4:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      tinyexec: 0.3.2
+      ufo: 1.6.3
+
   obug@2.1.1: {}
+
+  ohash@2.0.11: {}
 
   once@1.4.0:
     dependencies:
@@ -2127,9 +2325,17 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   postcss@8.5.8:
     dependencies:
@@ -2163,6 +2369,11 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -2175,6 +2386,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readdirp@4.1.2: {}
 
   rollup@4.59.0:
     dependencies:
@@ -2260,6 +2473,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2305,18 +2527,20 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.57.1(eslint@10.1.0)(typescript@5.9.3):
+  typescript-eslint@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0)(typescript@5.9.3))(eslint@10.1.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0)(typescript@5.9.3)
-      eslint: 10.1.0
+      '@typescript-eslint/utils': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
 
   undici-types@7.18.2: {}
 
@@ -2326,13 +2550,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(@types/node@25.5.0):
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2347,7 +2571,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.5.0):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2358,12 +2582,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       fsevents: 2.3.3
+      jiti: 2.6.1
 
-  vitest@3.2.4(@types/node@25.5.0):
+  vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2381,8 +2606,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)
-      vite-node: 3.2.4(@types/node@25.5.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -2400,10 +2625,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)):
+  vitest@4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0))
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -2420,7 +2645,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -2441,6 +2666,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yallist@4.0.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Implement c12 config loader with 4-layer merge: defaults (Zod) → global (~/.config/dc/config.jsonc) → project (.dc/config.jsonc) → runtime (CLI/env)
- Add `loadConfig()` to `@diricode/core` — async, returns `DiriCodeConfig` validated with Zod
- Add platform-aware path resolution: Linux (XDG), macOS (~/Library/Preferences/dc/)
- Map `DC_PROVIDER`, `DC_MODEL`, `DC_VERBOSE` env vars to config overlay
- Load `.env` from CWD via c12's built-in dotenv integration
- Export `loadConfig`, `LoadConfigOptions`, `LoadConfigResult`, `getGlobalConfigDir`, `getProjectConfigPath` from `@diricode/core`
- Refactor CLI `resolveConfig()` to use new async `loadConfig()`
- Add 25 new tests: 9 for paths, 16 for loader

## Files
- `packages/core/src/config/loader.ts` — c12 config loader
- `packages/core/src/config/paths.ts` — platform path utilities
- `packages/core/src/config/__tests__/loader.test.ts` — loader tests
- `packages/core/src/config/__tests__/paths.test.ts` — paths tests
- `packages/core/package.json` — added c12, confbox, defu deps
- `packages/core/src/config/index.ts` — barrel exports
- `packages/core/src/index.ts` — package exports
- `apps/cli/src/config.ts` — refactored to use loadConfig
- `apps/cli/src/cli.ts` — updated callers to await resolveConfig

Closes #24