### PR TITLE
fix(providers): add global @napi-rs/keyring mock in vitest setupFiles (#441)

### DIFF
--- a/packages/providers/src/__tests__/copilot.test.ts
+++ b/packages/providers/src/__tests__/copilot.test.ts
@@ -1,16 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-
-const mockGetPassword = vi.hoisted(() => vi.fn<() => string | null>().mockReturnValue(null));
-
-vi.mock("@napi-rs/keyring", () => {
-  class MockEntry {
-    getPassword = mockGetPassword;
-    setPassword = vi.fn();
-    deletePassword = vi.fn<() => boolean>().mockReturnValue(true);
-  }
-  return { Entry: MockEntry, findCredentials: vi.fn().mockReturnValue([]) };
-});
-
 import { CopilotProvider, createCopilotProvider } from "../copilot/adapter.js";
 import { DEFAULT_COPILOT_MODEL, getGithubModelInfo, isKnownModel } from "../copilot/models.js";
 import { getGithubToken, hasGithubAuth } from "../copilot/auth.js";

--- a/packages/providers/vitest.config.ts
+++ b/packages/providers/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     pool: "forks",
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts"],
+    setupFiles: ["./vitest.setup.ts"],
     server: {
       deps: {
         external: ["@napi-rs/keyring"],

--- a/packages/providers/vitest.setup.ts
+++ b/packages/providers/vitest.setup.ts
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+
+const keychainStore = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("@napi-rs/keyring", () => ({
+  Entry: vi.fn().mockImplementation((_service: string, account: string) => ({
+    getPassword: vi.fn(() => keychainStore.get(`${_service}:${account}`) ?? null),
+    setPassword: vi.fn((value: string) => {
+      keychainStore.set(`${_service}:${account}`, value);
+    }),
+    deletePassword: vi.fn(() => keychainStore.delete(`${_service}:${account}`)),
+  })),
+  findCredentials: vi.fn((service: string) => {
+    const creds: { account: string; password: string }[] = [];
+    for (const [key, password] of keychainStore) {
+      if (key.startsWith(`${service}:`)) {
+        creds.push({ account: key.slice(service.length + 1), password });
+      }
+    }
+    return creds;
+  }),
+}));


### PR DESCRIPTION
## Summary

- Add `vitest.setup.ts` with global `vi.mock("@napi-rs/keyring")` using `vi.hoisted()` and in-memory Map store, ensuring no test can accidentally load the native binary
- Reference setup file via `setupFiles` in `vitest.config.ts`
- Remove redundant per-file mock from `copilot.test.ts` (now covered by global setup)
- Existing per-file mocks in `keychain.test.ts` and `auth.test.ts` are preserved — per-file mocks correctly override setup file mocks

Closes #441

## Verification

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` (providers) — 12/12 files, 209/209 tests, 509ms ✅