### PR TITLE
feat(providers): add MinimaxProviderAdapter for LLM Picker

### DIFF
--- a/packages/providers/src/__tests__/minimax.test.ts
+++ b/packages/providers/src/__tests__/minimax.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { MinimaxProviderAdapter } from "../providers/minimax.js";
+
+describe("MinimaxProviderAdapter", () => {
+  describe("providerId", () => {
+    it("returns 'minimax'", () => {
+      const adapter = new MinimaxProviderAdapter();
+      expect(adapter.providerId).toBe("minimax");
+    });
+  });
+
+  describe("listModels", () => {
+    it("returns array of MiniMax model descriptors", () => {
+      const adapter = new MinimaxProviderAdapter();
+      const models = adapter.listModels();
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBeGreaterThan(0);
+    });
+
+    it("each model has required fields", () => {
+      const adapter = new MinimaxProviderAdapter();
+      const models = adapter.listModels();
+      for (const model of models) {
+        expect(model).toHaveProperty("apiModel");
+        expect(model).toHaveProperty("contextWindow");
+        expect(model).toHaveProperty("maxOutput");
+        expect(model).toHaveProperty("canReason");
+        expect(model).toHaveProperty("toolCall");
+        expect(model).toHaveProperty("vision");
+        expect(model).toHaveProperty("attachment");
+        expect(model).toHaveProperty("quotaMultiplier");
+      }
+    });
+
+    it("includes MiniMax-M2.7 model", () => {
+      const adapter = new MinimaxProviderAdapter();
+      const models = adapter.listModels();
+      const m27 = models.find((m) => m.apiModel === "MiniMax-M2.7");
+      expect(m27).toBeDefined();
+      expect(m27?.contextWindow).toBe(204_800);
+      expect(m27?.maxOutput).toBe(16_384);
+      expect(m27?.canReason).toBe(true);
+    });
+
+    it("includes highspeed variants with quotaMultiplier 2", () => {
+      const adapter = new MinimaxProviderAdapter();
+      const models = adapter.listModels();
+      const highspeed = models.filter((m) => m.apiModel.includes("highspeed"));
+      expect(highspeed.length).toBeGreaterThan(0);
+      for (const model of highspeed) {
+        expect(model.quotaMultiplier).toBe(2);
+      }
+    });
+  });
+
+  describe("getQuota", () => {
+    it("returns null", () => {
+      const adapter = new MinimaxProviderAdapter();
+      expect(adapter.getQuota()).toBeNull();
+    });
+  });
+});

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -62,6 +62,8 @@ export type { KimiApiKeySource, KimiAuthConfig } from "./kimi/index.js";
 export { ZaiProvider, createZaiProvider } from "./providers/zai.js";
 export type { ZaiProviderConfig } from "./providers/zai.js";
 
+export { MinimaxProviderAdapter } from "./providers/minimax.js";
+
 export { ABExperimentManager } from "./ab/ABExperimentManager.js";
 
 export type {

--- a/packages/providers/src/providers/minimax.ts
+++ b/packages/providers/src/providers/minimax.ts
@@ -1,0 +1,86 @@
+import type { ModelDescriptor, ModelQuota, ProviderAdapter } from "../types.js";
+
+const MINIMAX_MODELS: ModelDescriptor[] = [
+  {
+    apiModel: "MiniMax-M2.7",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: true,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 1,
+  },
+  {
+    apiModel: "MiniMax-M2.7-highspeed",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: true,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 2,
+  },
+  {
+    apiModel: "MiniMax-M2.5",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: false,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 1,
+  },
+  {
+    apiModel: "MiniMax-M2.5-highspeed",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: false,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 2,
+  },
+  {
+    apiModel: "MiniMax-M2.1",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: false,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 1,
+  },
+  {
+    apiModel: "MiniMax-M2.1-highspeed",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: false,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 2,
+  },
+  {
+    apiModel: "MiniMax-M2",
+    contextWindow: 204_800,
+    maxOutput: 16_384,
+    canReason: false,
+    toolCall: true,
+    vision: false,
+    attachment: false,
+    quotaMultiplier: 1,
+  },
+];
+
+export class MinimaxProviderAdapter implements ProviderAdapter {
+  readonly providerId = "minimax";
+
+  listModels(): ModelDescriptor[] {
+    return MINIMAX_MODELS;
+  }
+
+  getQuota(): ModelQuota[] | null {
+    return null;
+  }
+}

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -21,6 +21,7 @@ export const ProviderPriorities = {
   COPILOT: 1,
   ZAI: 1,
   KIMI: 2,
+  MINIMAX: 3,
 } as const satisfies Record<string, ProviderPriority>;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `MinimaxProviderAdapter` implementing `ProviderAdapter` interface for LLM Picker
- Register 7 MiniMax models: MiniMax-M2.7, M2.5, M2.1, M2 (+ highspeed variants)
- Add `MINIMAX: 3` to `ProviderPriorities`
- Full unit test coverage

## Test plan
- [x] `pnpm --filter @diricode/providers test` — 260 passed
- [x] `pnpm --filter @diricode/providers build` — success
- [x] `pnpm --filter @diricode/providers typecheck` — success
- [x] `pnpm --filter @diricode/providers lint` — success