### PR TITLE
feat(cli): add GitHub OAuth device flow for interactive login

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -10,8 +10,13 @@ import {
   getGithubToken,
   getGithubTokenSource,
   InvalidTokenError,
+  initiateGithubDeviceFlow,
+  pollGithubDeviceToken,
+  GithubOAuthError,
 } from "@diricode/providers";
 import { getGlobalConfigDir } from "@diricode/core";
+
+const GITHUB_CLIENT_ID = "Ov23li7a7FBdI2WkK0dd";
 
 export interface LoginOptions {
   token?: string;
@@ -116,6 +121,10 @@ async function loginGithub(
       process.exitCode = 1;
       return;
     }
+    const oauthSuccess = await tryGithubOAuth(forcedModel);
+    if (oauthSuccess) {
+      return;
+    }
     const token = await password({
       message: "Enter your GitHub Personal Access Token:",
       mask: true,
@@ -144,6 +153,36 @@ async function loginGithub(
   }
 
   await doGithubLogin(existingToken, forcedModel);
+}
+
+async function tryGithubOAuth(model?: string): Promise<boolean> {
+  process.stdout.write(`\nStarting GitHub OAuth device flow...\n`);
+  try {
+    const codeResponse = await initiateGithubDeviceFlow(GITHUB_CLIENT_ID);
+    process.stdout.write(
+      `\n  1. Open: ${codeResponse.verification_uri}\n` +
+        `  2. Enter: ${codeResponse.user_code}\n\n` +
+        `Waiting for authorization...\n`,
+    );
+    const tokenResponse = await pollGithubDeviceToken(
+      GITHUB_CLIENT_ID,
+      codeResponse.device_code,
+      codeResponse.interval,
+    );
+    await doGithubLogin(tokenResponse.access_token, model);
+    return true;
+  } catch (err) {
+    if (err instanceof GithubOAuthError) {
+      process.stdout.write(
+        `OAuth failed: ${err.message}\nFalling back to manual token entry.\n`,
+      );
+      return false;
+    }
+    process.stdout.write(
+      `OAuth failed: ${err instanceof Error ? err.message : String(err)}\nFalling back to manual token entry.\n`,
+    );
+    return false;
+  }
 }
 
 async function doGithubLogin(token: string, model?: string): Promise<void> {
@@ -204,9 +243,9 @@ async function selectProvider(): Promise<"github" | "google" | null> {
     message: "Which provider would you like to authenticate with?",
     choices: [
       {
-        name: "GitHub (Personal Access Token) — for GitHub Models",
+        name: "GitHub (OAuth) — for GitHub Models",
         value: "github",
-        description: "Store a GitHub PAT in your OS keychain for GitHub Models access",
+        description: "Authorize via GitHub browser flow for GitHub Models access",
       },
       {
         name: "Google (Gemini API Key) — for Gemini AI",

--- a/packages/providers/src/__tests__/github-oauth.test.ts
+++ b/packages/providers/src/__tests__/github-oauth.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  initiateGithubDeviceFlow,
+  pollGithubDeviceToken,
+  exchangeGithubDeviceCode,
+  GithubOAuthError,
+} from "../copilot/github-oauth.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("Github OAuth Device Flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("initiateGithubDeviceFlow()", () => {
+    it("POSTs to github.com/login/device/code with client_id and scope", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            device_code: "ABCD1234",
+            user_code: "WDXL-GHPW",
+            verification_uri: "https://github.com/login/device",
+            interval: 5,
+            expires_in: 900,
+          }),
+      });
+
+      const result = await initiateGithubDeviceFlow("Ov23li7a7FBdI2WkK0dd");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://github.com/login/device/code",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          }) as Record<string, string>,
+          body: JSON.stringify({
+            client_id: "Ov23li7a7FBdI2WkK0dd",
+            scope: "read:user",
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        device_code: "ABCD1234",
+        user_code: "WDXL-GHPW",
+        verification_uri: "https://github.com/login/device",
+      });
+    });
+
+    it("throws GithubOAuthError on network failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Connection refused"));
+
+      await expect(initiateGithubDeviceFlow("any-client")).rejects.toThrow(GithubOAuthError);
+    });
+
+    it("throws GithubOAuthError when GitHub returns error response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({ error: "invalid_client", error_description: "Client not found" }),
+      });
+
+      await expect(initiateGithubDeviceFlow("bad-client")).rejects.toThrow(GithubOAuthError);
+    });
+  });
+
+  describe("pollGithubDeviceToken()", () => {
+    it("polls with correct params and returns token on success", async () => {
+      let callCount = 0;
+      mockFetch.mockImplementation(() => {
+        callCount++;
+        if (callCount < 3) {
+          // Still pending
+          return Promise.resolve({
+            ok: false,
+            status: 400,
+            json: () =>
+              Promise.resolve({
+                error: "authorization_pending",
+                error_description: "Pending",
+              }),
+          });
+        }
+        // Success
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              access_token: "gho_success_token",
+              token_type: "Bearer",
+              scope: "read:user",
+            }),
+        });
+      });
+
+      const result = await pollGithubDeviceToken("Ov23li7a7FBdI2WkK0dd", "ABCD1234", 0.1);
+
+      expect(result).toMatchObject({
+        access_token: "gho_success_token",
+        token_type: "Bearer",
+        scope: "read:user",
+      });
+      // 3 calls: 2 failures + 1 success
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws GithubOAuthError when user declines (access_denied)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error: "access_denied",
+            error_description: "The user declined the authorization",
+          }),
+      });
+
+      await expect(
+        pollGithubDeviceToken("Ov23li7a7FBdI2WkK0dd", "ABCD1234", 5),
+      ).rejects.toThrow("Authorization declined");
+    });
+
+    it("throws GithubOAuthError when token expires (expired_token)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error: "expired_token",
+            error_description: "Device code expired",
+          }),
+      });
+
+      await expect(
+        pollGithubDeviceToken("Ov23li7a7FBdI2WkK0dd", "ABCD1234", 5),
+      ).rejects.toThrow("Authorization expired");
+    });
+
+    it.skip("slow_down causes retry with delay (would need mock clock to test in reasonable time)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error: "slow_down",
+            error_description: "Polling too fast",
+          }),
+      });
+
+      await expect(
+        pollGithubDeviceToken("Ov23li7a7FBdI2WkK0dd", "ABCD1234", 0.001),
+      ).rejects.toThrow("timed out");
+    });
+
+    it("throws GithubOAuthError on network failure during polling", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      await expect(pollGithubDeviceToken("Ov23li7a7FBdI2WkK0dd", "ABCD1234", 5)).rejects.toThrow(
+        GithubOAuthError,
+      );
+    });
+
+    it("throws GithubOAuthError on unknown error", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            error: "something_unexpected",
+          }),
+      });
+
+      await expect(pollGithubDeviceToken("Ov23li7a7FBdI2WkK0dd", "ABCD1234", 5)).rejects.toThrow(
+        GithubOAuthError,
+      );
+    });
+  });
+
+  describe("exchangeGithubDeviceCode()", () => {
+    it("POSTs to github.com/login/oauth/access_token with device_code params", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            access_token: "gho_token",
+            token_type: "Bearer",
+            scope: "read:user",
+          }),
+      });
+
+      const result = await exchangeGithubDeviceCode("Ov23li7a7FBdI2WkK0dd", "ABCD1234");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://github.com/login/oauth/access_token",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          }) as Record<string, string>,
+          body: JSON.stringify({
+            client_id: "Ov23li7a7FBdI2WkK0dd",
+            device_code: "ABCD1234",
+            grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        access_token: "gho_token",
+        token_type: "Bearer",
+      });
+    });
+
+    it("throws GithubOAuthError on network failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Connection refused"));
+
+      await expect(exchangeGithubDeviceCode("Ov23li7a7FBdI2WkK0dd", "ABCD1234")).rejects.toThrow(
+        GithubOAuthError,
+      );
+    });
+  });
+});

