### PR TITLE
feat(core): add optional findings field to AgentResult for structured output (#342)

### DIFF
--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -239,6 +239,11 @@ export interface AgentResult {
   readonly output: string;
   readonly toolCalls: number;
   readonly tokensUsed: number;
+  /**
+   * Optional agent-specific structured output.
+   * Callers (dispatcher, UI) can inspect findings without parsing freeform text.
+   */
+  readonly findings?: unknown;
 }
 
 export class AgentError extends Error {


### PR DESCRIPTION
## Summary
- Add `readonly findings?: unknown` optional field to `AgentResult` interface
- Enables agents to return structured data alongside freeform output
- Callers (dispatcher, UI) can inspect `findings` without parsing text

## Verification
- TypeScript compiles cleanly (22/22 tasks)
- `code-explorer` remains compatible (optional field)
- Backward compatible — `findings` is optional

Closes #342