### PR TITLE
feat(core): add PromptCache for system prompt caching (#343)

### DIFF
--- a/packages/core/src/__tests__/prompt-cache.test.ts
+++ b/packages/core/src/__tests__/prompt-cache.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PromptCache } from "../agents/prompt-cache.js";
+import { PromptBuilder } from "../agents/prompt-builder.js";
+import type { AgentMetadata, Tool } from "../index.js";
+
+function makeMetadata(overrides?: Partial<AgentMetadata>): AgentMetadata {
+  return {
+    name: "test-agent",
+    description: "A test agent for unit testing",
+    tier: "medium",
+    category: "code",
+    capabilities: ["file-read", "file-write"],
+    tags: ["test"],
+    ...overrides,
+  };
+}
+
+function makeTool(name: string, description = `${name} tool`): Tool {
+  return {
+    name,
+    description,
+    parameters: { parse: (v: unknown) => v } as Tool["parameters"],
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    execute: async () => {
+      await Promise.resolve();
+      return { success: true, data: {} };
+    },
+  };
+}
+
+describe("PromptCache", () => {
+  describe("constructor", () => {
+    it("creates with default TTL", () => {
+      const cache = new PromptCache();
+      expect(cache).toBeDefined();
+      expect(cache.size).toBe(0);
+    });
+
+    it("accepts custom TTL", () => {
+      const cache = new PromptCache({ ttlMs: 60_000 });
+      expect(cache).toBeDefined();
+    });
+  });
+
+  describe("get", () => {
+    it("returns undefined for cache miss", () => {
+      const cache = new PromptCache();
+      const result = cache.get("agent", "/workspace", "medium");
+      expect(result).toBeUndefined();
+    });
+
+    it("returns cached entry for cache hit within TTL", () => {
+      const cache = new PromptCache({ ttlMs: 60_000 });
+      cache.set("agent", "/workspace", "medium", {
+        systemPrompt: "You are an agent.",
+        tokenEstimate: 10,
+      });
+      const result = cache.get("agent", "/workspace", "medium");
+      expect(result).toBeDefined();
+      expect(result?.systemPrompt).toBe("You are an agent.");
+      expect(result?.tokenEstimate).toBe(10);
+    });
+
+    it("evicts and returns undefined for expired entry", () => {
+      vi.useFakeTimers();
+      const cache = new PromptCache({ ttlMs: 1_000 });
+      cache.set("agent", "/workspace", "medium", {
+        systemPrompt: "You are an agent.",
+        tokenEstimate: 10,
+      });
+      expect(cache.size).toBe(1);
+
+      vi.advanceTimersByTime(1_001);
+
+      const result = cache.get("agent", "/workspace", "medium");
+      expect(result).toBeUndefined();
+      expect(cache.size).toBe(0);
+      vi.useRealTimers();
+    });
+  });
+
+  describe("set", () => {
+    it("stores entry with cachedAt timestamp", () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      const cache = new PromptCache();
+      cache.set("agent", "/workspace", "medium", {
+        systemPrompt: "System prompt",
+        tokenEstimate: 25,
+      });
+      const entry = cache.get("agent", "/workspace", "medium");
+      expect(entry).toBeDefined();
+      expect(entry?.cachedAt).toBe(now);
+      vi.useRealTimers();
+    });
+
+    it("overwrites existing entry", () => {
+      const cache = new PromptCache();
+      cache.set("agent", "/workspace", "medium", {
+        systemPrompt: "First prompt",
+        tokenEstimate: 10,
+      });
+      cache.set("agent", "/workspace", "medium", {
+        systemPrompt: "Second prompt",
+        tokenEstimate: 20,
+      });
+      expect(cache.size).toBe(1);
+      const entry = cache.get("agent", "/workspace", "medium");
+      expect(entry?.systemPrompt).toBe("Second prompt");
+      expect(entry?.tokenEstimate).toBe(20);
+    });
+  });
+
+  describe("invalidate", () => {
+    it("removes a specific entry", () => {
+      const cache = new PromptCache();
+      cache.set("agent", "/workspace", "medium", { systemPrompt: "sp", tokenEstimate: 5 });
+      expect(cache.size).toBe(1);
+      cache.invalidate("agent", "/workspace", "medium");
+      expect(cache.size).toBe(0);
+      expect(cache.get("agent", "/workspace", "medium")).toBeUndefined();
+    });
+
+    it("no-ops for non-existent key", () => {
+      const cache = new PromptCache();
+      expect(() => {
+        cache.invalidate("nobody", "/nowhere", "light");
+      }).not.toThrow();
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  describe("invalidateWorkspace", () => {
+    it("removes all entries for a workspace", () => {
+      const cache = new PromptCache();
+      cache.set("agent-a", "/workspace", "medium", { systemPrompt: "sp-a", tokenEstimate: 5 });
+      cache.set("agent-b", "/workspace", "heavy", { systemPrompt: "sp-b", tokenEstimate: 10 });
+      expect(cache.size).toBe(2);
+      cache.invalidateWorkspace("/workspace");
+      expect(cache.size).toBe(0);
+    });
+
+    it("keeps entries for other workspaces", () => {
+      const cache = new PromptCache();
+      cache.set("agent", "/workspace-a", "medium", { systemPrompt: "sp-a", tokenEstimate: 5 });
+      cache.set("agent", "/workspace-b", "medium", { systemPrompt: "sp-b", tokenEstimate: 5 });
+      expect(cache.size).toBe(2);
+      cache.invalidateWorkspace("/workspace-a");
+      expect(cache.size).toBe(1);
+      expect(cache.get("agent", "/workspace-b", "medium")).toBeDefined();
+    });
+  });
+
+  describe("clear", () => {
+    it("removes all entries", () => {
+      const cache = new PromptCache();
+      cache.set("agent-a", "/ws", "medium", { systemPrompt: "sp", tokenEstimate: 5 });
+      cache.set("agent-b", "/ws", "heavy", { systemPrompt: "sp2", tokenEstimate: 10 });
+      expect(cache.size).toBe(2);
+      cache.clear();
+      expect(cache.size).toBe(0);
+    });
+  });
+
+  describe("size", () => {
+    it("returns correct count", () => {
+      const cache = new PromptCache();
+      expect(cache.size).toBe(0);
+      cache.set("a", "/ws", "light", { systemPrompt: "s", tokenEstimate: 1 });
+      expect(cache.size).toBe(1);
+      cache.set("b", "/ws", "medium", { systemPrompt: "s", tokenEstimate: 1 });
+      expect(cache.size).toBe(2);
+      cache.invalidate("a", "/ws", "light");
+      expect(cache.size).toBe(1);
+    });
+  });
+
+  describe("computeKey (via get/set roundtrip)", () => {
+    it("produces consistent hash for same inputs", () => {
+      const cache = new PromptCache();
+      cache.set("agent", "/workspace", "heavy", { systemPrompt: "sp", tokenEstimate: 5 });
+      const first = cache.get("agent", "/workspace", "heavy");
+      const second = cache.get("agent", "/workspace", "heavy");
+      expect(first).toEqual(second);
+    });
+
+    it("produces different hashes for different inputs", () => {
+      const cache = new PromptCache();
+      cache.set("agent-a", "/workspace", "medium", { systemPrompt: "sp-a", tokenEstimate: 5 });
+      cache.set("agent-b", "/workspace", "medium", { systemPrompt: "sp-b", tokenEstimate: 5 });
+      expect(cache.size).toBe(2);
+      expect(cache.get("agent-a", "/workspace", "medium")?.systemPrompt).toBe("sp-a");
+      expect(cache.get("agent-b", "/workspace", "medium")?.systemPrompt).toBe("sp-b");
+    });
+  });
+});
+
+describe("PromptBuilder with PromptCache", () => {
+  let cache: PromptCache;
+
+  beforeEach(() => {
+    cache = new PromptCache();
+  });
+
+  it("withPromptCache returns this for chaining", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata() });
+    const ret = pb.withPromptCache(cache);
+    expect(ret).toBe(pb);
+  });
+
+  it("cache miss: builds and stores system prompt", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata(), workspaceRoot: "/proj" });
+    pb.withPromptCache(cache);
+
+    expect(cache.size).toBe(0);
+    const result = pb.build("hello", []);
+    expect(cache.size).toBe(1);
+    expect(result.systemPrompt).toContain("test-agent");
+
+    const cached = cache.get("test-agent", "/proj", "medium");
+    expect(cached).toBeDefined();
+    expect(cached?.systemPrompt).toBe(result.systemPrompt);
+  });
+
+  it("cache hit: returns cached system prompt without rebuilding", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata(), workspaceRoot: "/proj" });
+    pb.withPromptCache(cache);
+
+    const first = pb.build("first call", []);
+    const second = pb.build("second call", []);
+
+    expect(first.systemPrompt).toBe(second.systemPrompt);
+    expect(cache.size).toBe(1);
+  });
+
+  it("dynamic context (files): bypasses cache", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata(), workspaceRoot: "/proj" });
+    pb.withPromptCache(cache).injectFiles([{ path: "x.ts", content: "const x = 1;" }]);
+
+    pb.build("hello", []);
+    expect(cache.size).toBe(0);
+  });
+
+  it("dynamic context (history): bypasses cache", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata(), workspaceRoot: "/proj" });
+    pb.withPromptCache(cache).injectHistory([{ role: "user", content: "prev", timestamp: 0 }]);
+
+    pb.build("hello", []);
+    expect(cache.size).toBe(0);
+  });
+
+  it("dynamic context (repoMap): bypasses cache", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata(), workspaceRoot: "/proj" });
+    pb.withPromptCache(cache).injectRepoMap({ rootPath: "/proj", files: [] });
+
+    pb.build("hello", []);
+    expect(cache.size).toBe(0);
+  });
+
+  it("dynamic context (plan): bypasses cache", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata(), workspaceRoot: "/proj" });
+    pb.withPromptCache(cache).injectPlan({
+      tasks: [{ id: "t1", description: "do thing", status: "pending" }],
+    });
+
+    pb.build("hello", []);
+    expect(cache.size).toBe(0);
+  });
+
+  it("without cache: works exactly as before", () => {
+    const pb = new PromptBuilder({ metadata: makeMetadata() });
+    pb.bindTools([makeTool("read")], ["read"]);
+    const result = pb.build("write a function", []);
+    expect(result.systemPrompt).toContain("test-agent");
+    expect(result.userMessage).toBe("write a function");
+    expect(result.toolsSection).toContain("read");
+    expect(result.tokenEstimate).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/agents/prompt-builder.ts
+++ b/packages/core/src/agents/prompt-builder.ts
@@ -11,6 +11,7 @@ import type {
   TemplateVars,
 } from "./types.js";
 import type { Tool } from "../tools/types.js";
+import type { PromptCache } from "./prompt-cache.js";
 
 export const DEFAULT_BUDGET: PromptBudget = {
   system: { maxTokens: 2000 },
@@ -40,6 +41,7 @@ export class PromptBuilder {
   private modelHints?: ModelHints;
   private customVars: Record<string, string> = {};
   private capabilities: readonly string[] = [];
+  private promptCache?: PromptCache;
 
   constructor(config: PromptBuilderConfig) {
     this.config = config;
@@ -82,22 +84,66 @@ export class PromptBuilder {
     return this;
   }
 
+  withPromptCache(cache: PromptCache): this {
+    this.promptCache = cache;
+    return this;
+  }
+
   build(userMessage: string, _injections: ContextInjection[]): BuiltPrompt {
-    const systemPrompt = this.renderSystemPrompt();
+    const useCache = this.promptCache !== undefined && !this.hasDynamicContext();
+
+    let systemPrompt: string;
+    let systemTokenEstimate: number;
+
+    if (useCache && this.promptCache) {
+      const cached = this.promptCache.get(
+        this.config.metadata.name,
+        this.config.workspaceRoot ?? "",
+        this.config.metadata.tier,
+      );
+
+      if (cached) {
+        systemPrompt = cached.systemPrompt;
+        systemTokenEstimate = cached.tokenEstimate;
+      } else {
+        const rendered = this.renderSystemPrompt();
+        systemPrompt = this.truncate(rendered, this.budget.system.maxTokens);
+        systemTokenEstimate = this.estimateTokens(systemPrompt);
+        this.promptCache.set(
+          this.config.metadata.name,
+          this.config.workspaceRoot ?? "",
+          this.config.metadata.tier,
+          { systemPrompt, tokenEstimate: systemTokenEstimate },
+        );
+      }
+    } else {
+      systemPrompt = this.renderSystemPrompt();
+      systemTokenEstimate = this.estimateTokens(systemPrompt);
+    }
+
     const toolsSection = this.tools.map((t) => `${t.name}: ${t.description}`).join("\n");
     const tokenEstimate =
-      this.estimateTokens(systemPrompt) +
-      this.estimateTokens(userMessage) +
-      this.estimateTokens(toolsSection);
+      systemTokenEstimate + this.estimateTokens(userMessage) + this.estimateTokens(toolsSection);
 
     return {
-      systemPrompt: this.truncate(systemPrompt, this.budget.system.maxTokens),
+      systemPrompt: useCache
+        ? systemPrompt
+        : this.truncate(systemPrompt, this.budget.system.maxTokens),
       userMessage: this.truncate(userMessage, this.budget.userInput.maxTokens),
       toolsSection: this.truncate(toolsSection, this.budget.tools.maxTokens),
       tokenBudget: this.budget,
       modelHints: this.modelHints ?? {},
       tokenEstimate,
     };
+  }
+
+  private hasDynamicContext(): boolean {
+    return (
+      this.repoMap !== undefined ||
+      this.files.length > 0 ||
+      this.history.length > 0 ||
+      this.plan !== undefined
+    );
   }
 
   private renderSystemPrompt(): string {

--- a/packages/core/src/agents/prompt-cache.ts
+++ b/packages/core/src/agents/prompt-cache.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import type { AgentTier } from "./types.js";
+
+export interface CachedEntry {
+  systemPrompt: string;
+  tokenEstimate: number;
+  cachedAt: number;
+}
+
+export interface PromptCacheConfig {
+  ttlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 300_000;
+
+export class PromptCache {
+  private cache = new Map<string, CachedEntry>();
+  private workspaceIndex = new Map<string, Set<string>>();
+  private ttlMs: number;
+
+  constructor(config?: PromptCacheConfig) {
+    this.ttlMs = config?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  get(agentName: string, workspaceRoot: string, agentTier: AgentTier): CachedEntry | undefined {
+    const key = this.computeKey(agentName, workspaceRoot, agentTier);
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+
+    if (Date.now() - entry.cachedAt >= this.ttlMs) {
+      this.cache.delete(key);
+      this.workspaceIndex.get(workspaceRoot)?.delete(key);
+      return undefined;
+    }
+
+    return entry;
+  }
+
+  set(
+    agentName: string,
+    workspaceRoot: string,
+    agentTier: AgentTier,
+    entry: Omit<CachedEntry, "cachedAt">,
+  ): void {
+    const key = this.computeKey(agentName, workspaceRoot, agentTier);
+    this.cache.set(key, { ...entry, cachedAt: Date.now() });
+
+    if (!this.workspaceIndex.has(workspaceRoot)) {
+      this.workspaceIndex.set(workspaceRoot, new Set());
+    }
+    const keys = this.workspaceIndex.get(workspaceRoot);
+    if (keys) {
+      keys.add(key);
+    }
+  }
+
+  invalidate(agentName: string, workspaceRoot: string, agentTier: AgentTier): void {
+    const key = this.computeKey(agentName, workspaceRoot, agentTier);
+    this.cache.delete(key);
+    this.workspaceIndex.get(workspaceRoot)?.delete(key);
+  }
+
+  invalidateWorkspace(workspaceRoot: string): void {
+    this.workspaceIndex.get(workspaceRoot)?.forEach((key) => {
+      this.cache.delete(key);
+    });
+    this.workspaceIndex.delete(workspaceRoot);
+  }
+
+  clear(): void {
+    this.cache.clear();
+    this.workspaceIndex.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  private computeKey(agentName: string, workspaceRoot: string, agentTier: AgentTier): string {
+    return createHash("sha256").update(`${agentName}:${workspaceRoot}:${agentTier}`).digest("hex");
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,8 @@ export type {
 } from "./agents/types.js";
 export { PromptBuilder, DEFAULT_BUDGET } from "./agents/prompt-builder.js";
 export type { PromptBuilderConfig } from "./agents/prompt-builder.js";
+export { PromptCache } from "./agents/prompt-cache.js";
+export type { PromptCacheConfig, CachedEntry } from "./agents/prompt-cache.js";
 export { AgentProtocolError } from "./agents/protocol.js";
 export type {
   ContextHandoffEnvelope,


### PR DESCRIPTION
## Summary

- Add `PromptCache` class with SHA-256 cache keys, TTL-based expiration (5min default), and workspace-level invalidation
- Integrate cache into `PromptBuilder` via `withPromptCache()` fluent method — caches system prompts when no dynamic context (repoMap/files/history/plan) is injected
- 23 new tests covering cache hit/miss, TTL expiration, invalidation, workspace eviction, and PromptBuilder integration

Closes #343

## Verification

- [x] `PromptCache` class implemented
- [x] Cache hit returns same system prompt without rebuilding
- [x] Cache miss rebuilds and stores
- [x] Cache invalidation works on workspace change
- [x] Existing tests pass (189/189, 1 pre-existing failure unrelated)