### PR TITLE
feat(providers): retry engine with exponential backoff (#30)

### DIFF
--- a/packages/providers/src/__tests__/retry-engine.test.ts
+++ b/packages/providers/src/__tests__/retry-engine.test.ts
@@ -34,7 +34,7 @@ function failThenSucceed<T>(failures: number, result: T): () => Promise<T> {
   return (): Promise<T> => {
     calls += 1;
     if (calls <= failures) {
-      return Promise.reject(new Error(`failure ${calls}`));
+      return Promise.reject(new Error("failure " + String(calls)));
     }
     return Promise.resolve(result);
   };
@@ -137,7 +137,7 @@ describe("withRetry", () => {
 
     it("uses last classified error when retries exhausted", async () => {
       let callCount = 0;
-      const fn = (): Promise<never> => Promise.reject(new Error(`error ${++callCount}`));
+      const fn = (): Promise<never> => Promise.reject(new Error("error " + String(++callCount)));
       const classify = (err: unknown): ClassifiedError =>
         makeClassifiedError({ retryable: true, raw: err });
 
@@ -147,7 +147,7 @@ describe("withRetry", () => {
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect((result.error.raw as Error).message).toBe(`error ${callCount}`);
+        expect((result.error.raw as Error).message).toBe("error " + String(callCount));
       }
     });
 
@@ -203,10 +203,10 @@ describe("withRetry", () => {
 
     it("cancels immediately when signal is already aborted on first check after failure", async () => {
       const controller = new AbortController();
-      controller.abort(); // Pre-aborted
-      let callCount = 0;
+      controller.abort();
+      let _callCount = 0;
       const fn = (): Promise<never> => {
-        callCount += 1;
+        _callCount += 1;
         return Promise.reject(new Error("fail"));
       };
 
@@ -238,11 +238,9 @@ describe("withRetry", () => {
 
       expect(result.ok).toBe(true);
       // The delay used should be at least retryAfterMs
-      const lastCall = setTimeoutSpy.mock.calls.at(-1);
-      if (lastCall !== undefined) {
-        const usedDelay = lastCall[1] as number;
-        expect(usedDelay).toBeGreaterThanOrEqual(retryAfterMs);
-      }
+      const lastCall = setTimeoutSpy.mock.calls.at(-1) ?? [];
+      const usedDelay = lastCall[1] ?? 0;
+      expect(usedDelay).toBeGreaterThanOrEqual(retryAfterMs);
       setTimeoutSpy.mockRestore();
     });
   });
@@ -260,13 +258,11 @@ describe("withRetry", () => {
       const result = await resultPromise;
 
       expect(result.ok).toBe(true);
-      const lastCall = setTimeoutSpy.mock.calls.at(-1);
-      if (lastCall !== undefined) {
-        const usedDelay = lastCall[1] as number;
-        // With baseDelayMs=500, attempt 0: 500*1 + jitter(0..250) ≈ 500–750
-        expect(usedDelay).toBeLessThanOrEqual(10_000);
-        expect(usedDelay).toBeGreaterThan(0);
-      }
+      const lastCall = setTimeoutSpy.mock.calls.at(-1) ?? [];
+      const usedDelay = lastCall[1] ?? 0;
+      // With baseDelayMs=500, attempt 0: 500*1 + jitter(0..250) ≈ 500–750
+      expect(usedDelay).toBeLessThanOrEqual(10_000);
+      expect(usedDelay).toBeGreaterThan(0);
       setTimeoutSpy.mockRestore();
     });
 
@@ -282,11 +278,9 @@ describe("withRetry", () => {
       const result = await resultPromise;
 
       expect(result.ok).toBe(true);
-      const lastCall = setTimeoutSpy.mock.calls.at(-1);
-      if (lastCall !== undefined) {
-        const usedDelay = lastCall[1] as number;
-        expect(usedDelay).toBeLessThanOrEqual(100);
-      }
+      const lastCall = setTimeoutSpy.mock.calls.at(-1) ?? [];
+      const usedDelay = lastCall[1] ?? 0;
+      expect(usedDelay).toBeLessThanOrEqual(100);
       setTimeoutSpy.mockRestore();
     });
   });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -31,7 +31,7 @@ export {
 
 export type { RetryConfig, RetryResult } from "./retry-engine.js";
 
-export { computeDelay, withRetry } from "./retry-engine.js";
+export { BASE_DELAY_MS, computeDelay, withRetry } from "./retry-engine.js";
 
 export { GeminiProvider } from "./providers/gemini.js";
 export type { GeminiProviderConfig } from "./providers/gemini.js";

--- a/packages/providers/src/retry-engine.ts
+++ b/packages/providers/src/retry-engine.ts
@@ -148,14 +148,12 @@ export async function withRetry<T>(
   let attempts = 0;
   let lastClassified: ClassifiedError | undefined;
 
-  while (true) {
-    // Check for abort before attempting
-    if (signal?.aborted) {
-      // lastClassified must be defined here because we only abort after the
-      // first attempt sets it (loop condition ensures this path is hit only
-      // after at least one failure that set lastClassified).
+  for (;;) {
+    if (attempts > 0 && signal?.aborted) {
+      // attempts > 0 means lastClassified was set in previous catch block
       return {
         ok: false,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         error: lastClassified!,
         attempts,
       };


### PR DESCRIPTION
## Summary

Implements DC-PROV-004: Retry engine with exponential backoff for the `@diricode/providers` package.

### What's new

- **`withRetry<T>(fn, classify, config?)`** — Main retry function that wraps async calls with configurable retry logic. Returns a discriminated union `RetryResult<T>` (never throws).
- **`computeDelay(attempt, baseDelayMs, maxDelayMs, retryAfterMs)`** — Exponential backoff calculator with jitter, Retry-After header support, and max delay capping.
- **Constants**: `MAX_RETRIES=3`, `MAX_RETRY_DELAY_MS=15_000`, `BASE_DELAY_MS=1_000` (per ADR-025)

### Key design decisions

- **Non-retryable errors bail immediately** — Uses `ClassifiedError.retryable` from the error classifier (DC-PROV-003)
- **Retry-After headers respected** — Server-requested delays take precedence when larger than computed backoff
- **AbortSignal support** — Retry loop can be cancelled mid-wait
- **Discriminated union result** — `RetryResult<T>` is `{ ok: true, value, attempts }` or `{ ok: false, error, attempts }`, no exceptions thrown

### Testing

- 28 tests covering: success paths, non-retryable bail, retry exhaustion, AbortSignal cancellation, Retry-After respect, backoff calculation, jitter bounds, config overrides

Closes #30

Epic: #3