### PR TITLE
feat(cli): add interactive login with OS Keychain auth and model selection (#346)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,6 +25,8 @@
   },
   "dependencies": {
     "@diricode/core": "workspace:*",
+    "@diricode/providers": "workspace:*",
+    "@inquirer/prompts": "^8.3.2",
     "cac": "^6.7.14",
     "defu": "^6.1.4",
     "zod": "^3.24.0"

--- a/apps/cli/src/__tests__/login.test.ts
+++ b/apps/cli/src/__tests__/login.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@diricode/providers", () => ({
+  KeychainService: vi.fn().mockImplementation(() => ({
+    set: vi.fn(),
+    get: vi.fn().mockReturnValue(null),
+  })),
+  KEYCHAIN_SERVICE: "diricode",
+  KEYCHAIN_ACCOUNT: "github-token",
+  validateGithubToken: vi.fn(),
+  InvalidTokenError: class InvalidTokenError extends Error {
+    constructor(message = "invalid") {
+      super(message);
+      this.name = "InvalidTokenError";
+    }
+  },
+  fetchAvailableModels: vi.fn(),
+}));
+
+vi.mock("@inquirer/prompts", () => ({
+  password: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock("@diricode/core", () => ({
+  getGlobalConfigDir: vi.fn().mockReturnValue("/tmp/dc-test-config"),
+}));
+
+vi.mock("node:fs", () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  existsSync: vi.fn().mockReturnValue(false),
+}));
+
+import { password, confirm, select } from "@inquirer/prompts";
+import {
+  validateGithubToken,
+  InvalidTokenError,
+  KeychainService,
+  fetchAvailableModels,
+} from "@diricode/providers";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { runLogin } from "../commands/login.js";
+
+describe("runLogin", () => {
+  let keychainSetMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    keychainSetMock = vi.fn();
+    vi.mocked(KeychainService).mockImplementation(
+      () =>
+        ({ set: keychainSetMock, get: vi.fn() }) as unknown as InstanceType<typeof KeychainService>,
+    );
+    vi.mocked(fetchAvailableModels).mockResolvedValue([
+      { id: "gpt-4o", provider: "openai", modelId: "gpt-4o", supportsStreaming: true },
+    ]);
+    vi.mocked(select).mockResolvedValue("gpt-4o");
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  it("saves token to keychain on successful validation", async () => {
+    vi.mocked(password).mockResolvedValue("ghp_valid_token");
+    vi.mocked(validateGithubToken).mockResolvedValue({
+      login: "octocat",
+      name: "The Octocat",
+    });
+
+    await runLogin();
+
+    expect(keychainSetMock).toHaveBeenCalledWith("diricode", "github-token", "ghp_valid_token");
+  });
+
+  it("saves default model to global config after token is saved", async () => {
+    vi.mocked(password).mockResolvedValue("ghp_valid_token");
+    vi.mocked(validateGithubToken).mockResolvedValue({ login: "octocat" });
+    vi.mocked(select).mockResolvedValue("gpt-4o");
+
+    await runLogin();
+
+    expect(mkdirSync).toHaveBeenCalled();
+    expect(writeFileSync).toHaveBeenCalled();
+  });
+
+  it("uses non-interactive token and model when provided via options", async () => {
+    vi.mocked(validateGithubToken).mockResolvedValue({ login: "octocat" });
+
+    await runLogin({ token: "ghp_provided", model: "claude-3-5-sonnet" });
+
+    expect(password).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+    expect(keychainSetMock).toHaveBeenCalledWith("diricode", "github-token", "ghp_provided");
+    const written = vi.mocked(writeFileSync).mock.calls[0];
+    expect(written?.[1]).toContain("claude-3-5-sonnet");
+  });
+
+  it("exits with code 1 on InvalidTokenError", async () => {
+    vi.mocked(password).mockResolvedValue("ghp_bad");
+    vi.mocked(validateGithubToken).mockRejectedValue(new InvalidTokenError("token rejected"));
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(runLogin()).rejects.toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("aborts when user declines to save unverified token", async () => {
+    vi.mocked(password).mockResolvedValue("ghp_unverified");
+    vi.mocked(validateGithubToken).mockRejectedValue(new Error("network error"));
+    vi.mocked(confirm).mockResolvedValue(false);
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    await expect(runLogin()).rejects.toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(keychainSetMock).not.toHaveBeenCalled();
+  });
+
+  it("saves token when user confirms saving unverified token", async () => {
+    vi.mocked(password).mockResolvedValue("ghp_unverified");
+    vi.mocked(validateGithubToken).mockRejectedValue(new Error("network error"));
+    vi.mocked(confirm).mockResolvedValue(true);
+
+    await runLogin();
+
+    expect(keychainSetMock).toHaveBeenCalledWith("diricode", "github-token", "ghp_unverified");
+  });
+});

--- a/apps/cli/src/__tests__/logout.test.ts
+++ b/apps/cli/src/__tests__/logout.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@diricode/providers", () => ({
+  KeychainService: vi.fn().mockImplementation(() => ({
+    delete: vi.fn().mockReturnValue(true),
+  })),
+  KEYCHAIN_SERVICE: "diricode",
+  KEYCHAIN_ACCOUNT: "github-token",
+}));
+
+import { KeychainService } from "@diricode/providers";
+import { runLogout } from "../commands/logout.js";
+
+describe("runLogout", () => {
+  let keychainDeleteMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    keychainDeleteMock = vi.fn();
+    vi.mocked(KeychainService).mockImplementation(
+      () =>
+        ({
+          delete: keychainDeleteMock,
+        }) as unknown as InstanceType<typeof KeychainService>,
+    );
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  it("deletes the token and shows confirmation when token exists", async () => {
+    keychainDeleteMock.mockReturnValue(true);
+
+    await runLogout();
+
+    expect(keychainDeleteMock).toHaveBeenCalledWith("diricode", "github-token");
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining("logged out"));
+  });
+
+  it("shows already-logged-out message when no token found", async () => {
+    keychainDeleteMock.mockReturnValue(false);
+
+    await runLogout();
+
+    expect(keychainDeleteMock).toHaveBeenCalledWith("diricode", "github-token");
+    expect(process.stdout.write).toHaveBeenCalledWith(
+      expect.stringContaining("already logged out"),
+    );
+  });
+});

