### PR TITLE
docs(planning): align prototype-first roadmap and backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,487 +4,248 @@
 [![CI Status](https://img.shields.io/github/actions/workflow/status/radoxtech/diricode/ci.yml?branch=main)](https://github.com/radoxtech/diricode/actions)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D24.0.0-green.svg)](https://nodejs.org/)
 
-An autonomous AI coding framework that helps you build applications — from POC to production — using a team of 40 specialized AI agents and LLM thought API. Whether you're a developer, product manager, or product owner, you describe what you want to build, and DiriCode interviews you, challenges your assumptions, builds a detailed plan, and implements it maximally autonomously. Questions are queued by importance and blocking-factor — the orchestrator gathers decision-making questions and doubts into a priority queue, sorted by how much they block other tasks, and you can answer them in batches from your mobile when you have time. All runtime state lives in a local SQLite database, so agents work at full speed with full autonomy, and you can review progress from your phone.
+DiriCode is a local-first agentic coding framework focused on building a **believable working prototype first**: a controlled runtime loop with a read-only dispatcher, specialized agents, safe tools, streamed execution visibility, and resumable checkpoints.
 
-> **Status: Pre-MVP (v0.0.0)**. Active early development. Core subsystems are functional, but the full pipeline is not yet wired end-to-end.
+> **Status: Pre-MVP (v0.0.0)** — core runtime pieces exist, but the end-to-end pipeline is still being wired.
 
 ---
 
-## What Makes DiriCode Different
+## Current Direction
 
-Most AI coding tools are glorified chatbots — you type, they respond, state disappears. DiriCode is designed to work more like an autonomous development team:
+The near-term goal is **not** to ship the entire long-range 40-agent vision at once.
 
-- **SQLite is the brain.** Plans, sprints, tasks, and progress live in a local SQLite database — autonomous, no rate limits. Agents read and write state at sub-millisecond speed. GitHub sync is optional: when you want external visibility, a sync adapter pushes state out to a GitHub Project. Agents operate with full autonomy — decisions are local, state is instant.
+The goal is to ship the fastest believable prototype with these properties:
 
-- **Sprint-based execution.** DiriCode doesn't just answer one question at a time. It interviews you to understand the full scope, builds a plan broken into sprints and epics, then executes tasks in parallel across isolated git worktrees. When it hits a blocker, it finishes everything else it can, does a project review, and replans. It only asks you questions when it genuinely gets stuck or when a decision requires your taste. Questions are queued by importance × blocking-factor — answered from mobile in batches when you have time.
+- **Read-only dispatcher** orchestrates work without directly mutating code.
+- **Sequential-first runtime** is easier to debug, trust, and resume.
+- **Streaming visibility** makes agent/tool progress observable instead of opaque.
+- **Checkpoint/resume** is a first-class MVP-1 requirement.
+- **Semantic navigation + structural tooling** raise coding quality early.
+- **Local SQLite state** keeps runtime operations offline-first and low-latency.
 
-- **Continuous progress reports.** While agents work, you receive real-time reports. If you have time, you can read them and guide the work. If you don't, agents keep going autonomously. You're never blocked, and neither are they.
+Later capabilities — broader swarm execution, richer approval UX, advanced context autopilot, full ReasoningBank live integration, and smarter LLM intent routing — remain in the roadmap, but they are not the first delivery target.
 
-- **40 specialized agents, not one do-everything bot.** There's an architect, a debugger, a test writer, a code reviewer, a frontend specialist, a web researcher — each one assigned to the right AI model for its job. A read-only dispatcher orchestrates them without ever writing code itself.
+## What Exists Today
 
-- **Safety you can't turn off.** Every bash command is parsed into an AST by tree-sitter before execution. Git operations go through mandatory safety rails. Secrets are automatically redacted before reaching any AI model. These protections are always on — even at maximum autonomy.
+These parts are already real in the repository:
 
-## The Vision
+- **Dispatcher and delegation protocol**
+  - read-only dispatcher runtime
+  - parent/child delegation envelopes
+  - context inheritance modes
+  - async job/sandbox primitives
+- **Tool layer**
+  - file read/write/edit
+  - grep/glob
+  - bash execution with safety controls
+  - LSP and AST-aware tooling foundations
+- **Runtime state and memory**
+  - SQLite-backed repositories
+  - task/context persistence primitives
+  - local-first issue system direction
+- **Transport and observability foundations**
+  - Hono API routes
+  - SSE transport
+  - event emission foundations
+- **Provider layer**
+  - provider registry
+  - router foundations
+  - model scoring / experiment primitives
 
-DiriCode is being built toward a future where you describe what you want to build, and an autonomous orchestrator turns that into a working product — running sprints, managing its own backlog, and asking for your input only when it matters. Here's how the pieces fit together:
+The biggest remaining gap is **integration**, not “missing ideas.”
 
-### How It Works (End-to-End Flow)
+## Prototype-First Scope
 
-```
-You describe what you want
-        ↓
-    Interview Phase — DiriCode asks clarifying questions
-        ↓
-    Planning Phase — breaks work into sprints, epics, and tasks (stored in local SQLite)
-        ↓
-    Execution Phase — agents work in parallel across git worktrees
-        ↓
-    ┌── Agent hits a blocker? → parks it, continues other tasks
-    ├── Agent encounters decision/doubt → adds to priority queue
-    │   └── Queue sorted by: importance × blocking-factor
-    ├── Time to ask? → batched questions sent to you (mobile-friendly)
-    │   └── You answer when convenient — never blocks agents
-    └── All tasks done in this sprint? → runs verification
-        ↓
-    Verify Phase — automated review, tests, lint checks
-        ↓
-    Sprint Review — evaluates progress, replans, starts next sprint
-        ↓
-    You review from the web UI (or optional GitHub sync), approve PRs, give feedback
-```
+### First-wave priorities
 
-**Questions Queue:** The orchestrator continuously gathers decision-making questions and doubts. Each is tagged with importance (architectural impact, user experience, technical debt) and blocking-factor (how many other tasks it halts). Queue is sorted automatically — highest impact blockers surface first. You receive batched notifications on mobile and answer when ready. Agents never wait on you unless truly blocked.
+The current prototype-first rollout is shaped by these patterns:
 
-### Three-Dimensional Model Selection
+1. Tool Call Loop
+2. Sequential-first execution with later wave compatibility
+3. Streaming Tool Calls
+4. Tool Loop Error Handling
+5. Read-Only Dispatcher
+6. Handoff Input Filtering
+7. Tool Whitelisting per Agent
+8. Semantic Navigation
+9. Structural Refactoring support
+10. Session Checkpointing / Resume
+11. Event Stream Coordination
 
-Instead of hardcoding "use GPT for everything," DiriCode classifies AI models along three dimensions:
+### Second-wave priorities
 
-**Tier** — how powerful (and expensive) the model is:
+After the first runtime path works:
 
-| Tier   | Used For                                         | Examples                               |
-| ------ | ------------------------------------------------ | -------------------------------------- |
-| HEAVY  | Architecture, complex reasoning, thorough review | Opus 4.6, GPT-5.4, Gemini 3.1 Pro      |
-| MEDIUM | Standard coding, quick review, debugging         | Sonnet 4.6, Kimi 2.5, Qwen3 Coder Next |
-| LOW    | Commit messages, naming, summaries               | Haiku 4.5, DeepSeek V3.2               |
+- auto-compact / tool result spill
+- sub-agent spawning and stronger autonomy loops
+- hash-anchored edits / fuzzier patch application
+- lightweight `AGENTS.md` support
+- ReasoningBank foundations and cross-session memory querying
+- stronger intent gate evolution
+- richer router/cost intelligence
 
-**Family** — what the model is good at:
+### Later priorities
 
-| Family       | Strength                                         |
-| ------------ | ------------------------------------------------ |
-| Reasoning    | Complex logic, math, architecture decisions      |
-| Creative     | Brainstorming, unconventional solutions, writing |
-| UI/UX        | Frontend code, styling, design systems           |
-| Speed        | Low latency responses, high throughput           |
-| Web Research | Searching, browsing, information gathering       |
-| Bulk         | High volume work at minimal cost                 |
-| Agentic      | Tool use, multi-step autonomous execution        |
-
-**Context Size** — how much input context the model can handle:
-
-| Context Group | Range          | Used For                                            |
-| ------------- | -------------- | --------------------------------------------------- |
-| Standard      | ≤200K tokens   | Most tasks, single-file analysis, standard coding   |
-| Extended      | 200K–1M tokens | Large codebases, multi-file analysis, big documents |
-| Massive       | ≥1M tokens     | Full-repo analysis, massive document processing     |
-
-The same model can appear in different context groups depending on your subscription — for example, Claude Opus via GitHub Copilot (200K, standard) vs Anthropic direct API (1M, massive). The router prefers cheaper subscriptions when smaller context is sufficient.
-
-Each agent requests `{ tier: "heavy", family: "reasoning" }` (and optionally `contextRequired: "standard"`) and the router finds the best available model across all your subscriptions, preferring cheaper subscriptions when smaller context is sufficient. A single model can belong to multiple families — Opus 4.6 is reasoning + creative + agentic.
-
-See [ADR-004](docs/adr/adr-004-agent-roster-3-tiers.md) and [ADR-042](docs/adr/adr-042-multi-subscription-management.md). The 3D classification system is documented in the [ADR-042 addendum](docs/adr/adr-042-multi-subscription-management.md).
-
-### Multi-Subscription Management
-
-You probably have more than one AI subscription — maybe an Anthropic API key, an Azure OpenAI account through work, a GitHub Copilot plan, and a free-tier Google AI key. DiriCode uses all of them simultaneously:
-
-- **Automatic rotation.** When one subscription hits its rate limit, requests immediately route to the next available subscription that offers an equivalent model.
-- **Auto-recovery.** When a rate limit resets, that subscription automatically rejoins the rotation pool.
-- **Cost awareness.** The router prefers cheaper subscriptions when model quality is equivalent.
-- **Budget caps.** Set monthly spending limits per subscription. The system respects them.
-
-**Planned (v2):** Quality scoring — track which models produce the best results for which tasks, using Elo-style ratings built from automated signals (did the code compile? did tests pass?) and optional human feedback.
-
-**Planned (v3):** A/B testing — run structured experiments comparing models on identical tasks to make data-driven decisions about which models to use where.
-
-See [ADR-042](docs/adr/adr-042-multi-subscription-management.md).
-
-### Observability — See Everything
-
-DiriCode treats transparency as a core feature, not an afterthought:
-
-- **Agent tree.** A live hierarchical view showing which agents are running, who spawned whom, what each one is doing right now, and how many tokens they've used.
-- **Metrics bar.** Real-time token count, cost, elapsed time, and which model is active — always visible.
-- **Live activity indicator.** See exactly what the current agent is doing: reading a file, calling a model, running a test.
-- **Continuous reports.** Agents push progress updates as they work. If you're watching, you can steer. If you're not, they keep going.
-
-**Planned (v2):** Click any agent in the tree to see its full conversation, tool calls, and token breakdown. Timeline/waterfall view showing parallel execution branches.
-
-**Planned (v3):** Cost analytics dashboard, performance profiling, model comparison views.
-
-See [ADR-031](docs/adr/adr-031-observability-eventstream-agent-tree.md).
-
-### Local-First Issue System
-
-This is DiriCode's most unconventional design choice. Agents are autonomous runtimes — their task state is operational data, not project metadata. Storing operational data in a remote API introduces rate limits, latency, and blocks autonomous execution. DiriCode keeps all state local for maximum autonomy and speed.
-
-SQLite is the source of truth for all runtime state — issues, tasks, epics, and their relationships. This is a full reversal from the original design (see [ADR-022](docs/adr/adr-022-github-issues-sqlite-timeline.md), superseded by [ADR-048](docs/adr/adr-048-sqlite-issue-system.md)):
-
-- **Plans become local records.** Each sprint task is stored in SQLite with acceptance criteria, file lists, and implementation notes. Local I/O at sub-millisecond speed enables full autonomous execution.
-- **Autonomous-first.** Agents work at full capability continuously. Creating an issue, updating task status, marking completion — all local I/O with full autonomy.
-- **No rate limits.** Dense agent activity during sprint execution no longer creates API pressure. SQLite reads are sub-millisecond; GitHub API calls have hundreds of milliseconds of round-trip latency.
-- **Sync adapters are output targets, not input sources.** If you want external visibility — for stakeholders, phone review, or team collaboration — a sync adapter pushes state from SQLite to a GitHub Project. The directionality is intentional: SQLite receives writes, GitHub receives exports.
-
-MVP ships with no sync adapters. v2 adds the GitHub sync adapter. v3/v4 add GitLab and Jira.
-
-See [ADR-048](docs/adr/adr-048-sqlite-issue-system.md).
+- full context-budget sophistication
+- file guard / AI-slop guards in broader hook framework
+- full permission service
+- confidence-based multi-agent review
+- interactive terminal / TUI
 
 ## Architecture
 
 ```mermaid
 graph TD
-    subgraph "Clients"
+    subgraph Clients
         CLI[CLI]
         Web[Web UI]
     end
 
-    subgraph "@diricode/server"
-        Hono[Hono HTTP + SSE]
-        Events[EventStream]
+    subgraph Server
+        API[Hono API]
+        SSE[SSE / Event stream]
     end
 
-    subgraph "@diricode/core"
-        Dispatcher[Dispatcher — Read-Only]
-        Pipeline[Interview → Plan → Execute → Verify]
-        Hooks[Hook Framework — 20 types]
-        WorkMode[4D Work Modes]
+    subgraph Core
+        Dispatcher[Dispatcher - read only]
+        Pipeline[Sequential-first pipeline]
+        Prompt[Prompt builder]
     end
 
-    subgraph "@diricode/agents"
-        Heavy[HEAVY — architect, code-writer, planner]
-        Medium[MEDIUM — debugger, reviewer, explorer]
-        Low[LOW — summarizer, commit-writer, namer]
+    subgraph Agents
+        Specialists[Specialist agents]
     end
 
-    subgraph "@diricode/tools"
-        Bash[Bash + tree-sitter guard]
-        Git[Git + Safety Rails]
-        Files[File Read / Write / Edit]
-        Search[Grep + Glob]
-        MCP[MCP Servers]
+    subgraph Tools
+        Files[Files]
+        Search[Search / LSP / AST]
+        Bash[Bash]
+        Git[Git]
     end
 
-    subgraph "@diricode/providers"
-        SubRouter[Subscription Router]
-        Router[Model Router + Fallback]
-        Redactor[Secret Redactor]
+    subgraph Memory
+        SQLite[SQLite runtime state]
     end
 
-    subgraph "@diricode/memory"
-        Issues[Local Issue System — SQLite + FTS5]
-        GHSync[GitHub Sync — optional, v2]
+    subgraph Providers
+        Registry[Provider registry]
+        Router[Routing foundations]
     end
 
-    CLI --> Hono
-    Web --> Hono
-    Hono --> Events
-    Events --> Dispatcher
+    CLI --> API
+    Web --> API
+    API --> SSE
+    API --> Dispatcher
     Dispatcher --> Pipeline
-    Pipeline --> Heavy
-    Pipeline --> Medium
-    Pipeline --> Low
-    Heavy --> Hooks
-    Medium --> Hooks
-    Hooks --> Bash
-    Hooks --> Git
-    Hooks --> Files
-    Hooks --> Search
-    Hooks --> MCP
-    Heavy --> SubRouter
-    Medium --> SubRouter
-    SubRouter --> Router
-    Router --> Redactor
-    Heavy --> Issues
-    Issues -.->|optional sync| GHSync
+    Pipeline --> Specialists
+    Specialists --> Files
+    Specialists --> Search
+    Specialists --> Bash
+    Specialists --> Git
+    Dispatcher --> SQLite
+    Specialists --> SQLite
+    Specialists --> Router
+    Router --> Registry
 ```
 
-Architecture decisions are documented in [48 ADRs](docs/adr/).
+## Key Architectural Decisions
 
-## Key Design Decisions
+### Dispatcher-first
 
-### 4-Dimension Work Modes
+The dispatcher remains the orchestrator and stays read-only. It routes, delegates, aggregates, and exposes progress — but should not become a hidden “do everything” agent.
 
-Instead of a binary "safe vs yolo" toggle, DiriCode uses four independent dimensions you can tune:
+See: `docs/adr/adr-002-dispatcher-first-agent-architecture.md`
 
-| Dimension      | Range | Low end          | High end           |
-| -------------- | ----- | ---------------- | ------------------ |
-| **Quality**    | 1-5   | Cheap/fast (POC) | Production-grade   |
-| **Autonomy**   | 1-5   | Ask everything   | Full auto          |
-| **Verbosity**  | 1-4   | Silent           | Narrated           |
-| **Creativity** | 1-5   | Reactive/minimal | Proactive/creative |
+### Pipeline-first, sequential-first
 
-Quality controls which model tier agents use. Autonomy controls how much human approval is needed. These are independent — you can run full-auto at POC quality for rapid prototyping, or ask-everything at production quality for critical systems.
+The long-term shape remains **Interview → Plan → Execute → Verify**, but MVP-1 delivery is clarified as:
 
-See [ADR-012](docs/adr/adr-012-4-dimension-work-mode-system.md).
+**Prompt → Dispatcher → Specialist → Tool execution → Response**
 
-### Agent Roster — 40 Agents, 6 Categories
+with **checkpoint/resume** and **observable progress** required from the start.
 
-The dispatcher selects agents dynamically via `search_agents()` — it searches by capability tags, not a hardcoded list.
+See: `docs/adr/adr-013-project-pipeline.md`
 
-```mermaid
-graph LR
-    D[Dispatcher]
+### EventStream as observability backbone
 
-    D --> SP[Strategy & Planning\n9 agents]
-    D --> CP[Code Production\n9 agents]
-    D --> QA[Quality Assurance\n8 agents]
-    D --> RE[Research & Exploration\n4 agents]
-    D --> UT[Utility\n8 agents]
-    D --> AC[auto-continue]
-```
+Observability starts with typed events and replayable runtime data. Richer UI surfaces build on top of that.
 
-#### Phase 1 MVP — 8 Agents Shipping First
+See: `docs/adr/adr-031-observability-eventstream-agent-tree.md`
 
-Phase 1 ships the minimum viable set for the Interview → Plan → Execute → Verify pipeline:
+### SQLite is runtime truth
 
-| Agent                  | Tier   | Role                             |
-| ---------------------- | ------ | -------------------------------- |
-| dispatcher             | HEAVY  | Orchestrates all agent execution |
-| planner-thorough       | HEAVY  | Builds detailed execution plans  |
-| architect              | HEAVY  | Selects files per subtask        |
-| code-writer            | HEAVY  | Primary implementation agent     |
-| code-explorer          | MEDIUM | Codebase navigation and search   |
-| code-reviewer-thorough | HEAVY  | Quality gate before merge        |
-| git-operator           | MEDIUM | Git operations with safety rails |
-| issue-writer           | LOW    | Creates and manages issues       |
+Runtime state lives in SQLite. GitHub is for planning/project visibility, not the runtime source of truth.
 
-The full 40-agent roster is the vision. Additional agents are activated as the pipeline matures and new capabilities (swarm coordination, A/B testing) require them. See [ADR-046](docs/adr/adr-046-swarm-coordination.md).
+See: `docs/adr/adr-048-sqlite-issue-system.md`
 
-<details open>
-<summary><b>Strategy & Planning</b> — 9 agents</summary>
+## MVP Roadmap Shape
 
-```mermaid
-graph LR
-    subgraph "HEAVY"
-        PT[planner-thorough]
-        AR[architect]
-        PB[project-builder]
-        PLR[plan-reviewer]
-    end
-    subgraph "MEDIUM"
-        PQ[planner-quick]
-        SP[sprint-planner]
-        PR[project-roadmapper]
-        PV[prompt-validator]
-    end
-    subgraph "LOW"
-        TM[todo-manager]
-    end
+### POC
 
-    PT -->|breaks into sprints| SP
-    AR -->|selects files for| PB
-    PLR -->|validates| PT
-```
+Prove the basic path:
 
-</details>
+- dispatcher runtime
+- safe tools
+- provider path
+- CLI/server/SSE skeleton
 
-<details open>
-<summary><b>Code Production</b> — 9 agents</summary>
+### MVP-1
 
-```mermaid
-graph LR
-    subgraph "HEAVY"
-        CW[code-writer]
-        CWH[code-writer-hard]
-        CT[creative-thinker]
-        FS[frontend-specialist]
-        RA[refactoring-agent]
-        DB[debugger]
-    end
-    subgraph "MEDIUM"
-        CWQ[code-writer-quick]
-        FB[file-builder]
-        TW[test-writer]
-    end
+Ship the first believable runtime:
 
-    CW -->|complex tasks| CWH
-    DB -->|fixes issues from| CW
-    TW -->|tests code from| CW
-```
+- sequential-first execution
+- explicit turn lifecycle
+- heuristic route into execution path
+- checkpoint/resume
+- semantic navigation / structural tooling uplift
+- early evented transparency
+- memory-backed runtime state
 
-</details>
+### MVP-2+
 
-<details open>
-<summary><b>Quality Assurance</b> — 8 agents</summary>
+Expand safely:
 
-```mermaid
-graph LR
-    subgraph "HEAVY"
-        CRT[code-reviewer-thorough]
-        VR[verifier]
-    end
-    subgraph "MEDIUM"
-        CRQ[code-reviewer-quick]
-        SCR[spec-compliance-reviewer]
-        RK[risk-assessor]
-        MC[merge-coordinator]
-        IC[integration-checker]
-    end
-    subgraph "LOW"
-        LC[license-checker]
-    end
+- richer hooks and guardrails
+- stronger autonomy / bounded waves
+- smarter context management
+- ReasoningBank live integration
+- richer observability UI
 
-    CRQ -->|escalates to| CRT
-    CRT -->|validates with| VR
-    RK -->|informs| MC
-```
-
-</details>
-
-<details open>
-<summary><b>Research & Exploration</b> — 4 agents</summary>
-
-```mermaid
-graph LR
-    subgraph "MEDIUM"
-        CE[code-explorer]
-        WR[web-researcher]
-        BA[browser-agent]
-        CM[codebase-mapper]
-    end
-
-    CM -->|maps structure for| CE
-    WR -->|finds docs, BA browses| BA
-```
-
-</details>
-
-<details open>
-<summary><b>Utility</b> — 8 agents</summary>
-
-```mermaid
-graph LR
-    subgraph "MEDIUM"
-        LT[long-task-runner]
-        GO[git-operator]
-        GHO[github-operator]
-        DO[devops-operator]
-    end
-    subgraph "LOW"
-        SU[summarizer]
-        CWR[commit-writer]
-        NM[namer]
-        IW[issue-writer]
-    end
-
-    GO -->|commits with msg from| CWR
-    GHO -->|creates issues via| IW
-```
-
-</details>
-
-See [ADR-004](docs/adr/adr-004-agent-roster-3-tiers.md) and [ADR-040](docs/adr/adr-040-tool-based-agent-discovery.md).
-
-### Safety Architecture
-
-Three layers of protection that are always on, even at Autonomy level 5:
-
-- **Tree-sitter Bash parsing.** Commands are parsed into ASTs before execution. Detects `rm -rf /`, pipes to `sh`, fork bombs — not with regex, but with a real parser. See [ADR-029](docs/adr/adr-029-treesitter-bash-parsing.md).
-- **Git safety rails.** Blocks `git add .` without review, requires confirmation for `--force` and `reset --hard`. Cannot be disabled. See [ADR-027](docs/adr/adr-027-git-safety-rails.md).
-- **Secret redaction.** Scans for API keys, tokens, and credentials before any data reaches an AI model. See [ADR-028](docs/adr/adr-028-secret-redaction.md).
-
-Tool actions are categorized as Safe, Risky, or Destructive — each with different approval requirements. See [ADR-014](docs/adr/adr-014-smart-hybrid-approval.md).
-
-Governance policies (file naming, import style, test coverage thresholds) can be declared in `.dc/policies/` YAML files and enforced via the policy engine. See [ADR-047](docs/adr/adr-047-governance-policy-engine.md).
-
-### Hook Framework
-
-20 hook types across lifecycle, safety, pipeline, and context categories. Two execution models:
-
-- **Interceptors** — Sequential state modification (e.g., `session-start`, `post-commit`)
-- **Wrappers** — Control flow, retries, safety (e.g., `pre-commit`, `pre-tool-use`)
-
-Hooks can be TypeScript or external scripts (Python, bash). See [ADR-024](docs/adr/adr-024-hook-framework-20-types.md).
-
-### Context Management
-
-A 3-layer system that keeps agents under 50% of their context window:
-
-1. **Structural Index** — SQLite + Tree-sitter + PageRank ranks files by importance
-2. **Condenser Pipeline** — 3-stage compression: dedup, masking, summarization
-3. **Context Composer** — Adaptive token budgets per category (files, history, tools, system)
-
-The architect agent picks specific files per subtask rather than dumping the whole codebase. See [ADR-016](docs/adr/adr-016-3-layer-context-management.md).
-
-Successful reasoning patterns are captured and stored in the ReasoningBank — a structured SQLite store that surfaces relevant prior approaches when agents tackle similar problems. See [ADR-045](docs/adr/adr-045-reasoningbank.md).
-
-### Skills and MCP
-
-Custom agents and skills via `SKILL.md` files (compatible with [agentskills.io](https://agentskills.io)). Integration with [Model Context Protocol](https://modelcontextprotocol.io/) servers for web search (zero API keys required) and Playwright browser automation.
-
-See [ADR-008](docs/adr/adr-008-skill-system-agentskills-io.md) and [ADR-041](docs/adr/adr-041-mcp-web-research-servers.md).
-
-### Configuration
-
-JSONC config via [c12](https://github.com/unjs/c12) with a 4-layer hierarchy:
-
-```
-CLI flags / DC_* env vars  →  Project .dc/  →  Global ~/.config/dc/  →  Defaults
-```
-
-All config validated with Zod schemas. See [ADR-009](docs/adr/adr-009-jsonc-config-c12-loader.md).
-
-## Project Structure
+## Current Package Layout
 
 ```text
 apps/
-  cli/              CLI entrypoint (dc / diricode commands)
+  cli/
 packages/
-  core/             Agent interfaces, config schema (Zod), tool types
-  agents/           Dispatcher agent and registry
-  tools/            File ops, grep, glob, bash execution with safety filter
-  providers/        Multi-LLM provider interface and registry
-  server/           Hono HTTP server with REST API + SSE transport
-  memory/           SQLite database with FTS5 search and local issue system
-  web/              Web UI (planned — Vite + React + shadcn/ui)
+  core/
+  agents/
+  tools/
+  providers/
+  server/
+  memory/
+  web/
 docs/
-  adr/              48 Architecture Decision Records
-  mvp/              MVP epic specifications
+  adr/
+  mvp/
+  v2/
+  v3/
+  v4/
 ```
 
-## Status
+## Current Status
 
-| Component           | Status     | Details                                              |
-| ------------------- | ---------- | ---------------------------------------------------- |
-| Dispatcher Agent    | ✅ Done    | Read-only orchestrator with dynamic agent discovery  |
-| Tool Suite          | ✅ Done    | Bash (tree-sitter), file read/write/edit, grep, glob |
-| Provider Layer      | ✅ Done    | Unified LLM interface with failover chain            |
-| CLI                 | ✅ Done    | REPL and one-shot modes with flag parsing            |
-| Memory              | ✅ Done    | SQLite + FTS5 persistence layer                      |
-| HTTP + SSE          | ✅ Done    | Hono server with SSE event transport                 |
-| CI                  | ✅ Done    | GitHub Actions with Turborepo caching                |
-| Pipeline            | 🏗️ WIP     | Interview → Plan → Execute → Verify                  |
-| Hook Framework      | 🏗️ WIP     | 20 hook types (interceptors + wrappers)              |
-| Agent Roster        | 🏗️ WIP     | 40 agents planned, 8 shipping in Phase 1             |
-| Context Manager     | 🏗️ WIP     | 3-layer system with PageRank indexing                |
-| Local Issue System  | 🏗️ WIP     | SQLite-native issues/tasks/epics (ADR-048)           |
-| Secret Redaction    | ⏳ Planned | Pattern-based masking before LLM dispatch            |
-| Config System       | ⏳ Planned | JSONC + c12, 4-layer hierarchy                       |
-| Skill System        | ⏳ Planned | SKILL.md definitions, agentskills.io compatibility   |
-| Subscription Router | ⏳ Planned | Multi-subscription rotation + health tracking        |
-| Web UI              | ⏳ Planned | Agent tree, event stream, metrics dashboard          |
-| GitHub Sync Adapter | 📋 v2      | Optional push from SQLite to GitHub Project          |
-| Quality Scoring     | 📋 v2      | Elo-based model quality tracking                     |
-| A/B Testing         | 📋 v3      | Structured model comparison experiments              |
-
-## Roadmap
-
-| Version   | Theme                | Key Deliverable                                                        |
-| --------- | -------------------- | ---------------------------------------------------------------------- |
-| **MVP**   | Core engine + Web UI | Working agent system with pipeline, web interface, real task execution |
-| **MVP-2** | Multi-subscription   | Subscription rotation, health tracking, auto-recovery                  |
-| **v2**    | Ecosystem + Quality  | GitHub sync adapter, quality scoring, embeddings, skill marketplace    |
-| **v3**    | Safety + Automation  | A/B testing, sandbox, auto-advance, GitLab sync adapter                |
-| **v4**    | Enterprise           | Jira sync adapter, multi-user support                                  |
+| Area                                | Status          | Notes                                                |
+| ----------------------------------- | --------------- | ---------------------------------------------------- |
+| Dispatcher / delegation             | ✅ Partial-real | Strong runtime foundation exists                     |
+| Tool layer                          | ✅ Partial-real | File/search/bash/LSP/AST foundations exist           |
+| SQLite memory backbone              | ✅ Partial-real | Repositories and local-first direction are real      |
+| SSE / transport                     | ✅ Partial-real | Transport exists; full event model still in progress |
+| Provider layer                      | ✅ Partial-real | Registry exists; richer routing still evolving       |
+| End-to-end pipeline                 | 🏗️ In progress  | Core integration still being wired                   |
+| Checkpoint / resume                 | 🏗️ In progress  | Explicit MVP-1 requirement                           |
+| Semantic navigation / refactoring   | 🏗️ In progress  | High-priority prototype multiplier                   |
+| Full context budgeting / compaction | 📋 Later        | Deliberately not first-wave                          |
+| Full swarm / broad autonomy         | 📋 Later        | Architectural direction kept, delivery delayed       |
 
 ## Getting Started
 
@@ -502,36 +263,31 @@ pnpm install
 pnpm build
 ```
 
-### Running the CLI
+### Development
 
 ```bash
-# Interactive REPL
-pnpm --filter @diricode/cli dev
-
-# One-shot prompt
-pnpm --filter @diricode/cli dev run "your prompt here"
-
-# See all options
-pnpm --filter @diricode/cli dev -- --help
+pnpm build
+pnpm test
+pnpm lint
+pnpm format
+pnpm typecheck
 ```
 
-## Development
+## Documentation Index
 
-Built with [Turborepo](https://turbo.build/) and [Vitest](https://vitest.dev/).
-
-```bash
-pnpm build          # Build all packages
-pnpm test           # Run tests
-pnpm lint           # Lint all packages
-pnpm format         # Format with Prettier
-pnpm typecheck      # TypeScript type checking
-```
+- ADRs: `docs/adr/`
+- MVP plan: `docs/mvp/`
+- later roadmap: `docs/v2/`, `docs/v3/`, `docs/v4/`
 
 ## Contributing
 
-DiriCode is in early development. Contributions are welcome.
+The project is still in active architectural shaping. If you want to understand the current direction, start with:
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, GitHub Projects setup, and how to get started. Start by reading the [Architecture Decision Records](docs/adr/) to understand the design philosophy.
+1. `docs/adr/adr-002-dispatcher-first-agent-architecture.md`
+2. `docs/adr/adr-013-project-pipeline.md`
+3. `docs/adr/adr-031-observability-eventstream-agent-tree.md`
+4. `docs/adr/adr-048-sqlite-issue-system.md`
+5. `docs/mvp/index.md`
 
 ## License
 

--- a/docs/adr/adr-013-project-pipeline.md
+++ b/docs/adr/adr-013-project-pipeline.md
@@ -21,9 +21,17 @@ Interview → Plan → Execute → Verify
 
 Each phase uses different agents. Dispatcher decides when to invoke the full pipeline vs. quick single-agent execution.
 
+**Prototype-first sequencing (clarification, 2026-03-28):**
+
+- MVP-1 is **sequential-first** by default. The first delivery goal is a believable end-to-end runtime path, not maximum parallel throughput.
+- The first working path is: **Prompt → Dispatcher → Specialist → Tool execution → Response**.
+- The full Interview → Plan → Execute → Verify pipeline remains the architectural target for non-trivial work, but early MVP implementation may expose planning/review stages progressively as the runtime path becomes stable.
+- Wave-based parallel execution remains part of the architecture, but it is treated as a **later extension on top of a stable sequential baseline**, not as the defining MVP-1 execution mode.
+
 **Pipeline rules (MVP):**
 - **Gray area auto-detection:** System flags areas requiring user decision.
-- **Wave-based parallel execution:** Independent subtasks run in parallel.
+- **Sequential-first execution:** MVP-1 executes one task chain at a time unless a later, explicitly enabled wave-based mode is active.
+- **Wave compatibility:** Planning and execution contracts must remain compatible with later wave-based parallel execution for clearly independent subtasks.
 - **Deviation rules (4):**
   1. Auto-fix bugs encountered during execution.
   2. Auto-add missing imports/dependencies.
@@ -31,16 +39,24 @@ Each phase uses different agents. Dispatcher decides when to invoke the full pip
   4. **ASK** for any architectural changes.
 - **Analysis paralysis guard:** 5+ reads without a write → STOP and escalate.
 - **Context budget:** Max 50% of context window for active work.
-- **Checkpoint protocols:** Save progress for resume after crash.
+- **Checkpoint protocols:** Save progress for resume after crash. This is an explicit MVP-1 requirement, not an optional hardening step.
 - **Atomic commits:** One commit per completed task.
 
 ### Consequences
 
-- **Positive:** Predictable execution flow. Checkpoints enable recovery. Deviation rules balance autonomy with safety.
-- **Negative:** Pipeline overhead for trivial tasks. Mitigated by dispatcher's ability to skip pipeline for simple requests.
+- **Positive:** Predictable execution flow. Checkpoints enable recovery. Sequential-first delivery reduces debugging complexity and makes early observability easier to trust. Deviation rules balance autonomy with safety.
+- **Negative:** Pipeline overhead for trivial tasks. Parallel throughput is intentionally delayed for the first milestone. Mitigated by dispatcher's ability to skip pipeline for simple requests and by preserving forward compatibility for later wave execution.
 
 ### Addendum — Pipeline State Backend Update (2026-03-23)
 
 Pipeline state (plans, tasks, checkpoints) is stored in the DiriCode Issue System — a local SQLite database (ADR-048), not GitHub Issues. GitHub Projects remains an optional sync target for team visibility but is not required for pipeline operation.
 
 This change enables fully offline pipeline execution with no network dependency for any state operation.
+
+### Addendum — Prototype-First Delivery Clarification (2026-03-28)
+
+This ADR is retained as the long-term shape of non-trivial task execution, but current delivery sequencing is clarified:
+
+- **What ships first:** a stable, observable, checkpointable sequential execution path.
+- **What is explicitly later:** richer wave-based parallel execution, more advanced LLM-backed intent analysis, and broader autonomy patterns that depend on the sequential path being trustworthy first.
+- **What must be visible from the start:** evented progress, failure states, and recovery checkpoints sufficient to resume work after interruption.

--- a/docs/adr/adr-031-observability-eventstream-agent-tree.md
+++ b/docs/adr/adr-031-observability-eventstream-agent-tree.md
@@ -15,12 +15,19 @@ Users need full transparency into what agents are doing (UX-003). An event-drive
 
 **EventStream** as the observability backbone + **6 UI components** (3 MVP, 3 v2).
 
+**Prototype-first sequencing (clarification, 2026-03-28):**
+
+- Observability starts with the **data/event layer first**, not with the full UI surface.
+- MVP-1 priority is to make the runtime visibly alive through structured streaming of agent/tool/progress/error/checkpoint activity.
+- Richer UI transparency remains important, but current delivery sequencing treats typed event emission and replayability as the foundation that must land before full polish.
+
 #### EventStream (Single Source of Truth)
 
 All agent activity emits structured events with:
 - Timestamp, event type, agent ID, parent agent ID (for tree building).
 - Tool calls, model requests, token usage, errors.
 - Parent-child links enable full tree reconstruction.
+- Checkpoint/resume markers and execution-state transitions are first-class event types for prototype reliability and recovery visibility.
 
 #### MVP UI Components (3)
 
@@ -29,6 +36,11 @@ All agent activity emits structured events with:
 | **Agent Tree** | Hierarchical view of running agents (who spawned whom, current status, token usage). Primary observability tool. |
 | **Metrics Bar** | Real-time token count, cost, elapsed time, model in use. Always visible. |
 | **Live Activity Indicator** | Shows what the current agent is doing (reading file X, calling model Y, executing bash Z). |
+
+For sequencing purposes, MVP observability is split into two layers:
+
+1. **MVP-1 data layer:** typed EventStream, event persistence, replayability, tool/agent/error/checkpoint visibility.
+2. **MVP-2/MVP-3 UI richness:** full Agent Tree polish, richer metrics surfaces, detail/timeline panels, approval UX.
 
 #### v2 UI Components (3)
 
@@ -40,5 +52,13 @@ All agent activity emits structured events with:
 
 ### Consequences
 
-- **Positive:** Full transparency (UX-003 satisfied). EventStream enables any UI component without changing core logic. Agent Tree is the killer feature for understanding multi-agent orchestration.
-- **Negative:** EventStream adds overhead (event emission per action). Acceptable — events are lightweight structs.
+- **Positive:** Full transparency (UX-003 satisfied). EventStream enables any UI component without changing core logic. Early evented visibility makes the prototype debuggable and trustworthy before the complete UI arrives.
+- **Negative:** EventStream adds overhead (event emission per action). Acceptable — events are lightweight structs. Splitting data-layer observability from later UI richness increases planning complexity, but reduces product ambiguity.
+
+### Addendum — Prototype-First Observability Clarification (2026-03-28)
+
+The Metrics Bar and Agent Tree remain target MVP surfaces, but implementation order is clarified:
+
+- **First priority:** streamed and persisted runtime events for tools, delegation, errors, token/cost usage, and checkpoints.
+- **Second priority:** UI components that subscribe to this data with stable schemas.
+- **Later priority:** richer approval/timeline/detail panels once the event backbone proves reliable.

--- a/docs/adr/adr-045-reasoningbank.md
+++ b/docs/adr/adr-045-reasoningbank.md
@@ -4,7 +4,7 @@
 |-------------|-----------------------------------------------------------------------|
 | Status      | Accepted                                                              |
 | Date        | 2026-03-23                                                            |
-| Scope       | MVP                                                                   |
+| Scope       | MVP foundations + v2 live integration                                 |
 | References  | ADR-024 (hooks), ADR-018 (SQLite), Survey Decision A1                 |
 
 ### Context
@@ -22,6 +22,13 @@ DiriCode's agents are short-lived by design. They run to completion, then stop. 
 ### Decision
 
 **Introduce ReasoningBank — a structured store of reasoning patterns — backed by the existing SQLite instance, integrated with the Hook Framework (ADR-024), and separate from RAG or document-chunk retrieval.**
+
+**Prototype-first sequencing (clarification, 2026-03-28):**
+
+- ReasoningBank remains an accepted strategic capability.
+- MVP focus is on **storage/schema/foundation work only where it does not slow the first working runtime path**.
+- Live injection and hook-driven learning remain staged behind the core runtime loop, observability, and checkpoint/resume milestones.
+- In practical planning terms, ReasoningBank is an **early second-wave capability**, not part of the narrowest first prototype slice.
 
 **What a reasoning record contains.** Each record captures a single problem-solving event:
 
@@ -71,3 +78,11 @@ The hook integration means ReasoningBank is an opt-in layer on top of the existi
   - Relevance matching is hard to get right. FTS5 keyword matching over problem descriptors is fast but brittle — a slightly different phrasing for the same class of problem may not match. Semantic search over sqlite-vec embeddings covers this, but similarity thresholds require calibration. Injecting an irrelevant reasoning record is worse than injecting nothing, because it consumes tokens and may steer the agent in the wrong direction.
   - Extraction quality depends on the `post-agent` hook. The hook must produce a normalized, useful problem descriptor from what can be noisy agent output. Poor extraction produces low-signal records that pass confidence thresholds but don't help future agents. This is a quality problem that will surface only during real usage.
   - The `pre-agent` and `post-agent` hooks are Phase 2/3 in ADR-024's timeline. ReasoningBank's full integration cannot ship until those hook types are available. The storage layer and schema can be built in MVP; the live injection pipeline is a v2 deliverable.
+
+### Addendum — Delivery Staging Clarification (2026-03-28)
+
+This ADR is **not** being reversed. Instead, its delivery order is clarified:
+
+- **Do early:** preserve ReasoningBank in architecture, schema planning, and memory-roadmap decisions.
+- **Do after core runtime:** live retrieval/injection, confidence-driven reuse, and hook-powered learning loops.
+- **Do not let it delay:** the first believable prototype centered on controlled execution, streaming visibility, semantic navigation, and checkpoint/resume.

--- a/docs/adr/adr-046-swarm-coordination.md
+++ b/docs/adr/adr-046-swarm-coordination.md
@@ -4,7 +4,7 @@
 |-------------|---------------------------------------------------------------------------------|
 | Status      | Accepted                                                                        |
 | Date        | 2026-03-23                                                                      |
-| Scope       | MVP                                                                             |
+| Scope       | MVP architecture, later delivery                                                |
 | References  | ADR-002 (dispatcher), ADR-003 (nesting), ADR-039 (async subagent), Survey Decision A2 |
 
 ### Context
@@ -26,6 +26,12 @@ Swarm coordination in DiriCode is not a replacement for any of these frameworks.
 ### Decision
 
 **The dispatcher can create a swarm: a group of N parallel agent sessions working on related subtasks of the same top-level task.**
+
+**Prototype-first sequencing (clarification, 2026-03-28):**
+
+- Swarm coordination remains an accepted architectural capability.
+- MVP-1 delivery is **sequential-first**. Swarms are not the default execution mode for the first believable prototype.
+- The dispatcher and planning model must stay compatible with later swarm activation, but the initial milestone optimizes for control, observability, and checkpointability over throughput.
 
 Swarms are created by the dispatcher when it determines that a task has parallel structure — multiple independent areas of work that can proceed simultaneously without requiring each other's output. The dispatcher acts as the swarm coordinator throughout execution.
 
@@ -142,6 +148,14 @@ These patterns introduce coordination complexity that is not justified by DiriCo
   - Debugging a failed swarm is harder than debugging a single agent chain. A problem in member B may only manifest in member C's output.
   - The question queue requires the dispatcher to track which questions came from which agent and route answers correctly. Incorrect routing (sending an answer to the wrong agent) produces silent errors.
   - SQLite write coordination: context bus and question queue records must be written safely from parallel processes. Row-level SQLite locking is sufficient for the access pattern described (infrequent writes, many reads), but requires attention in the implementation.
+
+### Addendum — Delivery Priority Clarification (2026-03-28)
+
+Swarm coordination is retained as the target model for tasks with true parallel structure, but current sequencing is clarified:
+
+- **First:** stable sequential runtime and explicit checkpoint/resume.
+- **Then:** bounded wave execution for clearly independent work.
+- **Later:** richer swarm coordination features such as broader async question batching and merge/reconciliation workflows.
 
 - **Migration notes:**
   - No migration required for existing single-agent tasks. Swarm creation is explicit — the dispatcher must choose to create a swarm.

--- a/docs/mvp/epic-agents-core.md
+++ b/docs/mvp/epic-agents-core.md
@@ -2,7 +2,7 @@
 
 > **Package**: `@diricode/core`  
 > **Iteration**: POC → MVP-1  
-> **Issue IDs**: DC-CORE-005 — DC-CORE-012  
+> **Issue IDs**: DC-CORE-005 — DC-CORE-016  
 > **Dependencies**: DC-CORE-001..004 (config), DC-SRV-001..004 (EventStream transport), DC-PROV-001..007 (model routing)
 
 ## Summary
@@ -14,6 +14,9 @@ Key constraints baked into this epic:
 - **ARCH-004**: Plandex roles map to first-class DiriCode agents (agentized responsibilities, no hidden role-switch magic).
 - **POC constraint**: no skills system dependency in routing/execution; agents are hardcoded in TypeScript first.
 - Tier controls cost/quality policy from day 1 (HEAVY/MEDIUM/LOW).
+- Dispatcher remains **read-only**.
+- Tool access is **explicitly allowlisted per agent**.
+- Sequential-first orchestration is the default early runtime shape; richer async/wave behavior is layered on later.
 
 ---
 
@@ -82,6 +85,7 @@ Build central coordinator runtime behavior:
 - POC routing is intentionally hardcoded (example baseline: code task -> `code-writer`, question/summarize -> `summarizer`).
 - Emits delegation and completion events to EventStream.
 - Keeps architecture open for MVP-1 LLM-based router without breaking interfaces.
+- Must not perform direct code/file mutation itself.
 
 POC must not depend on skills loading; static TS mappings only.
 
@@ -193,7 +197,8 @@ Prompt builder must produce inspectable artifacts for debugging/observability.
 Build delegation runtime over protocol/sandbox:
 - Dispatcher delegates to specialist agents.
 - Enforce delegation depth limit to prevent infinite chains.
-- Support parallel delegation where tasks are independent.
+- MVP-1 default: sequential delegation and result aggregation.
+- Later extension: support parallel/wave delegation where tasks are independent.
 - Emit complete delegation telemetry to EventStream.
 
 POC: deterministic delegation graph from hardcoded dispatcher logic.  
@@ -201,7 +206,8 @@ MVP-1: same APIs power LLM-assisted routing without redesign.
 
 ### Acceptance Criteria
 - [ ] Delegation depth guard is enforced and configurable.
-- [ ] Parallel child execution supported with join/aggregation semantics.
+- [ ] Sequential delegation path is deterministic and stable.
+- [ ] Parallel child execution remains an explicit extension point rather than a hidden default.
 - [ ] Parent receives normalized child results in stable order.
 - [ ] Delegation events cover start/success/failure/cancel.
 - [ ] System continues when one branch fails (unless policy says fail-fast).
@@ -263,7 +269,20 @@ This mapping is policy, not hardcoded constants, and must integrate with router 
 
 ---
 
-## New Tasks (Post-ADR Review)
+## Additional Tasks (Prototype-first follow-ups)
 
-- [ ] Implement async subagent pattern: start_job/check_status/get_result tools for HEAVY tier agents (ADR-039)
-- [ ] Implement tool-based agent discovery: list_agents(category?) and search_agents(query) tools replacing hardcoded dispatcher list (ADR-040)
+### DC-CORE-013 — Per-agent tool allowlists
+
+Bound each agent to an explicit tool policy enforced at prompt-build and runtime execution layers.
+
+### DC-CORE-014 — Async subagent spawning and background delegation
+
+Introduce bounded non-blocking child work after the stable sequential baseline, preserving parent/child traceability and tool/context boundaries.
+
+### DC-CORE-015 — Read-only dispatcher boundary enforcement
+
+Codify and test the dispatcher’s boundary so it cannot silently become a specialist executor.
+
+### DC-CORE-016 — Delegation handoff filtering and context boundaries
+
+Filter parent→child handoffs so delegated agents receive structured, bounded context rather than raw parent state.

--- a/docs/mvp/epic-context.md
+++ b/docs/mvp/epic-context.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-This epic implements DiriCode’s 3-layer context architecture from `analiza-context-management.md` and ADR-016/017/018/019/020, optimized for narrow provider windows (especially Copilot <200k). The design prioritizes **inherited context** (ARCH-005), deterministic budgeting, and incremental indexing so agents receive maximal task-relevant signal with minimal token waste.
+This epic implements DiriCode’s 3-layer context architecture from `analiza-context-management.md` and ADR-016/017/018/019/020, optimized for narrow provider windows (especially Copilot <200k). The prototype-first clarification is important: **context quality still matters, but full context-budget sophistication is not allowed to delay the first believable runtime**.
 
 The architecture is delivered in three layers:
 1. **Layer 1 — Structural Index**: tree-sitter + SQLite + PageRank-backed repository map primitives.
@@ -14,8 +14,8 @@ The architecture is delivered in three layers:
 3. **Layer 3 — Context Composer**: adaptive token allocation + binary-search fitting for final prompt assembly.
 
 MVP progression:
-- **MVP-1**: index + ranking + repo map
-- **MVP-2**: condenser pipeline and conversation compaction
+- **MVP-1**: index + ranking + repo map + basic active signal
+- **MVP-2**: condenser pipeline, lightweight directory guidance, and conversation compaction
 - **MVP-3**: production-grade composer with adaptive budget fitting, active-file priority, symbol FTS lookup
 
 ## Architecture Baseline (from primary analysis)
@@ -52,7 +52,7 @@ MVP progression:
 - `conversation`: 20–35%
 - `reserved`: 15%
 
-This adaptive split is mandatory to support both “active editing” and “exploration/no-active-file” states from the same architecture.
+This adaptive split remains the target architecture, but the full system is intentionally staged later than the first prototype runtime.
 
 ## Issues
 
@@ -136,6 +136,18 @@ This adaptive split is mandatory to support both “active editing” and “exp
 **References**
 - `analiza-context-management.md` (repo map + budgeting)
 - ADR-016/018
+
+---
+
+### Bridge feature — lightweight directory guidance (`AGENTS.md`)
+
+Before the full context composer and advanced rules-injection stack mature, DiriCode can support lightweight directory-level guidance files (`AGENTS.md`) as an additive context signal.
+
+This is intentionally a **bridge feature**, not a replacement for the 3-layer architecture:
+
+- useful for package/module conventions,
+- low cost to adopt,
+- should not dominate early context scope.
 
 ---
 
@@ -315,7 +327,7 @@ This adaptive split is mandatory to support both “active editing” and “exp
 - DC-CTX-001, DC-CTX-002, DC-CTX-003
 
 ### MVP-2
-- DC-CTX-004, DC-CTX-005, DC-CTX-006
+- DC-CTX-004, DC-CTX-005, DC-CTX-006 + lightweight `AGENTS.md` bridge support
 
 ### MVP-3
 - DC-CTX-007, DC-CTX-008, DC-CTX-009

--- a/docs/mvp/epic-memory.md
+++ b/docs/mvp/epic-memory.md
@@ -2,14 +2,14 @@
 
 > Package: `@diricode/memory`
 > Iteration: **MVP-1**
-> Issue IDs: **DC-MEM-001..DC-MEM-007**
+> Issue IDs: **DC-MEM-001..DC-MEM-009**
 > Sync adapters (GitHub, GitLab, Jira) are optional output targets planned for v2+ — not part of MVP.
 
 ## Summary
 
 This epic delivers durable, queryable project memory for DiriCode MVP-1 using SQLite (project-local `.dc/memory.db`) with timeline-first storage, FTS5 search, token/cost telemetry, and multi-project isolation. It operationalizes ADR-048 (SQLite Issue System), ADR-018 (FTS/indexing), and cross-cutting boundaries: no direct DB access outside `@diricode/memory`, local-first issue management with optional sync adapters for external visibility.
 
-Memory is designed as the state spine for pipeline checkpoints, observability, and issue-driven planning. MVP-1 prioritizes deterministic schema evolution (migrations), low-latency retrieval, and strict project separation, while explicitly tracking technical risk around Bun + SQLite FTS5 with a mandatory POC spike.
+Memory is the state spine for **checkpoint/resume**, observability, and issue-driven planning. MVP-1 prioritizes deterministic schema evolution (migrations), low-latency retrieval, and strict project separation, while explicitly tracking technical risk around Bun + SQLite FTS5 with a mandatory POC spike.
 
 ## Issue: DC-MEM-001 — SQLite database setup with migrations
 
@@ -333,3 +333,15 @@ Ensure strict per-project memory isolation with optional global cross-project me
 4. DC-MEM-005 (usage telemetry)
 5. DC-MEM-007 (isolation/global routing)
 6. DC-MEM-006 (Local issue system client)
+
+---
+
+## v2 follow-up tasks already anchored from the pattern review
+
+### DC-MEM-008 — ReasoningBank retrieval and write path
+
+Add the first delivery task for ReasoningBank as a runtime capability with storage/retrieval boundaries, without requiring full live prompt injection yet.
+
+### DC-MEM-009 — Cross-session memory querying
+
+Enable querying prior session/task memory across sessions within the same project without flooding current active context.

--- a/docs/mvp/epic-observability.md
+++ b/docs/mvp/epic-observability.md
@@ -1,8 +1,8 @@
 # Epic: EventStream Observability Backbone and MVP UI Transparency
 
 > **Packages**: `@diricode/core` + `@diricode/web`
-> **Iteration**: MVP-2 (data collection) → MVP-3 (UI components)
-> **Issue IDs**: DC-OBS-001 — DC-OBS-006
+> **Iteration**: MVP-1 (data layer) → MVP-3 (UI components)
+> **Issue IDs**: DC-OBS-001 — DC-OBS-009
 > **Dependencies**: DC-SRV SSE transport, DC-MEM SQLite persistence, DC-CORE agent lifecycle
 
 ## Summary
@@ -12,6 +12,8 @@ This epic delivers observability as a first-class system capability:
 3) low-latency metrics aggregation,
 4) real-time Web UI transparency components.
 
+Prototype-first sequencing clarifies that **the event/data layer lands before the full UI surface**. Early delivery must make runtime progress, tool activity, failures, and checkpoints visible even before every planned UI component is polished.
+
 Primary references:
 - `analiza-observability.md` (EventStream + 6 component model)
 - `analiza-lean-mode.md` (Verbose mode integration)
@@ -19,7 +21,7 @@ Primary references:
 
 ---
 
-## Issue: DC-OBS-001 — EventStream core implementation (MVP-2)
+## Issue: DC-OBS-001 — EventStream core implementation (MVP-1)
 
 ### Description
 Implement typed EventStream event bus with subscribe/publish APIs and SQLite persistence.
@@ -50,7 +52,7 @@ Canonical schema fields:
 
 ---
 
-## Issue: DC-OBS-002 — Event emission integration (MVP-2)
+## Issue: DC-OBS-002 — Event emission integration (MVP-1)
 
 ### Description
 Integrate consistent event emission across core systems:
@@ -78,7 +80,7 @@ Enforce hierarchy linking (`turn -> agent -> tool/delegate/llm`) via `parent_id`
 
 ---
 
-## Issue: DC-OBS-003 — Metrics aggregation engine (MVP-2)
+## Issue: DC-OBS-003 — Metrics aggregation engine (MVP-1 / MVP-2)
 
 ### Description
 Implement real-time aggregation for session/turn KPIs:
@@ -212,6 +214,18 @@ Provide the event mapping and layout logic for the AI Cockpit visualizer:
 
 ### Dependencies
 - Depends on: DC-OBS-001, DC-OBS-002, DC-WEB-008
+
+---
+
+## Additional prototype-first and v2 observability tasks
+
+### DC-OBS-008 — Streaming tool calls and partial execution updates (MVP-1)
+
+Stream tool invocation start/progress/end/error updates so long-running operations are visible before final completion.
+
+### DC-OBS-009 — Event coordination and execution correlation model (MVP-1)
+
+Define the correlation model tying turns, tasks, agents, tools, checkpoints, and recovery transitions into one coherent execution graph.
 
 ---
 

--- a/docs/mvp/epic-pipeline.md
+++ b/docs/mvp/epic-pipeline.md
@@ -2,17 +2,17 @@
 
 > Package: `@diricode/core`
 > Iteration: **MVP-1 (basic) → MVP-2 (full)**
-> Issue IDs: **DC-PIPE-001..DC-PIPE-008**
+> Issue IDs: **DC-PIPE-001..DC-PIPE-009**
 
 ## Summary
 
-This epic implements DiriCode's execution pipeline from basic turn orchestration (MVP-1) to the complete 4-phase workflow with guardrails (MVP-2). It formalizes how user intent becomes executable tasks, how results are checkpointed into memory, and how the system enforces anti-drift and context safety constraints.
+This epic implements DiriCode's execution pipeline from the first believable runtime path (MVP-1) to the complete 4-phase workflow with guardrails (MVP-2). The immediate goal is a **sequential-first, checkpointable, observable** execution model that proves the runtime can accept a prompt, route it safely, execute specialist/tool work, stream progress, and resume from a checkpoint.
 
-The pipeline must preserve dispatcher-first architecture, explicit phase transitions, and user authority for high-risk deviations. It aligns with ADR-013 (Interview→Plan→Execute→Verify), ADR-003 (delegation/loop safety), and cross-cutting requirements for typed events, deterministic state transitions, and observability integration.
+The pipeline must preserve dispatcher-first architecture, explicit phase transitions, and user authority for high-risk deviations. It aligns with ADR-013 (Interview→Plan→Execute→Verify), ADR-003 (delegation/loop safety), and cross-cutting requirements for typed events, deterministic state transitions, checkpoint persistence, and observability integration.
 
 ---
 
-## MVP-1 Issues (basic pipeline)
+## MVP-1 Issues (prototype-first pipeline)
 
 ## Issue: DC-PIPE-001 — Turn lifecycle
 
@@ -58,22 +58,22 @@ Create a robust turn execution lifecycle with traceable IDs, timeout safety, and
 
 ### Goal
 
-Implement initial routing logic between simple direct execution and planned execution.
+Implement the first execution-path router: heuristic intent/complexity analysis that chooses between direct specialist execution and the heavier planning path.
 
 ### Scope
 
-- Step 1: dispatcher analyzes user request complexity
-- Step 2: if simple → route directly to code-writer path
+- Step 1: dispatcher analyzes user request complexity / intent
+- Step 2: if simple → route directly to specialist execution path
 - Step 3: if complex → delegate to planner, then execute produced plan
 - Configurable complexity threshold:
-  - heuristics and/or scoring rules
+  - heuristic rules in MVP-1
   - override via config for tuning
 - Ensure deterministic route decision logged in turn metadata
 
 ### Acceptance criteria
 
-- [ ] Dispatcher performs complexity classification for each turn.
-- [ ] Simple requests bypass planner and execute directly.
+- [ ] Dispatcher performs deterministic heuristic classification for each turn.
+- [ ] Simple requests bypass planner and execute directly through specialist/tool path.
 - [ ] Complex requests go through planner before execution.
 - [ ] Decision boundary is configurable and test-covered.
 - [ ] Decision reason is observable in turn timeline metadata.
@@ -89,13 +89,15 @@ Implement initial routing logic between simple direct execution and planned exec
 
 ### Goal
 
-Provide reliable MVP-1 task runner with one-task-at-a-time semantics and checkpoints.
+Provide reliable MVP-1 task runner with one-task-at-a-time semantics, explicit checkpoints, and forward compatibility for later wave-based execution.
 
 ### Scope
 
 - Sequential executor:
   - execute planned tasks strictly one at a time
   - for each task: invoke agent → collect result → validate success → continue/abort
+- Compatibility requirement:
+  - task model and checkpoints must remain usable when wave execution is introduced later
 - Failure behavior:
   - abort-on-failure default
   - explicit failure reason and last successful checkpoint
@@ -115,6 +117,35 @@ Provide reliable MVP-1 task runner with one-task-at-a-time semantics and checkpo
 
 - `spec-mvp-diricode.md` (checkpoint protocols, atomic execution mindset)
 - `analiza-context-management.md` (timeline/checkpoint persistence rationale)
+
+---
+
+## Issue: DC-PIPE-009 — Tool loop error classification and recovery policy
+
+### Goal
+
+Define how tool-loop failures are classified, surfaced, and handled so the runtime can recover predictably from non-fatal errors while still stopping on genuinely blocking failures.
+
+### Scope
+
+- classify tool errors into recoverable / retryable / blocking / user-decision-needed
+- define retry vs stop vs escalate behavior per class
+- preserve typed error records in turn/task state
+- emit error and recovery events into EventStream
+- keep policy compatible with later deviation rules and wave execution
+
+### Acceptance criteria
+
+- [ ] Tool failures are categorized with deterministic policy outcomes.
+- [ ] Recoverable failures can continue without corrupting task state.
+- [ ] Blocking failures stop downstream work by default.
+- [ ] User-decision-needed failures are surfaced explicitly.
+- [ ] Error classification and recovery actions are observable in runtime events.
+
+### References
+
+- `docs/adr/adr-013-project-pipeline.md`
+- `docs/adr/adr-031-observability-eventstream-agent-tree.md`
 
 ---
 
@@ -161,7 +192,7 @@ Implement full 4-phase pipeline with explicit phase state machine and phase-spec
 
 ### Goal
 
-Upgrade executor from sequential to dependency-aware wave scheduling.
+Upgrade the already-stable sequential executor to dependency-aware wave scheduling for clearly independent work.
 
 ### Scope
 
@@ -227,7 +258,7 @@ Prevent endless analysis loops without implementation progress.
 
 ### Goal
 
-Enforce context-window safety limits across agents within each turn.
+Enforce context-window safety limits across agents within each turn after the first prototype runtime path is already working.
 
 ### Scope
 
@@ -322,3 +353,6 @@ Additional integration:
 
 - MVP-1: DC-PIPE-001 → 002 → 003
 - MVP-2: DC-PIPE-004 → 006 → 007 → 005 → 008
+
+Prototype-first reinforcement tasks:
+- MVP-1 hardening: DC-PIPE-009

--- a/docs/mvp/epic-router.md
+++ b/docs/mvp/epic-router.md
@@ -311,3 +311,11 @@ Implement Kimi adapter (priority 2) as fallback-capable Provider:
 
 POC exit requires baseline Copilot path operational with registry abstraction.
 MVP-1 exit requires full retry/fallback/error/stream behavior with Copilot→Kimi failover.
+
+---
+
+## v2 follow-up routing task
+
+### DC-ROUT-001 — Load-aware model routing and cooldown policy
+
+After the baseline router is stable, add health-aware routing inputs such as recent failures, cooldown windows, and basic load-aware selection without jumping straight to full adaptive orchestration.

--- a/docs/mvp/epic-tools.md
+++ b/docs/mvp/epic-tools.md
@@ -6,9 +6,9 @@
 > **Dependencies**: DC-SAFE-001..005, DC-SRV-001, DC-CORE-001
 
 ## Summary
-This epic delivers the shared tool layer for agent execution, starting from minimal POC filesystem/shell primitives, then adding MVP-1 developer integrations (Git, LSP), and finally MVP-2 smart code tooling (tree-sitter, AST-grep rewrite, hashline, web fetch). All tools implement one contract (`name`, `description`, `parameters` schema, `execute`) and emit `tool.start`/`tool.end` events.
+This epic delivers the shared tool layer for agent execution, starting from minimal POC filesystem/shell primitives, then adding MVP-1 developer integrations (Git, LSP, AST-aware search/refactor foundations), and finally MVP-2+ deeper tooling hardening. All tools implement one contract (`name`, `description`, `parameters` schema, `execute`) and emit `tool.start`/`tool.end` events.
 
-Primary source for scope and priorities: `analiza-narzedzi-ekosystem.md`. Tree-sitter/indexing constraints: `analiza-context-management.md`. Metis guidance is enforced: smart tools are MVP-2, not POC.
+Primary source for scope and priorities: `analiza-narzedzi-ekosystem.md`. Tree-sitter/indexing constraints: `analiza-context-management.md`. Prototype-first sequencing changes one important point: **semantic navigation and structural tooling move earlier**, because they materially raise coding quality in the first believable runtime.
 
 ## Global Requirements
 - Zod validation at tool boundary.
@@ -160,7 +160,7 @@ Provide constrained git CLI wrappers for core workflows, inheriting ADR-027 safe
 
 ### DC-TOOL-008: LSP client tools
 **Iteration**: MVP-1  
-**Priority**: P1
+**Priority**: P0
 
 **Description**:
 Implement goto-definition, find-references, and rename-symbol tools with capability checks and clear fallback diagnostics.
@@ -199,11 +199,11 @@ Add tree-sitter AST parsing and symbol extraction APIs with Bun-compatibility ri
 ---
 
 ### DC-TOOL-010: AST-grep search/replace
-**Iteration**: MVP-2  
-**Priority**: P1
+**Iteration**: MVP-1 → MVP-2  
+**Priority**: P0
 
 **Description**:
-Deliver structural code search and rewrite using AST patterns; dry-run first, explicit apply mode.
+Deliver structural code search and rewrite using AST patterns. MVP-1 focuses on structural search and safe dry-run workflows; MVP-2 hardens broader apply/rewrite behavior.
 
 **Acceptance Criteria**:
 - [ ] Structural search by pattern.
@@ -257,7 +257,7 @@ Implement URL fetch with timeout and markdown conversion for external context in
 **Dependencies**: DC-SAFE-004, DC-CORE-001
 
 ## Must NOT
-- Do **not** move smart code tooling into POC; keep it in MVP-2.
+- Do **not** move smart code tooling into POC; keep it after the safe runtime baseline.
 - Do **not** bypass DC-SAFE wrappers on mutating/system tools.
 - Do **not** include v2 scope (annotation approval UI, embeddings, advanced context hooks).
 - Do **not** leak secrets in tool payloads/logs.

--- a/docs/mvp/index.md
+++ b/docs/mvp/index.md
@@ -1,6 +1,6 @@
 # MVP — Parent Epic
 
-> Theme: Core engine + Web UI
+> Theme: Prototype-first runtime
 > Iterations: POC → MVP-1 → MVP-2 → MVP-3
 > PROCESS-001: Wheel → Scooter → Bicycle → Car
 
@@ -9,7 +9,7 @@
 ## Iteration Summary
 
 ### POC — "Wheel" (Week 1-2)
-**Goal**: Prove the architecture works end-to-end. Validate all technical risks.
+**Goal**: Prove the core runtime path works end-to-end with safe tools and a read-only dispatcher.
 
 Epics active:
 - [epic-monorepo-setup.md](epic-monorepo-setup.md) — Project scaffolding
@@ -23,44 +23,45 @@ Epics active:
 - [epic-cli.md](epic-cli.md) — Basic CLI entrypoint
 - [epic-testing-infra.md](epic-testing-infra.md) — Vitest setup + mock providers
 
-**Exit**: User types prompt in CLI → dispatcher delegates to code-writer → file created on disk via Copilot.
+**Exit**: User types prompt in CLI → dispatcher delegates to specialist → tools run safely → result returns with basic event visibility.
 
 ---
 
 ### MVP-1 — "Scooter" (Week 3-4)
-**Goal**: Real task execution with planning, review, and persistent memory.
+**Goal**: Ship the first believable runtime: sequential-first execution, explicit checkpoints, evented visibility, and memory-backed continuity.
 
 Epics active:
 - [epic-memory.md](epic-memory.md) — SQLite + FTS5 + timeline + local issue system
-- [epic-pipeline.md](epic-pipeline.md) — Basic pipeline (Plan→Execute only)
-- [epic-context.md](epic-context.md) — Layer 1: basic context window management
+- [epic-pipeline.md](epic-pipeline.md) — Turn lifecycle + dispatcher→specialist→tools path + sequential checkpoints
+- [epic-context.md](epic-context.md) — Structural context signal, not full context autopilot
 - [epic-agents-roster.md](epic-agents-roster.md) — +6 agents (planners, reviewers, verifier)
 - [epic-safety.md](epic-safety.md) — Git safety rails (full)
 - [epic-cli.md](epic-cli.md) — Session management, profile support
-- [epic-tools.md](epic-tools.md) — Git tools + AST-grep
+- [epic-tools.md](epic-tools.md) — Git tools + LSP + AST-aware structural tooling
+- [epic-observability.md](epic-observability.md) — Event/data layer for live execution transparency
 
-**Exit**: "Add a login page" → planner creates plan → code-writer implements → code-reviewer reviews → atomic commit made. Memory persists.
+**Exit**: Prompt enters system → dispatcher selects execution path → specialist uses tools → streamed progress is visible → checkpoint saved → session can resume from last valid state.
 
 ---
 
 ### MVP-2 — "Bicycle" (Week 5-6)
-**Goal**: Reliable, smart execution with hooks, guardrails, and skills.
+**Goal**: Expand reliability and autonomy without breaking the controlled MVP-1 runtime.
 
 Epics active:
 - [epic-hooks.md](epic-hooks.md) — Hook framework + 6 MVP hooks
 - [epic-pipeline.md](epic-pipeline.md) — Full pipeline (Interview→Plan→Execute→Verify)
-- [epic-context.md](epic-context.md) — Layer 2: condenser pipeline + context budget
+- [epic-context.md](epic-context.md) — Deeper compression/budget features after first runtime path works
 - [epic-skills.md](epic-skills.md) — SKILL.md parser + loader + shadowing
-- [epic-observability.md](epic-observability.md) — EventStream + basic agent tree (data layer)
-- [epic-tools.md](epic-tools.md) — Smart code tools + MCP basics + tool annotations
+- [epic-observability.md](epic-observability.md) — richer observability on top of stable event layer
+- [epic-tools.md](epic-tools.md) — additional smart tooling, MCP basics, tool annotations
 - [epic-agents-roster.md](epic-agents-roster.md) — +4 agents (git-operator, debugger, test-writer, project-builder)
 
-**Exit**: Full pipeline Interview→Plan→Execute→Verify works. Hooks fire. Guardrails catch paralysis. Context stays under 50%. Skills loaded.
+**Exit**: Full Interview→Plan→Execute→Verify path works on top of the already-trustworthy runtime substrate.
 
 ---
 
 ### MVP-3 — "Car" (Week 7-8)
-**Goal**: Complete MVP with Web UI, full observability, and all MVP agents.
+**Goal**: Complete MVP with richer Web UI, broader observability surfaces, and the wider MVP agent set.
 
 Epics active:
 - [epic-web-ui.md](epic-web-ui.md) — Vite + React + shadcn/ui
@@ -69,7 +70,7 @@ Epics active:
 - [epic-agents-roster.md](epic-agents-roster.md) — Remaining MVP agents (prompt-validator, plan-reviewer, specialists, etc.)
 - [epic-skills.md](epic-skills.md) — Skill-embedded MCP + references/ subfolder
 
-**Exit**: User opens Web UI → sees agent tree → watches pipeline execute → inspects costs. All 25+ MVP agents operational.
+**Exit**: User opens Web UI → sees live execution state derived from stable EventStream data → inspects activity/costs/history with confidence.
 
 ---
 
@@ -78,7 +79,7 @@ Epics active:
 - No TUI (v2)
 - No annotation-driven approval flow (v2)
 - No embeddings / vector search (v2)
-- No context monitoring hooks (v2)
+- No full context-monitor/autocompaction stack in the first believable runtime slice
 - No skill marketplace / catalog (v2)
 - No sandbox / Docker isolation (v3)
 - No auto-advance / full-auto mode (v3)
@@ -98,16 +99,29 @@ Epics active:
 | [config](epic-config.md) | @diricode/core | POC | DC-CORE-001..004 |
 | [router](epic-router.md) | @diricode/providers | POC | DC-PROV-001..007 |
 | [server](epic-server.md) | @diricode/server | POC | DC-SRV-001..004 |
-| [tools](epic-tools.md) | @diricode/tools | POC→MVP-2 | DC-TOOL-001..012 |
-| [memory](epic-memory.md) | @diricode/memory | MVP-1 | DC-MEM-001..007 |
-| [agents-core](epic-agents-core.md) | @diricode/core | POC→MVP-1 | DC-CORE-005..012 |
+| [tools](epic-tools.md) | @diricode/tools | POC→MVP-2 | DC-TOOL-001..012 + #45 |
+| [memory](epic-memory.md) | @diricode/memory | MVP-1 | DC-MEM-001..009 |
+| [agents-core](epic-agents-core.md) | @diricode/core | POC→MVP-1 | DC-CORE-005..016 |
 | [agents-roster](epic-agents-roster.md) | @diricode/core | POC→MVP-3 | DC-AGENT-001..025 |
 | [hooks](epic-hooks.md) | @diricode/core | MVP-2 | DC-HOOK-001..005 |
-| [pipeline](epic-pipeline.md) | @diricode/core | MVP-1→MVP-2 | DC-PIPE-001..008 |
+| [pipeline](epic-pipeline.md) | @diricode/core | MVP-1→MVP-2 | DC-PIPE-001..009 |
 | [context](epic-context.md) | @diricode/core | MVP-1→MVP-3 | DC-CTX-001..009 |
 | [safety](epic-safety.md) | @diricode/tools | POC→MVP-1 | DC-SAFE-001..005 |
 | [skills](epic-skills.md) | @diricode/core | MVP-2→MVP-3 | DC-SKILL-001..006 |
-| [observability](epic-observability.md) | @diricode/core, web | MVP-2→MVP-3 | DC-OBS-001..006 |
+| [observability](epic-observability.md) | @diricode/core, web | MVP-1→MVP-3 | DC-OBS-001..009 |
 | [web-ui](epic-web-ui.md) | @diricode/web | MVP-3 | DC-WEB-001..007 |
 | [cli](epic-cli.md) | apps/cli | POC→MVP-1 | DC-CLI-001..004 |
 | [testing-infra](epic-testing-infra.md) | root, test-utils | POC | DC-TEST-001..004 |
+
+---
+
+## Current prototype-first emphasis
+
+The current priority order across MVP work is:
+
+1. runtime loop and sequential execution
+2. checkpoint/resume
+3. evented visibility
+4. semantic navigation / structural tooling
+5. local-first runtime state
+6. later wave execution, richer hooks, deeper context automation, broader UI polish

--- a/docs/v2/epic-agents-v2.md
+++ b/docs/v2/epic-agents-v2.md
@@ -323,3 +323,13 @@ Source: `analiza-agent-roster.md` — agents mapped to v2 in overview.md agent�
 **References**
 - `analiza-agent-roster.md` Section 9.7 (github-operator spec)
 - Survey features 2.3, 2.4 (REQ-IDs in GitHub Issues/Epics)
+
+---
+
+## Additional v2 quality/orchestration tasks anchored outside the roster list
+
+- **DC-REVIEW-001** — Confidence-based review escalation
+- **DC-MEM-008** — ReasoningBank retrieval and write path
+- **DC-MEM-009** — Cross-session memory querying
+
+These are not new roster agents themselves, but they are key v2 capabilities that the roster and review flows depend on.

--- a/docs/v2/epic-context-v2.md
+++ b/docs/v2/epic-context-v2.md
@@ -2,7 +2,7 @@
 
 > Package: `@diricode/core`
 > Iteration: **v2.0**
-> Issue IDs: **DC-CTX-010..DC-CTX-016**
+> Issue IDs: **DC-CTX-010..DC-CTX-017**
 
 ## Summary
 
@@ -199,3 +199,27 @@ Survey references: 3.8 (token budget calculator), 6.1-6.6 (context monitoring su
 
 **References**
 - `analiza-context-management.md` Section 2.2 (Cline FileContextTracker with chokidar)
+
+---
+
+### DC-CTX-017 — Tool result spill and large-output offloading
+
+**Goal**: Offload oversized tool outputs into durable storage and replace them in active context with compact references.
+
+**Scope**
+- detect oversized tool outputs above configurable thresholds
+- persist payloads outside the active prompt path
+- use compact references/summaries in active context
+- support explicit rehydration when downstream agents need the full payload
+- emit spill/offload events and metrics
+
+**Acceptance criteria**
+- [ ] Oversized outputs are detected deterministically.
+- [ ] Large payloads are persisted with stable references.
+- [ ] Active context uses compact references instead of full payloads.
+- [ ] Rehydration path can recover original payload when needed.
+- [ ] Spill metrics are observable.
+
+**References**
+- Pattern 06 — Tool Result Auto-Spill
+- sample repo research: `example-repos/agentic-flow/agentic-flow/src/reasoningbank/AdvancedMemory.ts`

--- a/docs/v2/epic-hooks-v2.md
+++ b/docs/v2/epic-hooks-v2.md
@@ -2,7 +2,7 @@
 
 > Package: `@diricode/core`
 > Iteration: **v2.0**
-> Issue IDs: **DC-HOOK-006..DC-HOOK-012**
+> Issue IDs: **DC-HOOK-006..DC-HOOK-013**
 
 ## Summary
 
@@ -222,3 +222,24 @@ Source: `analiza-hookow.md` Section 4 — v2 roadmap.
 - `analiza-hookow.md` Section 3 (#13 loop-detection)
 - OMO: ralph-loop hook
 - MVP DC-CORE analysis paralysis guard (generalized here)
+
+---
+
+### DC-HOOK-013 — AI-slop guardrails and low-signal output detection
+
+**Goal**: Detect low-signal / low-quality agent output before it silently degrades code or planning quality.
+
+**Scope**
+- classify generic/repetitive/low-evidence outputs as warn / block / escalate
+- emit quality-warning events for observability
+- keep thresholds configurable to reduce false positives
+
+**Acceptance criteria**
+- [ ] First useful set of low-signal patterns is detected.
+- [ ] Quality warnings are observable.
+- [ ] Strictness is configurable.
+- [ ] False positives can be tuned down.
+
+**References**
+- Pattern 16 — AI Slop Guards
+- Langfuse evaluation/observability references

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -61,11 +61,11 @@ v2 transforms DiriCode from a functional MVP into a polished developer tool. Key
 |------|--------|---------------|-----------|
 | [epic-tui.md](epic-tui.md) | Ink TUI client | DC-TUI-001..DC-TUI-006 | v2.0 |
 | [epic-annotation-approval.md](epic-annotation-approval.md) | Annotation-driven approval | DC-APPR-001..DC-APPR-005 | v2.0 |
-| [epic-hooks-v2.md](epic-hooks-v2.md) | 7 new hook types | DC-HOOK-006..DC-HOOK-012 | v2.0 |
-| [epic-context-v2.md](epic-context-v2.md) | Context monitoring + token budget | DC-CTX-010..DC-CTX-016 | v2.0 |
+| [epic-hooks-v2.md](epic-hooks-v2.md) | 7 new hook types + quality guardrails | DC-HOOK-006..DC-HOOK-013 | v2.0 |
+| [epic-context-v2.md](epic-context-v2.md) | Context monitoring + token budget + output spill | DC-CTX-010..DC-CTX-017 | v2.0 |
 | [epic-agents-v2.md](epic-agents-v2.md) | 12 additional agents | DC-AGENT-026..DC-AGENT-037 | v2.0 |
 | [epic-marketplace.md](epic-marketplace.md) | Skill catalog + discovery | DC-MKT-001..DC-MKT-006 | v2.1 |
-| [epic-observability-v2.md](epic-observability-v2.md) | Detail Panel + Timeline + Approval UI | DC-OBS-007..DC-OBS-012 | v2.1 |
+| [epic-observability-v2.md](epic-observability-v2.md) | Detail Panel + Timeline + Approval UI | DC-OBS-010..DC-OBS-012 | v2.1 |
 | [epic-embeddings.md](epic-embeddings.md) | Semantic embeddings + vector search | DC-EMB-001..DC-EMB-005 | v2.1 |
 | [epic-config-v2.md](epic-config-v2.md) | Config substitution + GUI + presets | DC-CFG-005..DC-CFG-009 | v2.1 |
 


### PR DESCRIPTION
## Summary
- align README, MVP docs, ADR addenda, and v2 docs with the prototype-first roadmap
- sync canonical markdown issue ranges with the rewritten GitHub epics/tasks and new backlog issues
- keep `.sisyphus/drafts/` as working notes only while moving project truth into repo docs and GitHub