### PR TITLE
feat(providers): add error classifier for provider router (#29)

### DIFF
--- a/packages/providers/src/__tests__/error-classifier.test.ts
+++ b/packages/providers/src/__tests__/error-classifier.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from "vitest";
+import { type ClassifiedError, type ProviderErrorKind } from "../index.js";
+import { classifyError, deriveRetryable, parseRetryAfter } from "../index.js";
+
+describe("classifyError", () => {
+  describe("status code mapping", () => {
+    it("401 → auth_error", () => {
+      const err = { statusCode: 401, message: "Unauthorized" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("auth_error");
+    });
+
+    it("403 with no special message → auth_error", () => {
+      const err = { statusCode: 403, message: "Forbidden" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("auth_error");
+    });
+
+    it("403 with 'quota' message → quota_exhausted", () => {
+      const err = { statusCode: 403, message: "You have exceeded your quota" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("quota_exhausted");
+    });
+
+    it("404 → not_found", () => {
+      const err = { statusCode: 404, message: "Not Found" };
+      expect(classifyError(err, { provider: "gemini" }).kind).toBe("not_found");
+    });
+
+    it("413 → context_overflow", () => {
+      const err = { statusCode: 413, message: "Payload Too Large" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("context_overflow");
+    });
+
+    it("429 → rate_limited", () => {
+      const err = { statusCode: 429, message: "Too Many Requests" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("rate_limited");
+    });
+
+    it("500 → other", () => {
+      const err = { statusCode: 500, message: "Internal Server Error" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("other");
+    });
+
+    it("502 → other", () => {
+      const err = { statusCode: 502, message: "Bad Gateway" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("other");
+    });
+
+    it("503 → overloaded", () => {
+      const err = { statusCode: 503, message: "Service Unavailable" };
+      expect(classifyError(err, { provider: "gemini" }).kind).toBe("overloaded");
+    });
+
+    it("529 → overloaded", () => {
+      const err = { statusCode: 529, message: "Server Overloaded" };
+      expect(classifyError(err, { provider: "copilot" }).kind).toBe("overloaded");
+    });
+  });
+
+  describe("message pattern matching", () => {
+    function errWithMsg(message: string): Error {
+      return new Error(message);
+    }
+
+    it('"rate limit exceeded" → rate_limited', () => {
+      expect(classifyError(errWithMsg("Rate limit exceeded"), { provider: "gemini" }).kind).toBe(
+        "rate_limited",
+      );
+    });
+
+    it('"too many requests" → rate_limited', () => {
+      expect(classifyError(errWithMsg("Too many requests"), { provider: "copilot" }).kind).toBe(
+        "rate_limited",
+      );
+    });
+
+    it('"context length exceeded" → context_overflow', () => {
+      expect(
+        classifyError(errWithMsg("context length exceeded"), { provider: "copilot" }).kind,
+      ).toBe("context_overflow");
+    });
+
+    it('"maximum context length" → context_overflow', () => {
+      expect(
+        classifyError(errWithMsg("maximum context length is 4096"), { provider: "copilot" }).kind,
+      ).toBe("context_overflow");
+    });
+
+    it('"token limit exceeded" → context_overflow', () => {
+      expect(classifyError(errWithMsg("token limit exceeded"), { provider: "gemini" }).kind).toBe(
+        "context_overflow",
+      );
+    });
+
+    it('"service unavailable" → overloaded', () => {
+      expect(classifyError(errWithMsg("service unavailable"), { provider: "copilot" }).kind).toBe(
+        "overloaded",
+      );
+    });
+
+    it('"server is overloaded" → overloaded', () => {
+      expect(
+        classifyError(errWithMsg("The server is overloaded. Try again later."), {
+          provider: "gemini",
+        }).kind,
+      ).toBe("overloaded");
+    });
+
+    it('"quota exceeded" → quota_exhausted', () => {
+      expect(classifyError(errWithMsg("quota exceeded"), { provider: "gemini" }).kind).toBe(
+        "quota_exhausted",
+      );
+    });
+
+    it('"billing limit reached" → quota_exhausted', () => {
+      expect(classifyError(errWithMsg("billing limit reached"), { provider: "copilot" }).kind).toBe(
+        "quota_exhausted",
+      );
+    });
+
+    it('"invalid api key" → auth_error', () => {
+      expect(classifyError(errWithMsg("invalid api key"), { provider: "gemini" }).kind).toBe(
+        "auth_error",
+      );
+    });
+
+    it('"unauthorized access" → auth_error', () => {
+      expect(classifyError(errWithMsg("unauthorized access"), { provider: "copilot" }).kind).toBe(
+        "auth_error",
+      );
+    });
+
+    it('"model not found" → not_found', () => {
+      expect(classifyError(errWithMsg("model not found"), { provider: "copilot" }).kind).toBe(
+        "not_found",
+      );
+    });
+
+    it('"does not exist" → not_found', () => {
+      expect(
+        classifyError(errWithMsg("resource does not exist"), { provider: "gemini" }).kind,
+      ).toBe("not_found");
+    });
+
+    it("random unknown message → other", () => {
+      expect(
+        classifyError(errWithMsg("something completely unexpected"), { provider: "copilot" }).kind,
+      ).toBe("other");
+    });
+  });
+
+  describe("context propagation", () => {
+    it("provider name is preserved in output", () => {
+      const result = classifyError(new Error("oops"), { provider: "gemini" });
+      expect(result.provider).toBe("gemini");
+    });
+
+    it("model ID is preserved when provided", () => {
+      const result = classifyError(new Error("oops"), { provider: "copilot", model: "gpt-4o" });
+      expect(result.model).toBe("gpt-4o");
+    });
+
+    it("model defaults to empty string when not provided", () => {
+      const result = classifyError(new Error("oops"), { provider: "copilot" });
+      expect(result.model).toBe("");
+    });
+
+    it("raw error is retained as-is", () => {
+      const rawErr = new Error("raw error message");
+      const result = classifyError(rawErr, { provider: "copilot" });
+      expect(result.raw).toBe(rawErr);
+    });
+
+    it("raw error is retained for plain object errors", () => {
+      const rawObj = { statusCode: 429, message: "Too many requests" };
+      const result = classifyError(rawObj, { provider: "gemini" });
+      expect(result.raw).toBe(rawObj);
+    });
+  });
+
+  describe("retryable field", () => {
+    it("rate_limited is retryable", () => {
+      const result = classifyError({ statusCode: 429 }, { provider: "copilot" });
+      expect(result.retryable).toBe(true);
+    });
+
+    it("auth_error is not retryable", () => {
+      const result = classifyError({ statusCode: 401 }, { provider: "copilot" });
+      expect(result.retryable).toBe(false);
+    });
+  });
+});
+
+describe("parseRetryAfter", () => {
+  describe("header variants", () => {
+    it("Retry-After as number string '30' → 30000ms", () => {
+      const err = { headers: { "Retry-After": "30" } };
+      expect(parseRetryAfter(err)).toBe(30_000);
+    });
+
+    it("Retry-After with large value is clamped to 60000ms", () => {
+      const err = { headers: { "Retry-After": "300" } };
+      expect(parseRetryAfter(err)).toBe(60_000);
+    });
+
+    it("Retry-After as HTTP date → calculated ms (future date)", () => {
+      const futureDate = new Date(Date.now() + 30_000);
+      const err = { headers: { "Retry-After": futureDate.toUTCString() } };
+      const result = parseRetryAfter(err);
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThanOrEqual(60_000);
+    });
+
+    it("Retry-After as HTTP date in the past → 0", () => {
+      const pastDate = new Date(Date.now() - 10_000);
+      const err = { headers: { "Retry-After": pastDate.toUTCString() } };
+      expect(parseRetryAfter(err)).toBe(0);
+    });
+
+    it("X-RateLimit-Reset as Unix timestamp → calculated ms", () => {
+      const resetAt = Math.floor(Date.now() / 1000) + 30;
+      const err = { headers: { "X-RateLimit-Reset": String(resetAt) } };
+      const result = parseRetryAfter(err);
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThanOrEqual(60_000);
+    });
+
+    it("no retry info → 0", () => {
+      const err = new Error("Something went wrong");
+      expect(parseRetryAfter(err)).toBe(0);
+    });
+
+    it("null → 0", () => {
+      expect(parseRetryAfter(null)).toBe(0);
+    });
+
+    it("undefined → 0", () => {
+      expect(parseRetryAfter(undefined)).toBe(0);
+    });
+  });
+
+  describe("body field variants", () => {
+    it("retry_after_ms on body → direct value in ms", () => {
+      const err = { retry_after_ms: 5000 };
+      expect(parseRetryAfter(err)).toBe(5000);
+    });
+
+    it("retry_after_ms clamped to 60000ms", () => {
+      const err = { retry_after_ms: 120_000 };
+      expect(parseRetryAfter(err)).toBe(60_000);
+    });
+
+    it("retryAfterMs on body → direct value in ms", () => {
+      const err = { retryAfterMs: 10_000 };
+      expect(parseRetryAfter(err)).toBe(10_000);
+    });
+
+    it("retry_after as number (seconds) → converted to ms", () => {
+      const err = { retry_after: 10 };
+      expect(parseRetryAfter(err)).toBe(10_000);
+    });
+
+    it("retry_after as string seconds → converted to ms", () => {
+      const err = { retry_after: "15" };
+      expect(parseRetryAfter(err)).toBe(15_000);
+    });
+
+    it("nested body.retry_after_ms → direct value", () => {
+      const err = { body: { retry_after_ms: 8000 } };
+      expect(parseRetryAfter(err)).toBe(8000);
+    });
+
+    it("nested body.retryAfterMs → direct value", () => {
+      const err = { body: { retryAfterMs: 9000 } };
+      expect(parseRetryAfter(err)).toBe(9000);
+    });
+
+    it("nested body.retry_after as seconds → converted to ms", () => {
+      const err = { body: { retry_after: 20 } };
+      expect(parseRetryAfter(err)).toBe(20_000);
+    });
+  });
+});
+
+describe("deriveRetryable", () => {
+  const cases: [ProviderErrorKind, boolean][] = [
+    ["rate_limited", true],
+    ["overloaded", true],
+    ["other", true],
+    ["context_overflow", false],
+    ["quota_exhausted", false],
+    ["auth_error", false],
+    ["not_found", false],
+  ];
+
+  for (const [kind, expected] of cases) {
+    it(`${kind} → ${String(expected)}`, () => {
+      expect(deriveRetryable(kind)).toBe(expected);
+    });
+  }
+});
+
+describe("edge cases", () => {
+  it("null error → other, retryable true", () => {
+    const result = classifyError(null, { provider: "copilot" });
+    expect(result.kind).toBe("other");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("undefined error → other, retryable true", () => {
+    const result = classifyError(undefined, { provider: "copilot" });
+    expect(result.kind).toBe("other");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("Error with statusCode property → classified by status", () => {
+    const err = Object.assign(new Error("rate limited"), { statusCode: 429 });
+    const result = classifyError(err, { provider: "copilot" });
+    expect(result.kind).toBe("rate_limited");
+  });
+
+  it("Error with nested response.status → classified by status", () => {
+    const err = Object.assign(new Error("forbidden"), { response: { status: 401 } });
+    const result = classifyError(err, { provider: "gemini" });
+    expect(result.kind).toBe("auth_error");
+  });
+
+  it("plain object with status property → classified by status", () => {
+    const err = { status: 503, message: "" };
+    const result = classifyError(err, { provider: "copilot" });
+    expect(result.kind).toBe("overloaded");
+  });
+
+  it("non-Error object with message → classified by message", () => {
+    const err = { message: "API key is invalid" };
+    const result = classifyError(err, { provider: "gemini" });
+    expect(result.kind).toBe("auth_error");
+  });
+
+  it("ClassifiedError shape has all required fields", () => {
+    const result: ClassifiedError = classifyError(new Error("oops"), {
+      provider: "copilot",
+      model: "gpt-4o",
+    });
+    expect(result).toHaveProperty("kind");
+    expect(result).toHaveProperty("provider");
+    expect(result).toHaveProperty("model");
+    expect(result).toHaveProperty("retryable");
+    expect(result).toHaveProperty("retryAfterMs");
+    expect(result).toHaveProperty("raw");
+  });
+});

--- a/packages/providers/src/error-classifier.ts
+++ b/packages/providers/src/error-classifier.ts
@@ -1,0 +1,420 @@
+/**
+ * Error classifier for the DiriCode provider router.
+ *
+ * Converts raw provider/API/stream errors into a unified {@link ClassifiedError}
+ * shape consumed by the retry engine and fallback chain.
+ *
+ * Classification rules and retry policies defined in ADR-025.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The 7 normalized error kinds per ADR-025. */
+export type ProviderErrorKind =
+  | "rate_limited"
+  | "context_overflow"
+  | "overloaded"
+  | "quota_exhausted"
+  | "auth_error"
+  | "not_found"
+  | "other";
+
+/** Structured error output from the classifier. */
+export interface ClassifiedError {
+  /** One of the 7 normalized error kinds. */
+  readonly kind: ProviderErrorKind;
+  /** Provider name (e.g. "copilot", "gemini"). */
+  readonly provider: string;
+  /** Model ID if available. */
+  readonly model: string;
+  /** Whether the error is retryable per ADR-025 policy. */
+  readonly retryable: boolean;
+  /** Parsed retry-after delay in milliseconds, or 0 if absent. */
+  readonly retryAfterMs: number;
+  /** Original raw error for observability/debugging. */
+  readonly raw: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Main classifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a raw provider error into a normalized {@link ClassifiedError}.
+ *
+ * Checks are applied in priority order — first match wins.
+ * Supports Vercel AI SDK errors, Google Gemini SDK errors, and generic
+ * HTTP/fetch errors.
+ *
+ * @param error - The raw error value (any shape).
+ * @param context - Provider and optional model context for the request.
+ * @returns A normalized {@link ClassifiedError} with retry policy applied.
+ */
+export function classifyError(
+  error: unknown,
+  context: { provider: string; model?: string },
+): ClassifiedError {
+  const status = extractStatusCode(error);
+  const msgLower = getErrorMessageLower(error);
+
+  const kind = classifyKind(status, msgLower);
+
+  return {
+    kind,
+    provider: context.provider,
+    model: context.model ?? "",
+    retryable: deriveRetryable(kind),
+    retryAfterMs: parseRetryAfter(error),
+    raw: error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retry-after parser
+// ---------------------------------------------------------------------------
+
+/** Maximum allowed retry-after delay in milliseconds (1 minute). */
+const MAX_RETRY_AFTER_MS = 60_000;
+
+/**
+ * Extract retry delay in milliseconds from an error.
+ *
+ * Checks in order:
+ * 1. `Retry-After` header (seconds number or HTTP-date string)
+ * 2. `X-RateLimit-Reset` header (Unix timestamp in seconds)
+ * 3. Error body fields: `retry_after_ms`, `retry_after`, `retryAfterMs`
+ *
+ * @param error - The raw error to inspect.
+ * @returns Delay in milliseconds, clamped to 60 000 ms; 0 if not found.
+ */
+export function parseRetryAfter(error: unknown): number {
+  if (error === null || error === undefined) {
+    return 0;
+  }
+
+  // 1. Check headers object (standard Response / Vercel AI SDK shapes)
+  const headers = extractHeaders(error);
+  if (headers !== undefined) {
+    const retryAfter = getHeader(headers, "retry-after");
+    if (retryAfter !== undefined) {
+      const parsed = parseRetryAfterHeaderValue(retryAfter);
+      if (parsed > 0) {
+        return Math.min(parsed, MAX_RETRY_AFTER_MS);
+      }
+    }
+
+    const rateLimitReset = getHeader(headers, "x-ratelimit-reset");
+    if (rateLimitReset !== undefined) {
+      const resetUnix = Number(rateLimitReset);
+      if (!Number.isNaN(resetUnix) && resetUnix > 0) {
+        const nowSec = Date.now() / 1000;
+        const delayMs = Math.round((resetUnix - nowSec) * 1000);
+        if (delayMs > 0) {
+          return Math.min(delayMs, MAX_RETRY_AFTER_MS);
+        }
+      }
+    }
+  }
+
+  // 2. Check error body / direct fields
+  const obj = error as Record<string, unknown>;
+
+  if (typeof obj.retry_after_ms === "number" && obj.retry_after_ms > 0) {
+    return Math.min(obj.retry_after_ms, MAX_RETRY_AFTER_MS);
+  }
+
+  if (typeof obj.retryAfterMs === "number" && obj.retryAfterMs > 0) {
+    return Math.min(obj.retryAfterMs, MAX_RETRY_AFTER_MS);
+  }
+
+  if (typeof obj.retry_after === "number" && obj.retry_after > 0) {
+    return Math.min(obj.retry_after * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  if (typeof obj.retry_after === "string") {
+    const parsed = parseRetryAfterHeaderValue(obj.retry_after);
+    if (parsed > 0) {
+      return Math.min(parsed, MAX_RETRY_AFTER_MS);
+    }
+  }
+
+  // 3. Check nested body object
+  if (typeof obj.body === "object" && obj.body !== null) {
+    const body = obj.body as Record<string, unknown>;
+
+    if (typeof body.retry_after_ms === "number" && body.retry_after_ms > 0) {
+      return Math.min(body.retry_after_ms, MAX_RETRY_AFTER_MS);
+    }
+    if (typeof body.retryAfterMs === "number" && body.retryAfterMs > 0) {
+      return Math.min(body.retryAfterMs, MAX_RETRY_AFTER_MS);
+    }
+    if (typeof body.retry_after === "number" && body.retry_after > 0) {
+      return Math.min(body.retry_after * 1000, MAX_RETRY_AFTER_MS);
+    }
+  }
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Retryable deriver
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive whether an error kind is retryable per ADR-025 policy.
+ *
+ * - `rate_limited` → true (retry with backoff)
+ * - `overloaded`   → true (retry with backoff)
+ * - `other`        → true (retry once, then fail — count managed by retry engine)
+ * - `context_overflow` → false (needs fallback to larger-context model)
+ * - `quota_exhausted`  → false (needs fallback to different provider)
+ * - `auth_error`       → false (fail immediately)
+ * - `not_found`        → false (fail immediately)
+ *
+ * @param kind - The normalized error kind.
+ * @returns `true` if the request may be retried.
+ */
+export function deriveRetryable(kind: ProviderErrorKind): boolean {
+  switch (kind) {
+    case "rate_limited":
+    case "overloaded":
+    case "other":
+      return true;
+    case "context_overflow":
+    case "quota_exhausted":
+    case "auth_error":
+    case "not_found":
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify to a {@link ProviderErrorKind} from status code and lowercased message.
+ * Priority order matches ADR-025 classification rules.
+ */
+function classifyKind(status: number | undefined, msgLower: string): ProviderErrorKind {
+  // 1. rate_limited — HTTP 429, or rate-limit message patterns
+  if (
+    status === 429 ||
+    msgLower.includes("rate limit") ||
+    msgLower.includes("rate_limit") ||
+    msgLower.includes("too many requests")
+  ) {
+    return "rate_limited";
+  }
+
+  // 2. context_overflow — HTTP 413, or context/token patterns
+  if (
+    status === 413 ||
+    msgLower.includes('context') ||
+    /\btoken/.test(msgLower) ||
+    /maximum.*context/.test(msgLower) ||
+    /too.*large/.test(msgLower) ||
+    /exceeds.*token/.test(msgLower) ||
+    msgLower.includes('context_length_exceeded') ||
+    /max.*token/.test(msgLower)
+  ) {
+    return "context_overflow";
+  }
+
+  // 3. overloaded — HTTP 503/529, or overload/capacity message patterns
+  if (
+    status === 503 ||
+    status === 529 ||
+    msgLower.includes("overloaded") ||
+    msgLower.includes("service unavailable") ||
+    msgLower.includes("capacity")
+  ) {
+    return "overloaded";
+  }
+
+  // 4/5. 403 is ambiguous — quota_exhausted vs auth_error; disambiguate by message
+  if (status === 403) {
+    if (isQuotaMessage(msgLower)) {
+      return "quota_exhausted";
+    }
+    return "auth_error";
+  }
+
+  // 4. quota_exhausted — HTTP 402, or quota/billing message patterns
+  if (status === 402 || isQuotaMessage(msgLower)) {
+    return "quota_exhausted";
+  }
+
+  // 5. auth_error — HTTP 401, or auth message patterns
+  if (status === 401 || isAuthMessage(msgLower)) {
+    return "auth_error";
+  }
+
+  // 6. not_found — HTTP 404, or not-found message patterns
+  if (
+    status === 404 ||
+    /model.*not.*found/.test(msgLower) ||
+    msgLower.includes("does not exist") ||
+    /not.*available/.test(msgLower)
+  ) {
+    return "not_found";
+  }
+
+  // 7. other — fallback
+  return "other";
+}
+
+/** Returns true when a lowercased message matches quota/billing patterns. */
+function isQuotaMessage(msgLower: string): boolean {
+  return (
+    msgLower.includes("quota") ||
+    msgLower.includes("billing") ||
+    /limit.*reached/.test(msgLower) ||
+    /exceeded.*quota/.test(msgLower) ||
+    /monthly.*limit/.test(msgLower) ||
+    msgLower.includes("spending")
+  );
+}
+
+/** Returns true when a lowercased message matches auth patterns. */
+function isAuthMessage(msgLower: string): boolean {
+  return (
+    msgLower.includes("api key") ||
+    msgLower.includes("unauthorized") ||
+    msgLower.includes("forbidden") ||
+    msgLower.includes("authentication") ||
+    /invalid.*key/.test(msgLower) ||
+    /access.*denied/.test(msgLower)
+  );
+}
+
+/**
+ * Extract HTTP status code from an error.
+ *
+ * Tries: `error.status`, `error.statusCode`, `error.response?.status`,
+ * `error.status_code`.
+ */
+function extractStatusCode(error: unknown): number | undefined {
+  if (error === null || error === undefined || typeof error !== "object") {
+    return undefined;
+  }
+  const obj = error as Record<string, unknown>;
+
+  const direct =
+    typeof obj.status === "number"
+      ? obj.status
+      : typeof obj.statusCode === "number"
+        ? obj.statusCode
+        : typeof obj.status_code === "number"
+          ? obj.status_code
+          : undefined;
+
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  // Nested: error.response?.status
+  if (typeof obj.response === "object" && obj.response !== null) {
+    const response = obj.response as Record<string, unknown>;
+    if (typeof response.status === "number") {
+      return response.status;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract a human-readable error message from any value.
+ *
+ * Tries `error.message` first (for Error instances), falls back to `String(error)`.
+ */
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (
+    error !== null &&
+    error !== undefined &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof (error as Record<string, unknown>).message === "string"
+  ) {
+    return (error as Record<string, unknown>).message as string;
+  }
+  return String(error);
+}
+
+/**
+ * Return the lowercased error message for pattern matching.
+ */
+function getErrorMessageLower(error: unknown): string {
+  return extractErrorMessage(error).toLowerCase();
+}
+
+/**
+ * Extract a headers map from an error object.
+ *
+ * Supports objects with a `headers` property (Record or Headers-like).
+ */
+function extractHeaders(error: unknown): Record<string, string> | Headers | undefined {
+  if (error === null || error === undefined || typeof error !== "object") {
+    return undefined;
+  }
+  const obj = error as Record<string, unknown>;
+  const h = obj.headers;
+  if (h === undefined || h === null) {
+    return undefined;
+  }
+  if (typeof h === "object") {
+    return h as Record<string, string> | Headers;
+  }
+  return undefined;
+}
+
+/**
+ * Get a header value (case-insensitive) from a headers object.
+ * Supports both plain record objects and `Headers` instances.
+ */
+function getHeader(headers: Record<string, string> | Headers, name: string): string | undefined {
+  if (typeof (headers as Headers).get === "function") {
+    return (headers as Headers).get(name) ?? undefined;
+  }
+  const plain = headers as Record<string, string>;
+  // Case-insensitive search
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(plain)) {
+    if (key.toLowerCase() === lower) {
+      return plain[key];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Parse a Retry-After header value into milliseconds.
+ *
+ * Handles:
+ * - Plain integer strings ("30" → 30 000 ms)
+ * - HTTP-date strings ("Wed, 21 Oct 2025 07:28:00 GMT" → future delta)
+ */
+function parseRetryAfterHeaderValue(value: string): number {
+  const trimmed = value.trim();
+
+  // Try integer seconds first
+  const seconds = Number(trimmed);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  // Try HTTP-date
+  const date = new Date(trimmed);
+  if (!Number.isNaN(date.getTime())) {
+    const delayMs = date.getTime() - Date.now();
+    return delayMs > 0 ? delayMs : 0;
+  }
+
+  return 0;
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -11,6 +11,10 @@ export { ProviderPriorities } from "./types.js";
 
 export { ProviderAlreadyRegisteredError, ProviderNotFoundError, Registry } from "./registry.js";
 
+export type { ClassifiedError, ProviderErrorKind } from "./error-classifier.js";
+
+export { classifyError, deriveRetryable, parseRetryAfter } from "./error-classifier.js";
+
 export { GeminiProvider } from "./providers/gemini.js";
 export type { GeminiProviderConfig } from "./providers/gemini.js";
 


### PR DESCRIPTION
## Summary

Implements **DC-PROV-003: Error classifier** — central error normalization layer for the DiriCode provider router.

Converts raw provider/API/stream errors into a unified `ClassifiedError` shape with 7 error kinds per ADR-025:

- `rate_limited` → retry with backoff
- `context_overflow` → fallback to larger-context model
- `overloaded` → retry with backoff
- `quota_exhausted` → fallback to different provider
- `auth_error` → fail immediately
- `not_found` → fail immediately
- `other` → retry once, then fail

### What's included

- `ProviderErrorKind` union type + `ClassifiedError` interface
- `classifyError()` — priority-ordered classification (status code → message patterns, 403 disambiguated)
- `parseRetryAfter()` — extracts ms from `Retry-After`, `X-RateLimit-Reset`, body fields; clamped to 60s
- `deriveRetryable()` — ADR-025 retry policy switch
- 61 unit tests covering status codes, message patterns, retry-after variants, edge cases
- Barrel exports updated in `index.ts`

Epic: #3

Fixes #29