### PR TITLE
fix(kimi): use DC_KIMI_API_KEY for env var

### DIFF
--- a/packages/providers/src/__tests__/kimi.test.ts
+++ b/packages/providers/src/__tests__/kimi.test.ts
@@ -101,7 +101,7 @@ describe("KimiProvider", () => {
     it.skip("requires live API for integration testing", () => {
       // Skipped: mocking @ai-sdk/openai-compatible is unreliable in CI environment
       // The implementation is tested manually and works correctly
-      // To test: set KIMI_API_KEY env var and run integration tests
+      // To test: set DC_KIMI_API_KEY env var and run integration tests
     });
 
     it("throws error when no API key is available", async () => {
@@ -119,7 +119,7 @@ describe("KimiProvider", () => {
     it.skip("requires live API for integration testing", () => {
       // Skipped: mocking @ai-sdk/openai-compatible is unreliable in CI environment
       // The implementation is tested manually and works correctly
-      // To test: set KIMI_API_KEY env var and run integration tests
+      // To test: set DC_KIMI_API_KEY env var and run integration tests
     });
 
     it("throws error when no API key is available", async () => {
@@ -152,7 +152,7 @@ describe("Kimi Auth Module", () => {
 
   describe("KIMI_API_KEY_ENV_VAR", () => {
     it("exports expected environment variable name", () => {
-      expect(auth.KIMI_API_KEY_ENV_VAR).toBe("KIMI_API_KEY");
+      expect(auth.KIMI_API_KEY_ENV_VAR).toBe("DC_KIMI_API_KEY");
     });
   });
 

--- a/packages/providers/src/kimi/auth.ts
+++ b/packages/providers/src/kimi/auth.ts
@@ -3,7 +3,7 @@ import { Entry } from "@napi-rs/keyring";
 export const KIMI_KEYCHAIN_SERVICE = "diricode";
 export const KIMI_KEYCHAIN_ACCOUNT = "kimi-api-key";
 
-export const KIMI_API_KEY_ENV_VAR = "KIMI_API_KEY";
+export const KIMI_API_KEY_ENV_VAR = "DC_KIMI_API_KEY";
 
 export type KimiApiKeySource = "env" | "keychain" | "none";
 

--- a/packages/providers/src/providers/kimi.ts
+++ b/packages/providers/src/providers/kimi.ts
@@ -66,7 +66,7 @@ export class KimiProvider implements Provider {
     if (!apiKey) {
       throw new Error(
         "KimiProvider requires an API key. " +
-          "Set KIMI_API_KEY environment variable or use KimiProvider.login(apiKey).",
+          "Set DC_KIMI_API_KEY environment variable or use KimiProvider.login(apiKey).",
       );
     }
 
@@ -149,7 +149,7 @@ export class KimiProvider implements Provider {
       ) {
         return new Error(
           "Invalid or missing Kimi API key. " +
-            "Check your KIMI_API_KEY environment variable or use KimiProvider.login(apiKey).",
+            "Check your DC_KIMI_API_KEY environment variable or use KimiProvider.login(apiKey).",
         );
       }
 


### PR DESCRIPTION
## Summary

Changes the environment variable name from `KIMI_API_KEY` to `DC_KIMI_API_KEY` for consistency with other DiriCode providers.

## Changes

- `KIMI_API_KEY_ENV_VAR = "DC_KIMI_API_KEY"` (was "KIMI_API_KEY")
- Updated error messages to reference `DC_KIMI_API_KEY`
- Updated test expectations

## Usage

```bash
export DC_KIMI_API_KEY=your-key
```

Or use interactive login:
```typescript
KimiProvider.login('your-key');
```