--- a/apps/cli/src/__tests__/repl.test.ts
+++ b/apps/cli/src/__tests__/repl.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { type ReplOptions, type ReplStatus } from "../commands/repl.js";
+
+vi.mock("@diricode/providers", () => ({
+  hasGithubAuth: vi.fn().mockReturnValue(true),
+}));
 
 describe("ReplStatus", () => {
   it("has correct shape", () => {

--- a/apps/cli/src/__tests__/whoami.test.ts
+++ b/apps/cli/src/__tests__/whoami.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@diricode/providers", () => ({
+  hasGithubAuth: vi.fn(),
+  getGithubTokenSource: vi.fn(),
+  getGithubTokenWithFallback: vi.fn(),
+  validateGithubToken: vi.fn(),
+}));
+
+vi.mock("@diricode/core", () => ({
+  getGlobalConfigDir: vi.fn().mockReturnValue("/tmp/dc-test-whoami"),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+}));
+
+import {
+  hasGithubAuth,
+  getGithubTokenSource,
+  getGithubTokenWithFallback,
+  validateGithubToken,
+} from "@diricode/providers";
+import { existsSync, readFileSync } from "node:fs";
+import { runWhoami } from "../commands/whoami.js";
+
+describe("runWhoami", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  it("shows not-logged-in message when no auth", async () => {
+    vi.mocked(hasGithubAuth).mockReturnValue(false);
+
+    await runWhoami();
+
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining("Not logged in"));
+  });
+
+  it("shows login, source, and default model when authenticated", async () => {
+    vi.mocked(hasGithubAuth).mockReturnValue(true);
+    vi.mocked(getGithubTokenSource).mockReturnValue("keychain");
+    vi.mocked(getGithubTokenWithFallback).mockReturnValue("ghp_test");
+    vi.mocked(validateGithubToken).mockResolvedValue({
+      login: "octocat",
+      name: "The Octocat",
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('{"providers":{"copilot":{"defaultModel":"gpt-4o"}}}');
+
+    await runWhoami();
+
+    const calls = vi.mocked(process.stdout.write).mock.calls.map((c) => String(c[0]));
+    expect(calls.join("")).toContain("octocat");
+    expect(calls.join("")).toContain("keychain");
+    expect(calls.join("")).toContain("gpt-4o");
+  });
+
+  it("shows env token source when token comes from env", async () => {
+    vi.mocked(hasGithubAuth).mockReturnValue(true);
+    vi.mocked(getGithubTokenSource).mockReturnValue("env");
+    vi.mocked(getGithubTokenWithFallback).mockReturnValue("ghp_env");
+    vi.mocked(validateGithubToken).mockResolvedValue({ login: "devuser" });
+
+    await runWhoami();
+
+    const output = vi
+      .mocked(process.stdout.write)
+      .mock.calls.map((c) => String(c[0]))
+      .join("");
+    expect(output).toContain("env");
+  });
+
+  it("shows fallback message when default model not set", async () => {
+    vi.mocked(hasGithubAuth).mockReturnValue(true);
+    vi.mocked(getGithubTokenSource).mockReturnValue("keychain");
+    vi.mocked(getGithubTokenWithFallback).mockReturnValue("ghp_test");
+    vi.mocked(validateGithubToken).mockResolvedValue({ login: "octocat" });
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await runWhoami();
+
+    const output = vi
+      .mocked(process.stdout.write)
+      .mock.calls.map((c) => String(c[0]))
+      .join("");
+    expect(output).toContain("not set");
+  });
+});

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -5,6 +5,9 @@ import { validateFlags } from "./flags.js";
 import { resolveConfig } from "./config.js";
 import { startRepl } from "./commands/repl.js";
 import { runOnce } from "./commands/run.js";
+import { runLogin } from "./commands/login.js";
+import { runLogout } from "./commands/logout.js";
+import { runWhoami } from "./commands/whoami.js";
 
 const cli = cac("diricode");
 
@@ -56,6 +59,49 @@ cli
       process.exit(1);
     }
   });