--- a/packages/providers/src/copilot/github-oauth.ts
+++ b/packages/providers/src/copilot/github-oauth.ts
@@ -1,0 +1,172 @@
+export interface GithubDeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  interval: number;
+  expires_in: number;
+}
+
+export interface GithubOAuthToken {
+  access_token: string;
+  token_type: string;
+  scope: string;
+}
+
+export class GithubOAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly errorCode?: string,
+  ) {
+    super(message);
+    this.name = "GithubOAuthError";
+  }
+}
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+async function ghFetch(
+  url: string,
+  body: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new GithubOAuthError(
+      `Network error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const data = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    const error = data.error as string | undefined;
+    const description = (data.error_description as string | undefined) ?? error ?? "Unknown error";
+    throw new GithubOAuthError(description, error);
+  }
+
+  return data;
+}
+
+export async function initiateGithubDeviceFlow(
+  clientId: string,
+): Promise<GithubDeviceCodeResponse> {
+  const data = await ghFetch(DEVICE_CODE_URL, {
+    client_id: clientId,
+    scope: "read:user",
+  });
+
+  return {
+    device_code: data.device_code as string,
+    user_code: data.user_code as string,
+    verification_uri: data.verification_uri as string,
+    interval: data.interval as number,
+    expires_in: data.expires_in as number,
+  };
+}
+
+export async function exchangeGithubDeviceCode(
+  clientId: string,
+  deviceCode: string,
+): Promise<GithubOAuthToken> {
+  const data = await ghFetch(ACCESS_TOKEN_URL, {
+    client_id: clientId,
+    device_code: deviceCode,
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+  });
+
+  return {
+    access_token: data.access_token as string,
+    token_type: data.token_type as string,
+    scope: data.scope as string,
+  };
+}
+
+const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+async function pollFetch(
+  clientId: string,
+  deviceCode: string,
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await fetch(ACCESS_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        device_code: deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+    });
+  } catch (err) {
+    throw new GithubOAuthError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return (await response.json()) as Record<string, unknown>;
+}
+
+export async function pollGithubDeviceToken(
+  clientId: string,
+  deviceCode: string,
+  intervalSeconds: number,
+  signal?: AbortSignal,
+): Promise<GithubOAuthToken> {
+  const intervalMs = intervalSeconds * 1000;
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+  while (!signal?.aborted && Date.now() < deadline) {
+    let data: Record<string, unknown>;
+    try {
+      data = await pollFetch(clientId, deviceCode);
+    } catch (err) {
+      if (err instanceof GithubOAuthError) {
+        throw err;
+      }
+      throw new GithubOAuthError(
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    const error = data.error as string | undefined;
+
+    if (!error) {
+      return {
+        access_token: data.access_token as string,
+        token_type: data.token_type as string,
+        scope: data.scope as string,
+      };
+    }
+
+    if (error === "authorization_pending" || error === "slow_down") {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      continue;
+    }
+
+    if (error === "access_denied") {
+      throw new GithubOAuthError("Authorization declined. Please try logging in again.", error);
+    }
+
+    if (error === "expired_token") {
+      throw new GithubOAuthError("Authorization expired. Please try logging in again.", error);
+    }
+
+    throw new GithubOAuthError(
+      (data.error_description as string | undefined) ?? `OAuth error: ${error}`,
+      error,
+    );
+  }
+
+  throw new GithubOAuthError("Authorization timed out. Please try logging in again.", "timeout");
+}

--- a/packages/providers/src/copilot/index.ts
+++ b/packages/providers/src/copilot/index.ts
@@ -23,3 +23,10 @@ export { validateGithubToken, InvalidTokenError } from "./validator.js";
 export type { GithubUser } from "./validator.js";
 export { fetchAvailableModels, clearModelsCache } from "./models-fetcher.js";
 export type { CatalogModel } from "./models-fetcher.js";
+export {
+  initiateGithubDeviceFlow,
+  pollGithubDeviceToken,
+  exchangeGithubDeviceCode,
+  GithubOAuthError,
+} from "./github-oauth.js";
+export type { GithubDeviceCodeResponse, GithubOAuthToken } from "./github-oauth.js";

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -43,5 +43,15 @@ export {
   InvalidTokenError,
   fetchAvailableModels,
   clearModelsCache,
+  initiateGithubDeviceFlow,
+  pollGithubDeviceToken,
+  exchangeGithubDeviceCode,
+  GithubOAuthError,
 } from "./copilot/index.js";
-export type { GithubUser, CatalogModel, GithubTokenSource } from "./copilot/index.js";
+export type {
+  GithubUser,
+  CatalogModel,
+  GithubTokenSource,
+  GithubDeviceCodeResponse,
+  GithubOAuthToken,
+} from "./copilot/index.js";


### PR DESCRIPTION
## Summary

Add GitHub OAuth device flow for interactive login.

### Changes

- `packages/providers/src/copilot/github-oauth.ts` - OAuth device flow implementation
- `apps/cli/src/commands/login.ts` - Updated to use OAuth by default, falls back to PAT
- `packages/providers/src/__tests__/github-oauth.test.ts` - OAuth tests

### Why

Users shouldn't need to manually create PATs. OAuth device flow opens browser for authentication.

Closes #346