### PR TITLE
feat(cli): interactive login with provider selection (GitHub/Google) and REPL /login

### DIFF
--- a/apps/cli/src/__tests__/login.integration.test.ts
+++ b/apps/cli/src/__tests__/login.integration.test.ts
@@ -117,7 +117,7 @@ describe("login → whoami → logout integration", () => {
     await runLogin({ token: "ghp_test_integration", model: "gpt-5-mini" });
     loginOut.restore();
 
-    expect(loginOut.lines.join("")).toContain("Logged in as octocat");
+    expect(loginOut.lines.join("")).toContain("Logged in to GitHub as octocat");
     expect(keychainStore.get("diricode:github-token")).toBe("ghp_test_integration");
 
     mockGetGithubToken.mockReturnValue("ghp_test_integration");
@@ -196,7 +196,7 @@ describe("login → whoami → logout integration", () => {
     await runLogin({});
     loginOut.restore();
 
-    expect(loginOut.lines.join("")).toContain("Already authenticated");
+    expect(loginOut.lines.join("")).toContain("Already logged in with GitHub");
     expect(mockValidateGithubToken).not.toHaveBeenCalled();
     expect(keychainStore.has("diricode:github-token")).toBe(false);
   });

--- a/apps/cli/src/__tests__/login.test.ts
+++ b/apps/cli/src/__tests__/login.test.ts
@@ -100,7 +100,7 @@ describe("runLogin()", () => {
       return true;
     });
     await runLogin({});
-    expect(out.join("")).toContain("Already authenticated");
+    expect(out.join("")).toContain("Already logged in with GitHub");
     expect(validateGithubToken).not.toHaveBeenCalled();
   });
 

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -16,12 +16,16 @@ import { getGlobalConfigDir } from "@diricode/core";
 export interface LoginOptions {
   token?: string;
   model?: string;
+  provider?: "github" | "google";
 }
 
 interface NestedConfig {
   providers?: {
     copilot?: {
       defaultModel?: string;
+    };
+    google?: {
+      apiKey?: string;
     };
   };
 }
@@ -60,23 +64,89 @@ function saveDefaultModelToConfig(defaultModel: string): void {
   writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", "utf-8");
 }
 