+
+cli
+  .command("login", "Authenticate with GitHub and store token in system keychain")
+  .option("--token <token>", "GitHub token (non-interactive)")
+  .option("--model <model>", "Default model to use (non-interactive)")
+  .action(async (options: Record<string, unknown>) => {
+    try {
+      await runLogin({
+        token: typeof options.token === "string" ? options.token : undefined,
+        model: typeof options.model === "string" ? options.model : undefined,
+      });
+    } catch (err) {
+      if (err instanceof Error) {
+        // eslint-disable-next-line no-console
+        console.error(`Error: ${err.message}`);
+      }
+      process.exit(1);
+    }
+  });
+
+cli.command("logout", "Remove GitHub token from system keychain").action(async () => {
+  try {
+    await runLogout();
+  } catch (err) {
+    if (err instanceof Error) {
+      // eslint-disable-next-line no-console
+      console.error(`Error: ${err.message}`);
+    }
+    process.exit(1);
+  }
+});
+
+cli.command("whoami", "Show current authentication status").action(async () => {
+  try {
+    await runWhoami();
+  } catch (err) {
+    if (err instanceof Error) {
+      // eslint-disable-next-line no-console
+      console.error(`Error: ${err.message}`);
+    }
+    process.exit(1);
+  }
+});
 
 cli.help();
 cli.version(pkg.version);

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,0 +1,132 @@
+import { password, confirm, select } from "@inquirer/prompts";
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  KeychainService,
+  KEYCHAIN_SERVICE,
+  KEYCHAIN_ACCOUNT,
+  validateGithubToken,
+  InvalidTokenError,
+  fetchAvailableModels,
+} from "@diricode/providers";
+import { getGlobalConfigDir } from "@diricode/core";
+
+export interface LoginOptions {
+  token?: string;
+  model?: string;
+}
+
+async function promptForToken(): Promise<string> {
+  const token = await password({
+    message: "Paste your GitHub Personal Access Token:",
+    validate(input: string) {
+      if (!input || input.trim().length === 0) return "Token cannot be empty";
+      return true;
+    },
+  });
+  return token.trim();
+}
+
+function readGlobalConfig(configPath: string): Record<string, unknown> {
+  if (!existsSync(configPath)) return {};
+  try {
+    const content = readFileSync(configPath, "utf-8");
+    const parsed: unknown = JSON.parse(content);
+    if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}
+
+function saveDefaultModel(modelId: string): void {
+  const dir = getGlobalConfigDir();
+  mkdirSync(dir, { recursive: true });
+
+  const configPath = join(dir, "config.jsonc");
+  const existing = readGlobalConfig(configPath);
+
+  const providers = (existing.providers as Record<string, unknown> | undefined) ?? {};
+  const copilot = (providers.copilot as Record<string, unknown> | undefined) ?? {};
+  const updated = {
+    ...existing,
+    providers: {
+      ...providers,
+      copilot: {
+        ...copilot,
+        defaultModel: modelId,
+      },
+    },
+  };
+
+  writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", "utf-8");
+}
+
+export async function runLogin(options: LoginOptions = {}): Promise<void> {
+  process.stdout.write("\nDiriCode — GitHub Login\n\n");
+
+  const token = options.token ?? (await promptForToken());
+
+  process.stdout.write("\nValidating token...\n");
+
+  let userLogin = "";
+  try {
+    const user = await validateGithubToken(token);
+    userLogin = user.login;
+    process.stdout.write(
+      `\nAuthenticated as: ${user.login}${user.name ? ` (${user.name})` : ""}\n`,
+    );
+  } catch (err) {
+    if (err instanceof InvalidTokenError) {
+      process.stderr.write(`\nInvalid token: ${err.message}\n`);
+      process.exit(1);
+    }
+    process.stderr.write(
+      `\nWarning: Could not verify token — ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+
+    const proceed = await confirm({ message: "Save token anyway?", default: false });
+    if (!proceed) {
+      process.stdout.write("Aborted.\n");
+      process.exit(0);
+    }
+  }
+
+  const svc = new KeychainService();
+  try {
+    svc.set(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, token);
+    process.stdout.write("\nToken saved to system keychain.\n");
+  } catch {
+    process.stderr.write("\nFailed to save token to keychain. Check keychain permissions.\n");
+    process.exit(1);
+  }
+
+  let chosenModel: string;
+  if (options.model) {
+    chosenModel = options.model;
+  } else {
+    process.stdout.write("\nFetching available models...\n");
+    const models = await fetchAvailableModels(token);
+
+    if (models.length === 0) {
+      process.stdout.write("\nNo models available. Skipping default model selection.\n");
+      return;
+    }
+
+    chosenModel = await select({
+      message: "Select default model:",
+      choices: models.map((m) => ({
+        name: m.id,
+        value: m.id,
+        description: `${m.provider} · streaming: ${String(m.supportsStreaming)}`,
+      })),
+    });
+  }
+
+  saveDefaultModel(chosenModel);
+
+  const who = userLogin ? ` as ${userLogin}` : "";
+  process.stdout.write(`\nAll done! Logged in${who}. Default model: ${chosenModel}\n`);
+}

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,0 +1,12 @@
+import { KeychainService, KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT } from "@diricode/providers";
+
+export async function runLogout(): Promise<void> {
+  const svc = new KeychainService();
+  const deleted = svc.delete(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+
+  if (deleted) {
+    process.stdout.write("\nToken removed from system keychain. You are now logged out.\n");
+  } else {
+    process.stdout.write("\nNo token found in keychain — already logged out.\n");
+  }
+}

--- a/apps/cli/src/commands/repl.ts
+++ b/apps/cli/src/commands/repl.ts
@@ -1,5 +1,6 @@
 import { createInterface, type Interface } from "node:readline/promises";
 import type { DiriCodeConfig } from "@diricode/core";
+import { hasGithubAuth } from "@diricode/providers";
 
 export interface ReplOptions {
   session?: string;
@@ -74,6 +75,12 @@ function* dispatchToAgent(
 
 export async function startRepl(config: DiriCodeConfig, options: ReplOptions): Promise<void> {
   let status: ReplStatus = { session: options.session ?? null, mode: "idle", historySize: 0 };
+
+  if (!hasGithubAuth()) {
+    process.stdout.write(
+      "\nNo GitHub token found. Run 'dc login' to authenticate before using the REPL.\n\n",
+    );
+  }
 
   const rl = createInterface({
     input: process.stdin,

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,0 +1,62 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  hasGithubAuth,
+  getGithubTokenSource,
+  getGithubTokenWithFallback,
+  validateGithubToken,
+} from "@diricode/providers";
+import { getGlobalConfigDir } from "@diricode/core";
+
+function readDefaultModel(): string | null {
+  let dir: string;
+  try {
+    dir = getGlobalConfigDir();
+  } catch {
+    return null;
+  }
+
+  const configPath = join(dir, "config.jsonc");
+  if (!existsSync(configPath)) return null;
+
+  try {
+    const content = readFileSync(configPath, "utf-8");
+    const parsed: unknown = JSON.parse(content);
+    if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const config = parsed as Record<string, unknown>;
+      const providers = config.providers as Record<string, unknown> | undefined;
+      const copilot = providers?.copilot as Record<string, unknown> | undefined;
+      const model = copilot?.defaultModel;
+      return typeof model === "string" ? model : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export async function runWhoami(): Promise<void> {
+  if (!hasGithubAuth()) {
+    process.stdout.write("\nNot logged in. Run 'dc login' to authenticate.\n");
+    return;
+  }
+
+  const source = getGithubTokenSource();
+  const token = getGithubTokenWithFallback();
+  let login = "(unknown)";
+
+  if (token) {
+    try {
+      const user = await validateGithubToken(token);
+      login = user.login + (user.name ? ` (${user.name})` : "");
+    } catch {
+      login = "(could not verify)";
+    }
+  }
+
+  const defaultModel = readDefaultModel() ?? "(not set — run 'dc login' to choose)";
+
+  process.stdout.write(`\nLogged in as: ${login}\n`);
+  process.stdout.write(`Token source: ${source}\n`);
+  process.stdout.write(`Default model: ${defaultModel}\n`);
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../../packages/core" }]
+  "references": [{ "path": "../../packages/core" }, { "path": "../../packages/providers" }]
 }

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -13,6 +13,7 @@ export const ProviderIdSchema = z.enum([
   "google",
   "mistral",
   "cohere",
+  "copilot",
   "groq",
   "ollama",
   "azure-openai",
@@ -49,9 +50,7 @@ export const ProviderConfigSchema = z
  * }
  * ```
  */
-export const ProvidersConfigSchema = z
-  .record(ProviderIdSchema, ProviderConfigSchema)
-  .default({});
+export const ProvidersConfigSchema = z.record(ProviderIdSchema, ProviderConfigSchema).default({});
 
 // ---------------------------------------------------------------------------
 // Agents

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -20,6 +20,7 @@
     "@ai-sdk/openai-compatible": "^2.0.0",
     "@github/models": "0.0.1-beta.2",
     "@google/genai": "^1.0.0",
+    "@napi-rs/keyring": "^1.2.0",
     "ai": "^6.0.138"
   },
   "devDependencies": {

--- a/packages/providers/src/__tests__/auth.test.ts
+++ b/packages/providers/src/__tests__/auth.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@napi-rs/keyring", () => {
+  const mockEntry = vi.fn();
+  mockEntry.prototype.getPassword = vi.fn().mockReturnValue(null);
+  mockEntry.prototype.setPassword = vi.fn();
+  mockEntry.prototype.deletePassword = vi.fn().mockReturnValue(true);
+  return {
+    Entry: mockEntry,
+    findCredentials: vi.fn().mockReturnValue([]),
+  };
+});
+
+import { Entry } from "@napi-rs/keyring";
+import {
+  getGithubToken,
+  getGithubTokenFromKeychain,
+  getGithubTokenWithFallback,
+  getGithubTokenSource,
+  hasGithubAuth,
+} from "../copilot/auth.js";
+
+describe("getGithubToken", () => {
+  beforeEach(() => {
+    vi.stubEnv("DC_GITHUB_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("GH_TOKEN", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns undefined when no env vars set", () => {
+    expect(getGithubToken()).toBeUndefined();
+  });
+
+  it("returns DC_GITHUB_TOKEN when set", () => {
+    vi.stubEnv("DC_GITHUB_TOKEN", "ghp_dc_token");
+    expect(getGithubToken()).toBe("ghp_dc_token");
+  });
+
+  it("returns GITHUB_TOKEN when DC_GITHUB_TOKEN not set", () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_gh_token");
+    expect(getGithubToken()).toBe("ghp_gh_token");
+  });
+
+  it("returns GH_TOKEN as last fallback", () => {
+    vi.stubEnv("GH_TOKEN", "ghp_alt_token");
+    expect(getGithubToken()).toBe("ghp_alt_token");
+  });
+
+  it("prefers DC_GITHUB_TOKEN over GITHUB_TOKEN", () => {
+    vi.stubEnv("DC_GITHUB_TOKEN", "ghp_dc");
+    vi.stubEnv("GITHUB_TOKEN", "ghp_gh");
+    expect(getGithubToken()).toBe("ghp_dc");
+  });
+
+  it("trims whitespace from token", () => {
+    vi.stubEnv("GITHUB_TOKEN", "  ghp_trimmed  ");
+    expect(getGithubToken()).toBe("ghp_trimmed");
+  });
+});
+
+describe("getGithubTokenFromKeychain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns undefined when keychain has no token", () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue(null);
+    expect(getGithubTokenFromKeychain()).toBeUndefined();
+  });
+
+  it("returns token when keychain has one", () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue("ghp_keychain_token");
+    expect(getGithubTokenFromKeychain()).toBe("ghp_keychain_token");
+  });
+
+  it("returns undefined when keychain throws", () => {
+    vi.mocked(Entry.prototype.getPassword).mockImplementation(() => {
+      throw new Error("unavailable");
+    });
+    expect(getGithubTokenFromKeychain()).toBeUndefined();
+  });
+});
+
+describe("getGithubTokenWithFallback", () => {
+  beforeEach(() => {
+    vi.stubEnv("DC_GITHUB_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("GH_TOKEN", "");
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns env token when available", () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_env");
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue("ghp_keychain");
+    expect(getGithubTokenWithFallback()).toBe("ghp_env");
+  });
+
+  it("falls back to keychain when no env token", () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue("ghp_keychain");
+    expect(getGithubTokenWithFallback()).toBe("ghp_keychain");
+  });
+
+  it("returns undefined when neither env nor keychain has a token", () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue(null);
+    expect(getGithubTokenWithFallback()).toBeUndefined();
+  });
+});
+
+describe("getGithubTokenSource", () => {
+  beforeEach(() => {
+    vi.stubEnv("DC_GITHUB_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("GH_TOKEN", "");
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns "env" when token is in env var', () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_env");
+    expect(getGithubTokenSource()).toBe("env");
+  });
+
+  it('returns "keychain" when token only in keychain', () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue("ghp_keychain");
+    expect(getGithubTokenSource()).toBe("keychain");
+  });
+
+  it('returns "none" when no token anywhere', () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue(null);
+    expect(getGithubTokenSource()).toBe("none");
+  });
+});
+
+describe("hasGithubAuth (with keychain fallback)", () => {
+  beforeEach(() => {
+    vi.stubEnv("DC_GITHUB_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("GH_TOKEN", "");
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns false when no env vars and no keychain token", () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue(null);
+    expect(hasGithubAuth()).toBe(false);
+  });
+
+  it("returns true when env var is set", () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_env");
+    expect(hasGithubAuth()).toBe(true);
+  });
+
+  it("returns true when only keychain has a token", () => {
+    vi.mocked(Entry.prototype.getPassword).mockReturnValue("ghp_keychain");
+    expect(hasGithubAuth()).toBe(true);
+  });
+});

