### PR TITLE
fix(providers): externalize @napi-rs/keyring in vitest config (#440)

### DIFF
--- a/packages/providers/src/__tests__/copilot.test.ts
+++ b/packages/providers/src/__tests__/copilot.test.ts
@@ -1,4 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+
+const mockGetPassword = vi.hoisted(() => vi.fn<() => string | null>().mockReturnValue(null));
+
+vi.mock("@napi-rs/keyring", () => {
+  class MockEntry {
+    getPassword = mockGetPassword;
+    setPassword = vi.fn();
+    deletePassword = vi.fn<() => boolean>().mockReturnValue(true);
+  }
+  return { Entry: MockEntry, findCredentials: vi.fn().mockReturnValue([]) };
+});
+
 import { CopilotProvider, createCopilotProvider } from "../copilot/adapter.js";
 import { DEFAULT_COPILOT_MODEL, getGithubModelInfo, isKnownModel } from "../copilot/models.js";
 import { getGithubToken, hasGithubAuth } from "../copilot/auth.js";

--- a/packages/providers/vitest.config.ts
+++ b/packages/providers/vitest.config.ts
@@ -2,12 +2,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // Required: native modules (e.g. @napi-rs/keyring) segfault with threads pool
     pool: "forks",
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts"],
     server: {
       deps: {
-        inline: [],
+        external: ["@napi-rs/keyring"],
       },
     },
   },


### PR DESCRIPTION
## Summary

- Add `@napi-rs/keyring` to `server.deps.external` in `packages/providers/vitest.config.ts` to prevent Vite from transforming the native Rust binary module
- Add inline comment on `pool: "forks"` explaining why native modules require the forks pool
- Add `vi.mock("@napi-rs/keyring")` to `copilot.test.ts` following the established pattern from `auth.test.ts` and `keychain.test.ts`, fixing a latent test timeout caused by native keychain access

Closes #440

## Verification

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` (providers) — 12/12 files, 209/209 tests pass ✅