-export async function runLogin(options: LoginOptions = {}): Promise<void> {
-  const existingToken = getGithubToken();
-  if (existingToken && !options.token) {
-    const source = getGithubTokenSource();
-    const sourceLabel =
-      source === "keychain" ? "OS Keychain" : source === "none" ? "unknown" : `${source} env var`;
-    process.stdout.write(
-      `Already authenticated. Token source: ${sourceLabel}\n` +
-        `Run 'dc login --token <token>' to re-authenticate.\n`,
-    );
+function saveGoogleApiKeyToConfig(apiKey: string): void {
+  let configDir: string;
+  try {
+    configDir = getGlobalConfigDir();
+  } catch {
     return;
   }
 
-  let token = options.token;
+  const configPath = join(configDir, "config.jsonc");
 
-  token ??= await password({ message: "Enter your GitHub Personal Access Token:" });
+  let existing: NestedConfig = {};
+  if (existsSync(configPath)) {
+    try {
+      existing = JSON.parse(readFileSync(configPath, "utf-8")) as NestedConfig;
+    } catch {
+      existing = {};
+    }
+  }
 
+  const providers = existing.providers ?? {};
+
+  const updated: NestedConfig = {
+    ...existing,
+    providers: {
+      ...providers,
+      google: { ...providers.google, apiKey },
+    },
+  };
+
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", "utf-8");
+}
+
+function isValidGoogleApiKeyFormat(key: string): boolean {
+  // Google API keys are typically 39+ characters
+  // Classic format: starts with "AIza", 39 chars total
+  // New format: varies, but generally 40+ chars
+  return key.length >= 20 && /^[A-Za-z0-9_-]+$/.test(key);
+}
+
+async function loginGithub(
+  interactive: boolean,
+  forcedToken?: string,
+  forcedModel?: string,
+): Promise<void> {
+  const existingToken = forcedToken ?? getGithubToken();
+  if (!existingToken) {
+    if (!interactive) {
+      process.stderr.write(`No GitHub token provided. Run 'dc login' to authenticate.\n`);
+      process.exitCode = 1;
+      return;
+    }
+    const token = await password({
+      message: "Enter your GitHub Personal Access Token:",
+      mask: true,
+    });
+    await doGithubLogin(token, forcedModel);
+    return;
+  }
+
+  const source = forcedToken ? "(provided via --token)" : getGithubTokenSource();
+  const sourceLabel =
+    source === "keychain" ? "OS Keychain" : source === "none" ? "unknown" : `${source} env var`;
+
+  if (existingToken && !forcedToken) {
+    if (interactive) {
+      process.stdout.write(
+        `Already logged in with GitHub. Token source: ${sourceLabel}\n` +
+          `Run 'dc logout' first to sign out, or run 'dc login --token <token>' to replace.\n`,
+      );
+    } else {
+      process.stdout.write(
+        `Already authenticated with GitHub. Token source: ${sourceLabel}\n` +
+          `Run 'dc login --token <token>' to re-authenticate.\n`,
+      );
+    }
+    return;
+  }
+
+  await doGithubLogin(existingToken, forcedModel);
+}
+
+async function doGithubLogin(token: string, model?: string): Promise<void> {
   let user: Awaited<ReturnType<typeof validateGithubToken>>;
   try {
     user = await validateGithubToken(token);
@@ -93,7 +163,7 @@ export async function runLogin(options: LoginOptions = {}): Promise<void> {
   const keychain = new KeychainService();
   keychain.set(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, token);
 
-  let defaultModel = options.model;
+  let defaultModel = model;
   if (!defaultModel) {
     const models = await fetchAvailableModels(token);
     const choices = models.map((m) => ({ name: m.name || m.id, value: m.id }));
@@ -106,6 +176,73 @@ export async function runLogin(options: LoginOptions = {}): Promise<void> {
   saveDefaultModelToConfig(defaultModel);
 
   process.stdout.write(
-    `\n✓ Logged in as ${user.login}${user.name ? ` (${user.name})` : ""} | Default model: ${defaultModel}\n`,
+    `\n✓ Logged in to GitHub as ${user.login}${user.name ? ` (${user.name})` : ""} | Default model: ${defaultModel}\n`,
   );
+}
+
+async function loginGoogle(): Promise<void> {
+  const apiKey = await password({
+    message: "Enter your Google Gemini API key:",
+    mask: true,
+  });
+
+  if (!isValidGoogleApiKeyFormat(apiKey)) {
+    process.stderr.write(
+      `✗ That doesn't look like a valid Google API key.\n` +
+        `API keys are typically 20+ characters containing letters, numbers, underscores and dashes.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  saveGoogleApiKeyToConfig(apiKey);
+  process.stdout.write(`\n✓ Google Gemini configured. API key saved to config.\n`);
+}
+
+async function selectProvider(): Promise<"github" | "google" | null> {
+  const answer = await select({
+    message: "Which provider would you like to authenticate with?",
+    choices: [
+      {
+        name: "GitHub (Personal Access Token) — for GitHub Models",
+        value: "github",
+        description: "Store a GitHub PAT in your OS keychain for GitHub Models access",
+      },
+      {
+        name: "Google (Gemini API Key) — for Gemini AI",
+        value: "google",
+        description: "Save your Google Gemini API key to config for Gemini access",
+      },
+      {
+        name: "Cancel",
+        value: null,
+      },
+    ],
+  });
+  return answer as "github" | "google" | null;
+}
+
+export async function runLogin(options: LoginOptions = {}): Promise<void> {
+  if (options.token || options.model) {
+    await loginGithub(false, options.token, options.model);
+    return;
+  }
+
+  const existingToken = getGithubToken();
+  if (existingToken) {
+    await loginGithub(true);
+    return;
+  }
+
+  const provider = await selectProvider();
+  if (!provider) {
+    process.stdout.write("Login cancelled.\n");
+    return;
+  }
+
+  if (provider === "github") {
+    await loginGithub(true);
+  } else {
+    await loginGoogle();
+  }
 }

--- a/apps/cli/src/commands/repl.ts
+++ b/apps/cli/src/commands/repl.ts
@@ -1,6 +1,9 @@
 import { createInterface, type Interface } from "node:readline/promises";
 import type { DiriCodeConfig } from "@diricode/core";
 import { hasGithubAuth } from "@diricode/providers";
+import { runLogin } from "./login.js";
+import { runLogout } from "./logout.js";
+import { runWhoami } from "./whoami.js";
 
 export interface ReplOptions {
   session?: string;
@@ -17,6 +20,9 @@ function printHelp(): void {
   console.log(`
 Commands:
   /help     Show this help message
+  /login    Authenticate with GitHub or Google
+  /logout   Remove stored GitHub token from OS Keychain
+  /whoami   Show current authentication status
   /status   Show current REPL status
   /exit     Exit the REPL
   /clear    Clear the screen
@@ -82,7 +88,7 @@ export async function startRepl(config: DiriCodeConfig, options: ReplOptions): P
   if (promptOnMissing && !hasGithubAuth()) {
     // eslint-disable-next-line no-console
     console.log(
-      "No GitHub token found. Run 'dc login' to authenticate or set DC_GITHUB_TOKEN / GITHUB_TOKEN env var.\n",
+      "No GitHub token found. Run '/login' to authenticate or set DC_GITHUB_TOKEN / GITHUB_TOKEN env var.\n",
     );
   }
 
@@ -92,7 +98,16 @@ export async function startRepl(config: DiriCodeConfig, options: ReplOptions): P
     terminal: true,
     historySize: 100,
     completer: (line: string): [string[], string] => {
-      const commands = ["/help", "/status", "/exit", "/quit", "/clear"];
+      const commands = [
+        "/help",
+        "/login",
+        "/logout",
+        "/whoami",
+        "/status",
+        "/exit",
+        "/quit",
+        "/clear",
+      ];
       const hits = commands.filter((c) => c.startsWith(line));
       return [hits, line];
     },
@@ -133,6 +148,21 @@ export async function startRepl(config: DiriCodeConfig, options: ReplOptions): P
       if (trimmed === "/clear") {
         // eslint-disable-next-line no-console
         console.clear();
+        continue;
+      }
+
+      if (trimmed === "/login") {
+        await runLogin();
+        continue;
+      }
+
+      if (trimmed === "/logout") {
+        await runLogout();
+        continue;
+      }
+
+      if (trimmed === "/whoami") {
+        await runWhoami();
         continue;
       }
 

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,35 +1,69 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import {
   getGithubToken,
   getGithubTokenSource,
   validateGithubToken,
   InvalidTokenError,
 } from "@diricode/providers";
+import { getGlobalConfigDir } from "@diricode/core";
+
+function getGoogleAuthStatus(): { configured: boolean; source: string } {
+  const envKey = process.env.GEMINI_API_KEY;
+  if (envKey) {
+    return { configured: true, source: "GEMINI_API_KEY env var" };
+  }
+
+  try {
+    const configDir = getGlobalConfigDir();
+    const configPath = join(configDir, "config.jsonc");
+    if (!existsSync(configPath)) {
+      return { configured: false, source: "" };
+    }
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw) as { providers?: { google?: { apiKey?: string } } };
+    const providers = config.providers;
+    if (providers?.google?.apiKey) {
+      return { configured: true, source: "config.jsonc (global config)" };
+    }
+  } catch {
+    return { configured: false, source: "" };
+  }
+
+  return { configured: false, source: "" };
+}
 
 export async function runWhoami(): Promise<void> {
   const token = getGithubToken();
   const source = getGithubTokenSource();
 
   if (!token || source === "none") {
-    process.stdout.write(`Not logged in. Run 'dc login' to authenticate.\n`);
-    return;
-  }
+    process.stdout.write(`Not logged in to GitHub. Run 'dc login' to authenticate.\n`);
+  } else {
+    const sourceLabel = source === "keychain" ? "OS Keychain" : `${source} env var`;
 
-  const sourceLabel = source === "keychain" ? "OS Keychain" : `${source} env var`;
-
-  let login: string;
-  try {
-    const user = await validateGithubToken(token);
-    login = user.name ? `${user.login} (${user.name})` : user.login;
-  } catch (err) {
-    if (err instanceof InvalidTokenError) {
-      process.stdout.write(
-        `Token found (source: ${sourceLabel}) but it appears invalid: ${err.message}\n` +
-          `Run 'dc login' to re-authenticate.\n`,
-      );
-      return;
+    let login: string;
+    try {
+      const user = await validateGithubToken(token);
+      login = user.name ? `${user.login} (${user.name})` : user.login;
+    } catch (err) {
+      if (err instanceof InvalidTokenError) {
+        process.stdout.write(
+          `GitHub token found (source: ${sourceLabel}) but it appears invalid: ${err.message}\n` +
+            `Run 'dc login' to re-authenticate.\n`,
+        );
+        return;
+      }
+      throw err;
     }
-    throw err;
+
+    process.stdout.write(`GitHub: ${login} | Token source: ${sourceLabel}\n`);
   }
 
-  process.stdout.write(`Logged in as ${login} | Token source: ${sourceLabel}\n`);
+  const google = getGoogleAuthStatus();
+  if (google.configured) {
+    process.stdout.write(`Google: configured | Source: ${google.source}\n`);
+  } else {
+    process.stdout.write(`Google: not configured | Run 'dc login' to add a Gemini API key.\n`);
+  }
 }


### PR DESCRIPTION
## Summary
- REPL: add `/login`, `/logout`, `/whoami` commands wired directly to auth functions (not via agent dispatch)
- `login.ts`: interactive provider selection menu — choose GitHub (PAT) or Google (Gemini API key)
- `login.ts`: `loginGoogle()` — prompts for API key, validates format minimally, saves `providers.google.apiKey` to `config.jsonc`
- `login.ts`: `loginGithub()` now accepts `forcedToken`/`forcedModel` params for non-interactive use (e.g. `dc login --token xxx`)
- `whoami.ts`: shows both GitHub AND Google auth status
- `whoami.ts`: reads `config.jsonc` to detect Google API key presence
- Tab completion in REPL now includes `/login`, `/logout`, `/whoami`

## How to test
```bash
# REPL commands
pnpm --filter @diricode/cli dev
diricode> /login   # opens provider selection: GitHub or Google
diricode> /whoami  # shows auth status for all providers
diricode> /logout  # clears GitHub keychain token

# CLI commands
dc login           # interactive (provider selection)
dc login --token xxx  # non-interactive GitHub login
dc whoami
dc logout
```

Closes #346