--- a/packages/providers/src/__tests__/keychain.test.ts
+++ b/packages/providers/src/__tests__/keychain.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @napi-rs/keyring before importing the module under test
+vi.mock("@napi-rs/keyring", () => {
+  const mockEntry = vi.fn();
+  mockEntry.prototype.getPassword = vi.fn().mockReturnValue(null);
+  mockEntry.prototype.setPassword = vi.fn();
+  mockEntry.prototype.deletePassword = vi.fn().mockReturnValue(true);
+
+  return {
+    Entry: mockEntry,
+    findCredentials: vi.fn().mockReturnValue([]),
+  };
+});
+
+import { KeychainService, KeychainUnavailableError } from "../copilot/keychain.js";
+import { Entry, findCredentials } from "@napi-rs/keyring";
+
+describe("KeychainService", () => {
+  let service: KeychainService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new KeychainService();
+  });
+
+  describe("get()", () => {
+    it("returns null when entry not found (getPassword returns null)", () => {
+      vi.mocked(Entry.prototype.getPassword).mockReturnValue(null);
+      const result = service.get("diricode", "github-token");
+      expect(result).toBeNull();
+    });
+
+    it("returns the password when entry exists", () => {
+      vi.mocked(Entry.prototype.getPassword).mockReturnValue("ghp_test_token");
+      const result = service.get("diricode", "github-token");
+      expect(result).toBe("ghp_test_token");
+    });
+
+    it("constructs Entry with correct service and account", () => {
+      vi.mocked(Entry.prototype.getPassword).mockReturnValue(null);
+      service.get("my-service", "my-account");
+      expect(Entry).toHaveBeenCalledWith("my-service", "my-account");
+    });
+
+    it("returns null when keychain throws (unavailable)", () => {
+      vi.mocked(Entry.prototype.getPassword).mockImplementation(() => {
+        throw new Error("Keychain unavailable");
+      });
+      const result = service.get("diricode", "github-token");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("set()", () => {
+    it("calls Entry.setPassword with the value", () => {
+      service.set("diricode", "github-token", "ghp_new_token");
+      expect(Entry.prototype.setPassword).toHaveBeenCalledWith("ghp_new_token");
+    });
+
+    it("constructs Entry with correct service and account", () => {
+      service.set("my-service", "my-account", "secret");
+      expect(Entry).toHaveBeenCalledWith("my-service", "my-account");
+    });
+
+    it("throws KeychainUnavailableError when keychain is unavailable", () => {
+      vi.mocked(Entry.prototype.setPassword).mockImplementation(() => {
+        throw new Error("Keychain service unreachable");
+      });
+      expect(() => service.set("diricode", "github-token", "token")).toThrow(
+        KeychainUnavailableError,
+      );
+    });
+  });
+
+  describe("delete()", () => {
+    it("calls Entry.deletePassword", () => {
+      vi.mocked(Entry.prototype.deletePassword).mockReturnValue(true);
+      const result = service.delete("diricode", "github-token");
+      expect(Entry.prototype.deletePassword).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it("returns false when entry does not exist", () => {
+      vi.mocked(Entry.prototype.deletePassword).mockReturnValue(false);
+      const result = service.delete("diricode", "github-token");
+      expect(result).toBe(false);
+    });
+
+    it("returns false gracefully when keychain throws", () => {
+      vi.mocked(Entry.prototype.deletePassword).mockImplementation(() => {
+        throw new Error("Keychain unavailable");
+      });
+      const result = service.delete("diricode", "github-token");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getAll()", () => {
+    it("returns empty array when no credentials found", () => {
+      vi.mocked(findCredentials).mockReturnValue([]);
+      const result = service.getAll("diricode");
+      expect(result).toEqual([]);
+    });
+
+    it("returns credentials found for the service", () => {
+      vi.mocked(findCredentials).mockReturnValue([
+        { account: "github-token", password: "ghp_abc" },
+        { account: "other-account", password: "secret" },
+      ]);
+      const result = service.getAll("diricode");
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ account: "github-token", password: "ghp_abc" });
+    });
+
+    it("calls findCredentials with the service name", () => {
+      vi.mocked(findCredentials).mockReturnValue([]);
+      service.getAll("my-service");
+      expect(findCredentials).toHaveBeenCalledWith("my-service");
+    });
+
+    it("returns empty array when findCredentials throws", () => {
+      vi.mocked(findCredentials).mockImplementation(() => {
+        throw new Error("Keychain unavailable");
+      });
+      const result = service.getAll("diricode");
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/providers/src/__tests__/models-fetcher.test.ts
+++ b/packages/providers/src/__tests__/models-fetcher.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchAvailableModels, clearModelsCache } from "../copilot/models-fetcher.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe("fetchAvailableModels", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    clearModelsCache();
+  });
+
+  it("returns models from API on success", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse(200, [
+        { name: "gpt-5-mini", publisher: "openai" },
+        { name: "claude-3.5-sonnet", publisher: "anthropic" },
+      ]),
+    );
+
+    const models = await fetchAvailableModels("ghp_token");
+    expect(models.length).toBeGreaterThanOrEqual(2);
+    const gpt = models.find((m) => m.id === "gpt-5-mini");
+    expect(gpt).toBeDefined();
+    expect(gpt?.provider).toBe("openai");
+  });
+
+  it("falls back to static models on API failure", async () => {
+    mockFetch.mockResolvedValue(makeResponse(500, {}));
+
+    const models = await fetchAvailableModels("ghp_token");
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((m) => m.id === "gpt-5-mini")).toBe(true);
+  });
+
+  it("falls back to static models when fetch throws", async () => {
+    mockFetch.mockRejectedValue(new Error("network error"));
+
+    const models = await fetchAvailableModels("ghp_token");
+    expect(models.length).toBeGreaterThan(0);
+  });
+
+  it("uses cached result on second call within TTL", async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, [{ name: "gpt-5-mini", publisher: "openai" }]));
+
+    await fetchAvailableModels("ghp_token");
+    await fetchAvailableModels("ghp_token");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after cache is cleared", async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, [{ name: "gpt-5-mini", publisher: "openai" }]));
+
+    await fetchAvailableModels("ghp_token");
+    clearModelsCache();
+    await fetchAvailableModels("ghp_token");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns static models when API returns empty array", async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, []));
+
+    const models = await fetchAvailableModels("ghp_token");
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((m) => m.id === "gpt-5-mini")).toBe(true);
+  });
+
+  it("includes supportsStreaming from static model info", async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, [{ name: "gpt-5-mini", publisher: "openai" }]));
+
+    const models = await fetchAvailableModels("ghp_token");
+    const gpt = models.find((m) => m.id === "gpt-5-mini");
+    expect(gpt?.supportsStreaming).toBe(true);
+  });
+});

