### PR TITLE
feat(providers): refactor Kimi provider with keychain-based auth (#454)

### DIFF
--- a/packages/providers/src/__tests__/kimi.test.ts
+++ b/packages/providers/src/__tests__/kimi.test.ts
@@ -1,23 +1,49 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { KimiProvider } from "../providers/kimi.js";
+import * as auth from "../kimi/auth.js";
+
+vi.mock("../kimi/auth.js", async () => {
+  const actual = await vi.importActual("../kimi/auth.js");
+  return {
+    ...actual,
+    getKimiApiKey: vi.fn(),
+    hasKimiAuth: vi.fn(),
+  };
+});
 
 describe("KimiProvider", () => {
-  const mockApiKey = "test-api-key-12345";
+  const mockApiKey = "test-api-key-12345678901234567890";
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(auth.hasKimiAuth).mockReturnValue(false);
+    vi.mocked(auth.getKimiApiKey).mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   describe("constructor", () => {
-    it("creates instance with API key string", () => {
-      const provider = new KimiProvider(mockApiKey);
+    it("creates instance with no config", () => {
+      const provider = new KimiProvider();
       expect(provider).toBeDefined();
       expect(provider.name).toBe("kimi");
     });
 
-    it("creates instance with config object", () => {
+    it("creates instance with empty config object", () => {
+      const provider = new KimiProvider({});
+      expect(provider).toBeDefined();
+      expect(provider.name).toBe("kimi");
+    });
+
+    it("creates instance with apiKey in config", () => {
       const provider = new KimiProvider({ apiKey: mockApiKey });
       expect(provider).toBeDefined();
       expect(provider.name).toBe("kimi");
     });
 
-    it("creates instance with config object including custom baseURL", () => {
+    it("creates instance with custom baseURL", () => {
       const provider = new KimiProvider({
         apiKey: mockApiKey,
         baseURL: "https://custom.moonshot.cn/v1",
@@ -25,30 +51,18 @@ describe("KimiProvider", () => {
       expect(provider).toBeDefined();
       expect(provider.name).toBe("kimi");
     });
-
-    it("throws error when API key is empty string", () => {
-      expect(() => new KimiProvider("")).toThrow("KimiProvider requires an API key");
-    });
-
-    it("throws error when API key is whitespace only", () => {
-      expect(() => new KimiProvider("   ")).toThrow("KimiProvider requires an API key");
-    });
-
-    it("throws error when config object has empty apiKey", () => {
-      expect(() => new KimiProvider({ apiKey: "" })).toThrow("KimiProvider requires an API key");
-    });
   });
 
   describe("name", () => {
     it("returns 'kimi'", () => {
-      const provider = new KimiProvider(mockApiKey);
+      const provider = new KimiProvider();
       expect(provider.name).toBe("kimi");
     });
   });
 
   describe("defaultModel", () => {
     it("has correct default model configuration", () => {
-      const provider = new KimiProvider(mockApiKey);
+      const provider = new KimiProvider();
       expect(provider.defaultModel).toEqual({
         modelId: "moonshot-v1-8k",
         temperature: 0.3,
@@ -58,9 +72,28 @@ describe("KimiProvider", () => {
   });
 
   describe("isAvailable", () => {
-    it("returns true when initialized with valid API key", () => {
-      const provider = new KimiProvider(mockApiKey);
+    it("returns false when no auth is available", () => {
+      vi.mocked(auth.hasKimiAuth).mockReturnValue(false);
+      const provider = new KimiProvider();
+      expect(provider.isAvailable()).toBe(false);
+    });
+
+    it("returns true when keychain auth is available", () => {
+      vi.mocked(auth.hasKimiAuth).mockReturnValue(true);
+      const provider = new KimiProvider();
       expect(provider.isAvailable()).toBe(true);
+    });
+
+    it("returns true when apiKey is provided in constructor", () => {
+      vi.mocked(auth.hasKimiAuth).mockReturnValue(false);
+      const provider = new KimiProvider({ apiKey: mockApiKey });
+      expect(provider.isAvailable()).toBe(true);
+    });
+  });
+
+  describe("login", () => {
+    it("has a static login method", () => {
+      expect(typeof KimiProvider.login).toBe("function");
     });
   });
 
@@ -70,6 +103,16 @@ describe("KimiProvider", () => {
       // The implementation is tested manually and works correctly
       // To test: set DC_KIMI_API_KEY env var and run integration tests
     });
+
+    it("throws error when no API key is available", async () => {
+      vi.mocked(auth.hasKimiAuth).mockReturnValue(false);
+      vi.mocked(auth.getKimiApiKey).mockReturnValue(undefined);
+
+      const provider = new KimiProvider();
+      await expect(provider.generate({ prompt: "Hello" })).rejects.toThrow(
+        "KimiProvider requires an API key",
+      );
+    });
   });
 
   describe("stream", () => {
@@ -77,6 +120,50 @@ describe("KimiProvider", () => {
       // Skipped: mocking @ai-sdk/openai-compatible is unreliable in CI environment
       // The implementation is tested manually and works correctly
       // To test: set DC_KIMI_API_KEY env var and run integration tests
+    });
+
+    it("throws error when no API key is available", async () => {
+      vi.mocked(auth.hasKimiAuth).mockReturnValue(false);
+      vi.mocked(auth.getKimiApiKey).mockReturnValue(undefined);
+
+      const provider = new KimiProvider();
+      const stream = provider.stream({ prompt: "Hello" });
+      await expect(stream[Symbol.asyncIterator]().next()).rejects.toThrow(
+        "KimiProvider requires an API key",
+      );
+    });
+  });
+});
+
+describe("Kimi Auth Module", () => {
+  describe("validateKimiApiKey", () => {
+    it("validates correct API key format", () => {
+      expect(auth.validateKimiApiKey("sk-123456789012345678901234567890")).toBe(true);
+    });
+
+    it("rejects short API keys", () => {
+      expect(auth.validateKimiApiKey("short")).toBe(false);
+    });
+
+    it("rejects API keys with invalid characters", () => {
+      expect(auth.validateKimiApiKey("sk-12345678901234567890!@#")).toBe(false);
+    });
+  });
+
+  describe("KIMI_API_KEY_ENV_VARS", () => {
+    it("exports expected environment variable names", () => {
+      expect(auth.KIMI_API_KEY_ENV_VARS).toContain("DC_KIMI_API_KEY");
+      expect(auth.KIMI_API_KEY_ENV_VARS).toContain("KIMI_API_KEY");
+    });
+  });
+
+  describe("KIMI_KEYCHAIN constants", () => {
+    it("exports keychain service name", () => {
+      expect(auth.KIMI_KEYCHAIN_SERVICE).toBe("diricode");
+    });
+
+    it("exports keychain account name", () => {
+      expect(auth.KIMI_KEYCHAIN_ACCOUNT).toBe("kimi-api-key");
     });
   });
 });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -42,6 +42,23 @@ export type { GeminiProviderConfig } from "./providers/gemini.js";
 export { KimiProvider, createKimiProvider } from "./providers/kimi.js";
 export type { KimiProviderConfig } from "./providers/kimi.js";
 
+export {
+  deleteKimiApiKeyFromKeychain,
+  getKimiApiKey,
+  getKimiApiKeyFromEnv,
+  getKimiApiKeyFromKeychain,
+  getKimiApiKeySource,
+  hasKimiAuth,
+  KIMI_API_KEY_ENV_VARS,
+  KIMI_KEYCHAIN_ACCOUNT,
+  KIMI_KEYCHAIN_SERVICE,
+  KimiKeychainError,
+  setKimiApiKeyInKeychain,
+  validateKimiApiKey,
+} from "./kimi/index.js";
+
+export type { KimiApiKeySource, KimiAuthConfig } from "./kimi/index.js";
+
 export { ABExperimentManager } from "./ab/ABExperimentManager.js";
 
 export type {

--- a/packages/providers/src/kimi/auth.ts
+++ b/packages/providers/src/kimi/auth.ts
@@ -1,0 +1,138 @@
+import { Entry } from "@napi-rs/keyring";
+
+export const KIMI_KEYCHAIN_SERVICE = "diricode";
+export const KIMI_KEYCHAIN_ACCOUNT = "kimi-api-key";
+
+export const KIMI_API_KEY_ENV_VARS = ["DC_KIMI_API_KEY", "KIMI_API_KEY"] as const;
+
+export type KimiApiKeySource = (typeof KIMI_API_KEY_ENV_VARS)[number] | "keychain" | "none";
+
+export class KimiKeychainError extends Error {
+  constructor(cause: unknown) {
+    super(`Kimi keychain unavailable: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = "KimiKeychainError";
+  }
+}
+
+/**
+ * Gets the Kimi API key from the system keychain.
+ *
+ * @returns The API key if found, null otherwise
+ */
+export function getKimiApiKeyFromKeychain(): string | null {
+  try {
+    const entry = new Entry(KIMI_KEYCHAIN_SERVICE, KIMI_KEYCHAIN_ACCOUNT);
+    return entry.getPassword();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sets the Kimi API key in the system keychain.
+ *
+ * @param apiKey - The API key to store
+ * @throws {KimiKeychainError} If the keychain is unavailable
+ */
+export function setKimiApiKeyInKeychain(apiKey: string): void {
+  try {
+    const entry = new Entry(KIMI_KEYCHAIN_SERVICE, KIMI_KEYCHAIN_ACCOUNT);
+    entry.setPassword(apiKey);
+  } catch (err) {
+    throw new KimiKeychainError(err);
+  }
+}
+
+/**
+ * Deletes the Kimi API key from the system keychain.
+ *
+ * @returns True if the key was deleted, false if it didn't exist
+ */
+export function deleteKimiApiKeyFromKeychain(): boolean {
+  try {
+    const entry = new Entry(KIMI_KEYCHAIN_SERVICE, KIMI_KEYCHAIN_ACCOUNT);
+    return entry.deletePassword();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets the Kimi API key from environment variables (fallback).
+ *
+ * @returns The API key if found in env vars, undefined otherwise
+ */
+export function getKimiApiKeyFromEnv(): string | undefined {
+  for (const envVar of KIMI_API_KEY_ENV_VARS) {
+    const value = process.env[envVar];
+    if (value && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Gets the Kimi API key from the best available source.
+ * Priority: keychain > environment variables
+ *
+ * @returns The API key if available, undefined otherwise
+ */
+export function getKimiApiKey(): string | undefined {
+  // Primary: keychain (interactive login)
+  const keychainKey = getKimiApiKeyFromKeychain();
+  if (keychainKey) {
+    return keychainKey;
+  }
+
+  // Fallback: environment variables
+  return getKimiApiKeyFromEnv();
+}
+
+/**
+ * Determines the source of the Kimi API key.
+ *
+ * @returns The source of the API key
+ */
+export function getKimiApiKeySource(): KimiApiKeySource {
+  if (getKimiApiKeyFromKeychain()) {
+    return "keychain";
+  }
+
+  for (const envVar of KIMI_API_KEY_ENV_VARS) {
+    const value = process.env[envVar];
+    if (value && value.trim().length > 0) {
+      return envVar;
+    }
+  }
+
+  return "none";
+}
+
+/**
+ * Checks if Kimi authentication is available.
+ *
+ * @returns True if an API key is available from any source
+ */
+export function hasKimiAuth(): boolean {
+  return getKimiApiKey() !== undefined;
+}
+
+/**
+ * Validates a Kimi API key format.
+ * Kimi API keys are typically long alphanumeric strings.
+ *
+ * @param apiKey - The API key to validate
+ * @returns True if the key format appears valid
+ */
+export function validateKimiApiKey(apiKey: string): boolean {
+  // Kimi API keys are typically 30+ characters with alphanumeric and special chars
+  return apiKey.length >= 20 && /^[a-zA-Z0-9_-]+$/.test(apiKey);
+}
+
+export interface KimiAuthConfig {
+  /** API key (optional - will use keychain or env if not provided) */
+  apiKey?: string;
+  /** Base URL override (optional) */
+  baseURL?: string;
+}

--- a/packages/providers/src/kimi/index.ts
+++ b/packages/providers/src/kimi/index.ts
@@ -1,0 +1,16 @@
+export {
+  deleteKimiApiKeyFromKeychain,
+  getKimiApiKey,
+  getKimiApiKeyFromEnv,
+  getKimiApiKeyFromKeychain,
+  getKimiApiKeySource,
+  hasKimiAuth,
+  KIMI_API_KEY_ENV_VARS,
+  KIMI_KEYCHAIN_ACCOUNT,
+  KIMI_KEYCHAIN_SERVICE,
+  KimiKeychainError,
+  setKimiApiKeyInKeychain,
+  validateKimiApiKey,
+} from "./auth.js";
+
+export type { KimiApiKeySource, KimiAuthConfig } from "./auth.js";

--- a/packages/providers/src/providers/kimi.ts
+++ b/packages/providers/src/providers/kimi.ts
@@ -1,137 +1,93 @@
-/**
- * Kimi (Moonshot AI) provider implementation for @diricode/providers.
- *
- * Implements the Provider interface using Moonshot AI's OpenAI-compatible API
- * via the @ai-sdk/openai-compatible SDK. Provides both streaming and
- * non-streaming generation.
- *
- * @example
- * ```typescript
- * const provider = new KimiProvider(process.env.DC_KIMI_API_KEY!);
- * const response = await provider.generate({ prompt: "Hello!" });
- * ```
- */
-
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "../types.js";
+import {
+  getKimiApiKey,
+  hasKimiAuth,
+  setKimiApiKeyInKeychain,
+  validateKimiApiKey,
+} from "../kimi/auth.js";
 
-/** Default base URL for Moonshot AI API */
 const DEFAULT_KIMI_BASE_URL = "https://api.moonshot.cn/v1";
 
-/**
- * Configuration options for the KimiProvider.
- */
 export interface KimiProviderConfig {
-  /** Moonshot AI API key (required) */
-  apiKey: string;
-  /** Override the default base URL. Defaults to "https://api.moonshot.cn/v1" */
+  apiKey?: string;
   baseURL?: string;
 }
 
-/**
- * Kimi provider adapter implementing the DiriCode Provider interface.
- *
- * Uses Moonshot AI's moonshot-v1-8k model by default. Supports both
- * streaming and non-streaming generation via the OpenAI-compatible API.
- *
- * @implements {Provider}
- */
 export class KimiProvider implements Provider {
-  /** Provider name used for registry identification */
   readonly name = "kimi";
 
-  /**
-   * Default model configuration.
-   * Uses moonshot-v1-8k for cost-effective, fast responses.
-   */
   readonly defaultModel: ModelConfig = {
     modelId: "moonshot-v1-8k",
     temperature: 0.3,
     maxTokens: 4096,
   };
 
-  /** OpenAI-compatible provider instance */
-  #provider: ReturnType<typeof createOpenAICompatible>;
+  #provider: ReturnType<typeof createOpenAICompatible> | null = null;
+  #apiKey: string | null = null;
+  #baseURL: string;
 
-  /** Moonshot AI API key */
-  #apiKey: string;
+  constructor(config?: KimiProviderConfig) {
+    this.#baseURL = config?.baseURL ?? DEFAULT_KIMI_BASE_URL;
+
+    const configKey = config?.apiKey?.trim();
+    if (configKey) {
+      this.#apiKey = configKey;
+    }
+  }
 
   /**
-   * Creates a new KimiProvider instance.
+   * Prompts for API key via interactive login and stores it in keychain.
    *
-   * Resolves the API key from the provided config/string, then falls back to
-   * the DC_KIMI_API_KEY and KIMI_API_KEY environment variables.
-   *
-   * @param config - Configuration object or API key string
-   * @throws {Error} If no API key can be resolved from config or environment
-   *
-   * @example
-   * ```typescript
-   * // With config object
-   * const provider = new KimiProvider({ apiKey: "your-api-key" });
-   *
-   * // With API key string
-   * const provider = new KimiProvider("your-api-key");
-   *
-   * // From environment variable
-   * process.env.DC_KIMI_API_KEY = "your-api-key";
-   * const provider = new KimiProvider({ apiKey: process.env.DC_KIMI_API_KEY! });
-   * ```
+   * @param apiKey - The API key to store
+   * @throws {KimiKeychainError} If the keychain is unavailable
    */
-  constructor(config: KimiProviderConfig | string) {
-    const rawApiKey = typeof config === "string" ? config : config.apiKey;
-    const baseURL =
-      typeof config === "string"
-        ? DEFAULT_KIMI_BASE_URL
-        : (config.baseURL ?? DEFAULT_KIMI_BASE_URL);
-
-    const envApiKey = process.env.DC_KIMI_API_KEY ?? process.env.KIMI_API_KEY ?? "";
-    const resolvedApiKey = rawApiKey.trim() || envApiKey;
-
-    if (!resolvedApiKey) {
-      throw new Error(
-        "KimiProvider requires an API key. " +
-          "Provide it via constructor or DC_KIMI_API_KEY environment variable.",
-      );
+  static login(apiKey: string): void {
+    if (!validateKimiApiKey(apiKey)) {
+      throw new Error("Invalid Kimi API key format");
     }
-
-    this.#apiKey = resolvedApiKey;
-
-    this.#provider = createOpenAICompatible({
-      name: "kimi",
-      baseURL,
-      headers: {
-        Authorization: `Bearer ${this.#apiKey}`,
-      },
-    });
+    setKimiApiKeyInKeychain(apiKey);
   }
 
   /**
    * Checks if the provider is available and properly configured.
    *
-   * @returns {boolean} True if API key is present and non-empty
+   * @returns True if API key is available from keychain or environment
    */
   isAvailable(): boolean {
-    return this.#apiKey.length > 0;
+    return hasKimiAuth() || this.#apiKey !== null;
   }
 
-  /**
-   * Generates a non-streaming completion and returns the full text.
-   *
-   * @param options - Generation parameters including prompt and optional model overrides
-   * @returns {Promise<string>} The generated text response
-   * @throws {Error} If the API call fails or returns an empty response
-   *
-   * @example
-   * ```typescript
-   * const response = await provider.generate({
-   *   prompt: "Explain TypeScript generics"
-   * });
-   * console.log(response); // "TypeScript generics are..."
-   * ```
-   */
+  #ensureInitialized(): void {
+    if (this.#provider !== null) return;
+
+    const apiKey = this.#apiKey ?? getKimiApiKey();
+
+    if (!apiKey) {
+      throw new Error(
+        "KimiProvider requires an API key. " +
+          "Login with KimiProvider.login(apiKey) or set DC_KIMI_API_KEY environment variable.",
+      );
+    }
+
+    this.#apiKey = apiKey;
+    this.#provider = createOpenAICompatible({
+      name: "kimi",
+      baseURL: this.#baseURL,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+  }
+
   async generate(options: GenerateOptions): Promise<string> {
+    this.#ensureInitialized();
+
     const modelId = options.model?.modelId ?? this.defaultModel.modelId;
+
+    if (this.#provider === null) {
+      throw new Error("KimiProvider not initialized");
+    }
 
     try {
       const { generateText } = await import("ai");
@@ -149,28 +105,18 @@ export class KimiProvider implements Provider {
 
       return text;
     } catch (error) {
-      throw this.handleError(error, "generate");
+      throw this.#handleError(error, "generate");
     }
   }
 
-  /**
-   * Generates a streaming completion that yields chunks incrementally.
-   *
-   * @param options - Generation parameters including prompt and optional model overrides
-   * @returns {AsyncIterable<StreamChunk>} Async iterator of text chunks
-   * @yields {StreamChunk} Text chunks with delta updates
-   * @throws {Error} If the streaming API call fails
-   *
-   * @example
-   * ```typescript
-   * for await (const chunk of provider.stream({ prompt: "Hello" })) {
-   *   process.stdout.write(chunk.delta);
-   *   if (chunk.done) break;
-   * }
-   * ```
-   */
   async *stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
+    this.#ensureInitialized();
+
     const modelId = options.model?.modelId ?? this.defaultModel.modelId;
+
+    if (this.#provider === null) {
+      throw new Error("KimiProvider not initialized");
+    }
 
     try {
       const { streamText } = await import("ai");
@@ -190,26 +136,21 @@ export class KimiProvider implements Provider {
 
       yield { delta: "", done: true };
     } catch (error) {
-      throw this.handleError(error, "stream");
+      throw this.#handleError(error, "stream");
     }
   }
 
-  /**
-   * Converts API errors to descriptive Error instances.
-   *
-   * @param error - The error from the Moonshot AI API or SDK
-   * @param context - The operation context ("generate" or "stream")
-   * @returns {Error} Standardized error with descriptive message
-   * @private
-   */
-  private handleError(error: unknown, context: string): Error {
+  #handleError(error: unknown, context: string): Error {
     if (error instanceof Error) {
       if (
         error.message.toLowerCase().includes("api key") ||
         error.message.toLowerCase().includes("unauthorized") ||
         error.message.toLowerCase().includes("401")
       ) {
-        return new Error("Invalid or missing API key. Check your DC_KIMI_API_KEY configuration.");
+        return new Error(
+          "Invalid or missing Kimi API key. " +
+            "Login with KimiProvider.login(apiKey) or check your DC_KIMI_API_KEY configuration.",
+        );
       }
 
       if (
@@ -226,17 +167,6 @@ export class KimiProvider implements Provider {
   }
 }
 
-/**
- * Factory function to create a KimiProvider instance.
- *
- * @param config - Configuration object or API key string
- * @returns {Provider} A new KimiProvider instance
- *
- * @example
- * ```typescript
- * const provider = createKimiProvider(process.env.DC_KIMI_API_KEY!);
- * ```
- */
-export function createKimiProvider(config: KimiProviderConfig | string): Provider {
+export function createKimiProvider(config?: KimiProviderConfig): Provider {
   return new KimiProvider(config);
 }


### PR DESCRIPTION
## Summary

Refactors the Kimi provider to use interactive login (keychain storage) as the primary authentication method, with environment variables as optional fallback. This aligns with the Copilot provider's auth pattern.

Closes #454

## Changes

- **New auth module** (`packages/providers/src/kimi/auth.ts`):
  - `getKimiApiKeyFromKeychain()` - Retrieve API key from system keychain
  - `setKimiApiKeyInKeychain()` - Store API key in system keychain
  - `deleteKimiApiKeyFromKeychain()` - Remove API key from system keychain
  - `getKimiApiKeyFromEnv()` - Fallback to env vars
  - `getKimiApiKey()` - Returns key from best available source (keychain > env)
  - `hasKimiAuth()` - Check if authentication is available
  - `validateKimiApiKey()` - Validate API key format

- **Refactored KimiProvider** (`packages/providers/src/providers/kimi.ts`):
  - Added lazy initialization pattern
  - Added static `login()` method for interactive auth
  - Primary auth: keychain storage
  - Fallback auth: `DC_KIMI_API_KEY` or `KIMI_API_KEY` env vars

- **Updated exports** (`packages/providers/src/index.ts`):
  - Export auth functions for external use

- **Updated tests** (`packages/providers/src/__tests__/kimi.test.ts`):
  - Mock auth module for isolated unit testing
  - Tests for new auth flow

## Authentication Priority

1. **Keychain** (primary) - Set via `KimiProvider.login(apiKey)`
2. **Environment variables** (fallback) - `DC_KIMI_API_KEY` or `KIMI_API_KEY`
3. **Constructor config** (override) - Pass directly to constructor

## Usage

```typescript
// Interactive login (stores in keychain)
KimiProvider.login('your-api-key');

// Create provider (uses keychain automatically)
const provider = new KimiProvider();

// Or use env vars as fallback
// export DC_KIMI_API_KEY=your-api-key
const provider = new KimiProvider();
```

## Acceptance Criteria

- [x] Auth module with keychain support
- [x] Primary auth via keychain (interactive login)
- [x] Fallback auth via env vars
- [x] Refactored provider with lazy initialization
- [x] Static `login()` method
- [x] Updated tests
- [x] All lint, typecheck, build, test checks pass

## Test Results

- **Lint**: ✅ Passed
- **Typecheck**: ✅ Passed  
- **Build**: ✅ Passed
- **Tests**: ✅ 263 passed | 5 skipped