--- a/packages/providers/src/__tests__/validator.test.ts
+++ b/packages/providers/src/__tests__/validator.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { validateGithubToken, InvalidTokenError } from "../copilot/validator.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : status === 401 ? "Unauthorized" : "Forbidden",
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe("validateGithubToken", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns user info on success", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse(200, {
+        login: "octocat",
+        name: "The Octocat",
+        avatar_url: "https://github.com/octocat.png",
+      }),
+    );
+
+    const result = await validateGithubToken("ghp_valid");
+    expect(result.login).toBe("octocat");
+    expect(result.name).toBe("The Octocat");
+    expect(result.avatar_url).toBe("https://github.com/octocat.png");
+  });
+
+  it("throws InvalidTokenError on 401", async () => {
+    mockFetch.mockResolvedValue(makeResponse(401, {}));
+    await expect(validateGithubToken("ghp_bad")).rejects.toThrow(InvalidTokenError);
+  });
+
+  it("throws InvalidTokenError on 403", async () => {
+    mockFetch.mockResolvedValue(makeResponse(403, {}));
+    await expect(validateGithubToken("ghp_forbidden")).rejects.toThrow(InvalidTokenError);
+  });
+
+  it("throws generic Error on other non-2xx status", async () => {
+    mockFetch.mockResolvedValue(makeResponse(500, {}));
+    await expect(validateGithubToken("ghp_token")).rejects.toThrow(Error);
+    await expect(validateGithubToken("ghp_token")).rejects.not.toThrow(InvalidTokenError);
+  });
+
+  it("sends Bearer token in Authorization header", async () => {
+    mockFetch.mockResolvedValue(makeResponse(200, { login: "user" }));
+    await validateGithubToken("ghp_my_token");
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer ghp_my_token");
+  });
+
+  it("InvalidTokenError has correct name", async () => {
+    mockFetch.mockResolvedValue(makeResponse(401, {}));
+    try {
+      await validateGithubToken("bad");
+    } catch (err) {
+      expect((err as Error).name).toBe("InvalidTokenError");
+    }
+  });
+});

--- a/packages/providers/src/copilot/auth.ts
+++ b/packages/providers/src/copilot/auth.ts
@@ -5,7 +5,15 @@
  * The @github/models package defaults to GITHUB_TOKEN env var,
  * but we also support explicit DC_GITHUB_TOKEN for consistency
  * with the layered config system.
+ *
+ * Token resolution order:
+ *   1. DC_GITHUB_TOKEN env var
+ *   2. GITHUB_TOKEN env var
+ *   3. GH_TOKEN env var
+ *   4. OS keychain (via @napi-rs/keyring)
  */
+
+import { KeychainService, KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT } from "./keychain.js";
 
 /**
  * Well-known environment variable names for GitHub authentication.
@@ -33,12 +41,49 @@ export function getGithubToken(): string | undefined {
 }
 
 /**
+ * Get the GitHub token from the OS keychain (synchronous).
+ *
+ * @returns The stored token or undefined if not present / keychain unavailable.
+ */
+export function getGithubTokenFromKeychain(): string | undefined {
+  const svc = new KeychainService();
+  const value = svc.get(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+  if (value && value.trim().length > 0) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Get the GitHub token, checking env vars first then falling back to the keychain.
+ *
+ * @returns The first available token or undefined if none found.
+ */
+export function getGithubTokenWithFallback(): string | undefined {
+  return getGithubToken() ?? getGithubTokenFromKeychain();
+}
+
+/**
+ * Determine where the GitHub token originates from.
+ *
+ * @returns "env" if found in environment variables, "keychain" if found in the OS
+ *          keychain, or "none" if no token is available.
+ */
+export function getGithubTokenSource(): "env" | "keychain" | "none" {
+  if (getGithubToken() !== undefined) return "env";
+  if (getGithubTokenFromKeychain() !== undefined) return "keychain";
+  return "none";
+}
+
+/**
  * Check if GitHub authentication is configured.
  *
- * @returns true if a token is available in the environment.
+ * Checks env vars first, then falls back to the OS keychain.
+ *
+ * @returns true if a token is available.
  */
 export function hasGithubAuth(): boolean {
-  return getGithubToken() !== undefined;
+  return getGithubTokenWithFallback() !== undefined;
 }
 
 /**

--- a/packages/providers/src/copilot/index.ts
+++ b/packages/providers/src/copilot/index.ts
@@ -1,3 +1,24 @@
 export { CopilotProvider, createCopilotProvider } from "./adapter.js";
-export { DEFAULT_COPILOT_MODEL, getGithubModelInfo, isKnownModel } from "./models.js";
-export { getGithubToken, hasGithubAuth } from "./auth.js";
+export {
+  DEFAULT_COPILOT_MODEL,
+  GITHUB_MODELS,
+  getGithubModelInfo,
+  isKnownModel,
+} from "./models.js";
+export {
+  getGithubToken,
+  getGithubTokenFromKeychain,
+  getGithubTokenWithFallback,
+  getGithubTokenSource,
+  hasGithubAuth,
+} from "./auth.js";
+export {
+  KeychainService,
+  KeychainUnavailableError,
+  KEYCHAIN_SERVICE,
+  KEYCHAIN_ACCOUNT,
+} from "./keychain.js";
+export { validateGithubToken, InvalidTokenError } from "./validator.js";
+export type { GithubUserInfo } from "./validator.js";
+export { fetchAvailableModels, clearModelsCache } from "./models-fetcher.js";
+export type { FetchedModel } from "./models-fetcher.js";

--- a/packages/providers/src/copilot/keychain.ts
+++ b/packages/providers/src/copilot/keychain.ts
@@ -1,0 +1,48 @@
+import { Entry, findCredentials, type Credential } from "@napi-rs/keyring";
+
+export const KEYCHAIN_SERVICE = "diricode";
+export const KEYCHAIN_ACCOUNT = "github-token";
+
+export class KeychainUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(`Keychain unavailable: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = "KeychainUnavailableError";
+  }
+}
+
+export class KeychainService {
+  get(service: string, account: string): string | null {
+    try {
+      const entry = new Entry(service, account);
+      return entry.getPassword();
+    } catch {
+      return null;
+    }
+  }
+
+  set(service: string, account: string, value: string): void {
+    try {
+      const entry = new Entry(service, account);
+      entry.setPassword(value);
+    } catch (err) {
+      throw new KeychainUnavailableError(err);
+    }
+  }
+
+  delete(service: string, account: string): boolean {
+    try {
+      const entry = new Entry(service, account);
+      return entry.deletePassword();
+    } catch {
+      return false;
+    }
+  }
+
+  getAll(service: string): Credential[] {
+    try {
+      return findCredentials(service);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/providers/src/copilot/models-fetcher.ts
+++ b/packages/providers/src/copilot/models-fetcher.ts
@@ -1,0 +1,89 @@
+import { GITHUB_MODELS, type GithubModelInfo } from "./models.js";
+
+export interface FetchedModel {
+  id: string;
+  provider: string;
+  modelId: string;
+  supportsStreaming: boolean;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  models: FetchedModel[];
+  fetchedAt: number;
+}
+
+let cache: CacheEntry | null = null;
+
+function fromStaticModels(): FetchedModel[] {
+  return Object.entries(GITHUB_MODELS).map(([id, info]: [string, GithubModelInfo]) => ({
+    id,
+    provider: info.provider,
+    modelId: info.modelId,
+    supportsStreaming: info.supportsStreaming,
+  }));
+}
+
+interface ApiModelEntry {
+  name?: string;
+  id?: string;
+  publisher?: string;
+  summary?: string;
+  [key: string]: unknown;
+}
+
+function parseApiResponse(data: unknown): FetchedModel[] {
+  if (!Array.isArray(data)) return fromStaticModels();
+
+  const results: FetchedModel[] = [];
+  for (const item of data as ApiModelEntry[]) {
+    const id = item["name"] ?? item["id"];
+    if (typeof id !== "string" || !id) continue;
+
+    const static_ = GITHUB_MODELS[id];
+    results.push({
+      id,
+      provider:
+        typeof item["publisher"] === "string"
+          ? item["publisher"]
+          : (static_?.provider ?? "unknown"),
+      modelId: static_?.modelId ?? id,
+      supportsStreaming: static_?.supportsStreaming ?? true,
+    });
+  }
+  return results.length > 0 ? results : fromStaticModels();
+}
+
+export async function fetchAvailableModels(token: string): Promise<FetchedModel[]> {
+  const now = Date.now();
+
+  if (cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.models;
+  }
+
+  try {
+    const response = await fetch("https://models.github.ai/catalog/models", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return fromStaticModels();
+    }
+
+    const data: unknown = await response.json();
+    const models = parseApiResponse(data);
+
+    cache = { models, fetchedAt: now };
+    return models;
+  } catch {
+    return fromStaticModels();
+  }
+}
+
+export function clearModelsCache(): void {
+  cache = null;
+}

--- a/packages/providers/src/copilot/models.ts
+++ b/packages/providers/src/copilot/models.ts
@@ -4,7 +4,7 @@ export interface GithubModelInfo {
   readonly supportsStreaming: boolean;
 }
 
-const GITHUB_MODELS: Record<string, GithubModelInfo> = {
+export const GITHUB_MODELS: Record<string, GithubModelInfo> = {
   "gpt-5": { provider: "openai", modelId: "openai/gpt-5", supportsStreaming: true },
   "gpt-5-mini": { provider: "openai", modelId: "openai/gpt-5-mini", supportsStreaming: true },
   "gpt-5-nano": { provider: "openai", modelId: "openai/gpt-5-nano", supportsStreaming: true },

--- a/packages/providers/src/copilot/validator.ts
+++ b/packages/providers/src/copilot/validator.ts
@@ -1,0 +1,38 @@
+export class InvalidTokenError extends Error {
+  constructor(message = "GitHub token is invalid or unauthorized") {
+    super(message);
+    this.name = "InvalidTokenError";
+  }
+}
+
+export interface GithubUserInfo {
+  login: string;
+  name?: string;
+  avatar_url?: string;
+}
+
+export async function validateGithubToken(token: string): Promise<GithubUserInfo> {
+  const response = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new InvalidTokenError(`GitHub token rejected with status ${response.status}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as Record<string, unknown>;
+
+  return {
+    login: data["login"] as string,
+    name: data["name"] as string | undefined,
+    avatar_url: data["avatar_url"] as string | undefined,
+  };
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -27,4 +27,23 @@ export type {
 } from "./ab/ABExperimentManager.js";
 
 export { CopilotProvider, createCopilotProvider } from "./copilot/index.js";
-export { DEFAULT_COPILOT_MODEL, getGithubModelInfo, hasGithubAuth } from "./copilot/index.js";
+export {
+  DEFAULT_COPILOT_MODEL,
+  GITHUB_MODELS,
+  getGithubModelInfo,
+  isKnownModel,
+  getGithubToken,
+  getGithubTokenFromKeychain,
+  getGithubTokenWithFallback,
+  getGithubTokenSource,
+  hasGithubAuth,
+  KeychainService,
+  KeychainUnavailableError,
+  KEYCHAIN_SERVICE,
+  KEYCHAIN_ACCOUNT,
+  validateGithubToken,
+  InvalidTokenError,
+  fetchAvailableModels,
+  clearModelsCache,
+} from "./copilot/index.js";
+export type { GithubUserInfo, FetchedModel } from "./copilot/index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
       '@diricode/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@diricode/providers':
+        specifier: workspace:*
+        version: link:../../packages/providers
+      '@inquirer/prompts':
+        specifier: ^8.3.2
+        version: 8.3.2(@types/node@20.19.37)
       cac:
         specifier: ^6.7.14
         version: 6.7.14
@@ -144,6 +150,9 @@ importers:
       '@google/genai':
         specifier: ^1.0.0
         version: 1.46.0
+      '@napi-rs/keyring':
+        specifier: ^1.2.0
+        version: 1.2.0
       ai:
         specifier: ^6.0.138
         version: 6.0.138(zod@3.25.76)
@@ -756,6 +765,140 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@2.0.4':
+    resolution: {integrity: sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.2':
+    resolution: {integrity: sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.10':
+    resolution: {integrity: sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.7':
+    resolution: {integrity: sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.0.10':
+    resolution: {integrity: sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.10':
+    resolution: {integrity: sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@2.0.4':
+    resolution: {integrity: sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.4':
+    resolution: {integrity: sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.10':
+    resolution: {integrity: sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.10':
+    resolution: {integrity: sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.10':
+    resolution: {integrity: sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.3.2':
+    resolution: {integrity: sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.6':
+    resolution: {integrity: sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.6':
+    resolution: {integrity: sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.2':
+    resolution: {integrity: sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.4':
+    resolution: {integrity: sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -771,6 +914,82 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.2.0':
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1332,6 +1551,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -1359,6 +1581,10 @@ packages:
 
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1604,6 +1830,15 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1717,6 +1952,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1907,6 +2146,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -2185,6 +2428,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -2211,6 +2457,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -2969,6 +3219,125 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@2.0.4': {}
+
+  '@inquirer/checkbox@5.1.2(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/confirm@6.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/core@11.1.7(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/editor@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/external-editor': 2.0.4(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/expand@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/external-editor@2.0.4(@types/node@20.19.37)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/figures@2.0.4': {}
+
+  '@inquirer/input@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/number@4.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/password@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/prompts@8.3.2(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.2(@types/node@20.19.37)
+      '@inquirer/confirm': 6.0.10(@types/node@20.19.37)
+      '@inquirer/editor': 5.0.10(@types/node@20.19.37)
+      '@inquirer/expand': 5.0.10(@types/node@20.19.37)
+      '@inquirer/input': 5.0.10(@types/node@20.19.37)
+      '@inquirer/number': 4.0.10(@types/node@20.19.37)
+      '@inquirer/password': 5.0.10(@types/node@20.19.37)
+      '@inquirer/rawlist': 5.2.6(@types/node@20.19.37)
+      '@inquirer/search': 4.1.6(@types/node@20.19.37)
+      '@inquirer/select': 5.1.2(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/rawlist@5.2.6(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/search@4.1.6(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/select@5.1.2(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/type@4.0.4(@types/node@20.19.37)':
+    optionalDependencies:
+      '@types/node': 20.19.37
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2987,6 +3356,57 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring@1.2.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3567,6 +3987,8 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chardet@2.1.1: {}
+
   check-error@2.1.3: {}
 
   chokidar@3.6.0:
@@ -3598,6 +4020,8 @@ snapshots:
       clsx: 2.1.1
 
   classcat@5.0.5: {}
+
+  cli-width@4.1.0: {}
 
   clsx@2.1.1: {}
 
@@ -3849,6 +4273,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -3974,6 +4408,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -4145,6 +4583,8 @@ snapshots:
       ufo: 1.6.3
 
   ms@2.1.3: {}
+
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -4427,6 +4867,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -4444,6 +4886,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Implementuje interaktywny system logowania dla DiriCode CLI:

### Komendy
- `dc login` — walidacja tokena + wybór modelu + zapis do OS Keychain
- `dc logout` — usunięcie klucza z Keychain
- `dc whoami` — sprawdzenie statusu autoryzacji
- Auto-prompt w REPL gdy brak klucza

### Zmiany
- **providers**: Keychain service (`@napi-rs/keyring`), token validator (`GET /user`), GitHub Models API fetcher
- **core**: Dodany "copilot" do `ProviderIdSchema`
- **cli**: Nowe komendy login/logout/whoami

### Technical Details
- Keychain: `@napi-rs/keyring` (sync API, Rust bindings)
- Models API: `GET /catalog/models` na `models.github.ai`
- CLI prompts: `@inquirer/prompts`
- Auth precedence: env vars > Keychain

## Status
- [x] T1-T10 implemented
- [ ] Tests: nie mogą działać w worktree z powodu `#` w ścieżce (Turborepo limitation)
- [x] Build: działa w main repo

## Fixes #346