### PR TITLE
docs: apply Claude Code pattern survey — ADRs, epics, v2 research docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ After the first runtime path works:
 - stronger intent gate evolution
 - richer router/cost intelligence
 - LLM Picker decision engine (ADR-049)
+- Permission Context Engine (multi-context handlers, audit logging, granular levels — MVP-2; smart features in v2)
+- router-centric cost tracking (API vs subscription provider types — MVP-2)
+- Memory Systems research (ReasoningBank v2 + MemoryDir — v2, research required)
 
 ### Later priorities
 
@@ -214,6 +217,9 @@ Expand safely:
 - smarter context management
 - ReasoningBank live integration
 - richer observability UI
+- Permission Context Engine (2-phase)
+- Router Cost Tracking (API + Subscription)
+- Memory Systems (ReasoningBank + MemoryDir)
 
 ## Current Package Layout
 
@@ -238,19 +244,22 @@ docs/
 
 ## Current Status
 
-| Area                                | Status          | Notes                                                |
-| ----------------------------------- | --------------- | ---------------------------------------------------- |
-| Dispatcher / delegation             | ✅ Partial-real | Strong runtime foundation exists                     |
-| Tool layer                          | ✅ Partial-real | File/search/bash/LSP/AST foundations exist           |
-| SQLite memory backbone              | ✅ Partial-real | Repositories and local-first direction are real      |
-| SSE / transport                     | ✅ Partial-real | Transport exists; full event model still in progress |
-| Provider layer                      | ✅ Partial-real | Registry exists; richer routing still evolving       |
-| LLM Picker                          | 📐 Designed     | ADR-049 accepted; implementation in MVP-2            |
-| End-to-end pipeline                 | 🏗️ In progress  | Core integration still being wired                   |
-| Checkpoint / resume                 | 🏗️ In progress  | Explicit MVP-1 requirement                           |
-| Semantic navigation / refactoring   | 🏗️ In progress  | High-priority prototype multiplier                   |
-| Full context budgeting / compaction | 📋 Later        | Deliberately not first-wave                          |
-| Full swarm / broad autonomy         | 📋 Later        | Architectural direction kept, delivery delayed       |
+| Area                                          | Status          | Notes                                                             |
+| --------------------------------------------- | --------------- | ----------------------------------------------------------------- |
+| Dispatcher / delegation                       | ✅ Partial-real | Strong runtime foundation exists                                  |
+| Tool layer                                    | ✅ Partial-real | File/search/bash/LSP/AST foundations exist                        |
+| SQLite memory backbone                        | ✅ Partial-real | Repositories and local-first direction are real                   |
+| SSE / transport                               | ✅ Partial-real | Transport exists; full event model still in progress              |
+| Provider layer                                | ✅ Partial-real | Registry exists; richer routing still evolving                    |
+| LLM Picker                                    | 📐 Designed     | ADR-049 accepted; implementation in MVP-2                         |
+| End-to-end pipeline                           | 🏗️ In progress  | Core integration still being wired                                |
+| Checkpoint / resume                           | 🏗️ In progress  | Explicit MVP-1 requirement                                        |
+| Semantic navigation / refactoring             | 🏗️ In progress  | High-priority prototype multiplier                                |
+| Full context budgeting / compaction           | 📋 Later        | Deliberately not first-wave                                       |
+| Full swarm / broad autonomy                   | 📋 Later        | Architectural direction kept, delivery delayed                    |
+| Permission Context Engine                     | 📐 Designed     | ADR-051/052 accepted; Faza 1 in MVP-2, smart features in v2       |
+| Router Cost Tracking                          | 📐 Designed     | ADR-053 accepted; router-centric, API + subscription types; MVP-2 |
+| Memory Systems (ReasoningBank v2 + MemoryDir) | 🔬 Research     | Two systems; deep research required before implementation; v2     |
 
 ## Getting Started
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,7 @@
 # DiriCode — Architecture Decision Records
 
 > All ADRs in English. Consistent with all 13 analysis documents and user decisions.
-> Last updated: 2026-03-28
+> Last updated: 2026-03-31
 
 ## Index
 
@@ -56,6 +56,9 @@
 | [047](adr-047-governance-policy-engine.md) | Governance & Policy Engine | MVP | Pipeline |
 | [048](adr-048-sqlite-issue-system.md) | SQLite Issue System (supersedes ADR-022) | MVP | State |
 | [049](adr-049-llm-picker.md) | LLM Picker | MVP-2+v2+v3 | Router |
+| [051](adr-051-permission-context-engine-phase1.md) | Permission Context Engine: Phase 1 (Core) | MVP-2 | Safety |
+| [052](adr-052-permission-context-engine-phase2.md) | Permission Context Engine: Phase 2 (Smart) | v2 | Safety |
+| [053](adr-053-router-cost-tracking.md) | Router-Centric Cost Tracking | MVP-2+v2 | Router |
 
 ## Template
 

--- a/docs/adr/adr-045-reasoningbank.md
+++ b/docs/adr/adr-045-reasoningbank.md
@@ -86,3 +86,22 @@ This ADR is **not** being reversed. Instead, its delivery order is clarified:
 - **Do early:** preserve ReasoningBank in architecture, schema planning, and memory-roadmap decisions.
 - **Do after core runtime:** live retrieval/injection, confidence-driven reuse, and hook-powered learning loops.
 - **Do not let it delay:** the first believable prototype centered on controlled execution, streaming visibility, semantic navigation, and checkpoint/resume.
+
+### Addendum — MemoryDir Relationship (2026-03-31)
+
+ReasoningBank and MemoryDir are **two separate, complementary systems**.
+
+| Dimension | ReasoningBank | MemoryDir |
+|-----------|--------------|-----------|
+| **Purpose** | Problem-solving memory | General knowledge memory |
+| **Format** | Structured (problem → approach → outcome) | Flexible (facts, preferences, patterns, team knowledge) |
+| **Storage** | SQLite + sqlite-vec | File-based or SQLite (TBD via research) |
+| **Retrieval** | Semantic (embeddings) + keyword (FTS5) | Context-aware + keyword + recency |
+| **Integration** | Hook-based (pre-agent/post-agent) | Explicit API |
+
+**Synergy**: ReasoningBank records *how* agents solved problems. MemoryDir stores *what* they learned (facts, preferences, team conventions). Both systems will be integrated to provide full memory coverage, but are implemented independently.
+
+**Status**: Both systems require deep research and reference implementation analysis before implementation. See:
+- DC-MEM-001: ReasoningBank Deep Research & Design
+- DC-MEM-002: MemoryDir Deep Research & Design
+

--- a/docs/adr/adr-051-permission-context-engine-phase1.md
+++ b/docs/adr/adr-051-permission-context-engine-phase1.md
@@ -1,0 +1,79 @@
+## ADR-051 — Permission Context Engine: Phase 1 (Core)
+
+| Field       | Value                                                                 |
+|-------------|-----------------------------------------------------------------------|
+| Status      | Accepted                                                              |
+| Date        | 2026-03-31                                                            |
+| Scope       | MVP-2                                                                 |
+| References  | ADR-014 (Smart Hybrid Approval), ADR-015 (Tool Annotations), ADR-018 (SQLite), DC-SAFE-005 |
+
+### Context
+
+DiriCode runs in multiple execution contexts — interactive (user present), coordinator (orchestrating other agents), and swarm worker (background, speed-optimized). The current permission model in DC-SAFE-005 does not distinguish between these contexts: it applies the same approval logic regardless of whether a user is at the keyboard or an agent is running autonomously in the background.
+
+Claude Code analysis (2026-03-31 pattern survey) revealed a richer permission model with context-specific handlers, granular permission levels, and structured audit logging. DiriCode needs equivalent or better capabilities for safe autonomous operation.
+
+### Decision
+
+**Introduce the Permission Context Engine (DC-SAFE-006) as an extension of the existing DC-SAFE system, delivered in two phases.**
+
+**Phase 1 (this ADR, MVP-2)** delivers the core foundation:
+
+**1. Multi-Context Permission Handlers**
+
+Four context-specific handlers, each with a distinct approval strategy:
+
+| Handler | Context | Strategy |
+|---------|---------|----------|
+| `CoordinatorHandler` | Orchestrating agents | Delegation-aware, trust hierarchy |
+| `InteractiveHandler` | User at keyboard | Full UI approvals for all risky ops |
+| `SwarmWorkerHandler` | Background agent | Speed-optimized, auto-approve safe ops |
+| `DefaultHandler` | Fallback | Existing DC-SAFE-005 behavior |
+
+**2. Granular Permission Levels**
+
+Four levels replacing the binary allow/deny model:
+
+```
+"always-allow"  — never prompt, execute immediately
+"auto-allow"    — prompt once per session, remember for duration
+"ask"           — prompt every time
+"never-allow"   — always block, no override
+```
+
+Default configuration per context:
+```
+coordinator: { destructive: "ask", risky: "auto-allow", safe: "always-allow" }
+interactive:  { destructive: "ask", risky: "ask",        safe: "auto-allow"  }
+swarm:        { destructive: "ask", risky: "auto-allow", safe: "always-allow" }
+```
+
+**3. Permission Audit Logging**
+
+Every permission decision is logged to SQLite:
+- Timestamp, context type, tool name, tool annotation risk level
+- Decision (approved/denied/auto-approved)
+- User response (if interactive)
+- Session and agent identifiers
+
+Queryable: "Show all denials this session", "Permission stats per tool", "Audit trail for compliance".
+
+### Consequences
+
+**Positive:**
+- Swarm workers run efficiently without unnecessary prompts.
+- Interactive users still get full control over risky operations.
+- Coordinator agents can delegate with appropriate trust levels.
+- Backwards compatible: DefaultHandler preserves existing behavior.
+- Audit log provides observability and compliance trail.
+
+**Negative:**
+- Four handlers increase complexity vs current single path.
+- Context detection must be reliable — wrong context = wrong permission policy.
+- Async audit logging must not block execution on SQLite writes.
+
+### Delivery
+
+- **Scope**: MVP-2
+- **Issues**: DC-SAFE-006a (Multi-Context Handlers), DC-SAFE-006b (Permission Audit Logging), DC-SAFE-006c (Granular Permission Levels)
+- **Phase 2**: See ADR-052 for smart permission features (learning, UI, semantic analysis)

--- a/docs/adr/adr-052-permission-context-engine-phase2.md
+++ b/docs/adr/adr-052-permission-context-engine-phase2.md
@@ -1,0 +1,102 @@
+## ADR-052 — Permission Context Engine: Phase 2 (Smart)
+
+| Field       | Value                                                                 |
+|-------------|-----------------------------------------------------------------------|
+| Status      | Accepted                                                              |
+| Date        | 2026-03-31                                                            |
+| Scope       | v2                                                                    |
+| References  | ADR-051 (Phase 1), ADR-045 (ReasoningBank), DC-TOOL-010 (AST-grep) |
+
+### Context
+
+Phase 1 (ADR-051) delivers the structural foundation for context-aware permissions. Phase 2 adds intelligence: learning from user decisions, providing management UI, enabling semantic risk analysis, and supporting prefix-level blocking.
+
+This is deliberately scoped to v2 because it depends on:
+- Phase 1 being stable and observed in real usage
+- ReasoningBank (ADR-045) for pattern learning storage
+- AST-grep (DC-TOOL-010) for semantic code analysis
+
+### Decision
+
+**Phase 2 extends the Permission Context Engine with four smart capabilities:**
+
+**1. Prefix-Level and Pattern Blocking**
+
+Block entire categories of tools or operation patterns:
+
+```typescript
+BlockList {
+  exactNames: ["bash", "rm-rf-wrapper"]
+  prefixes:   ["git-push", "docker-deploy-prod"]
+  patterns:   ["**/secret*", "*.key", "*.pem"]
+}
+```
+
+Configurable per-user and per-project. Stored in `.dc/` config.
+
+**2. Permission Management Command**
+
+User-facing `/permissions` command:
+```
+/permissions list          — Show current permission levels
+/permissions block <tool>  — Block a tool
+/permissions allow <tool>  — Allow a tool
+/permissions audit         — Show decision log
+/permissions reset         — Reset to defaults
+```
+
+**3. Cross-Session Learning**
+
+Detect patterns in user permission decisions and offer auto-suggestions:
+- "You've approved 'refactor imports' 5 times — auto-approve future occurrences?"
+- Confidence scoring and decay (stale patterns lose weight)
+- Leverages ReasoningBank storage infrastructure
+
+**4. Semantic Risk Analysis**
+
+Integrate with AST-grep (DC-TOOL-010) to compute risk scores before permission prompts:
+
+```typescript
+RiskScore {
+  score:         0-100
+  changeSize:    "small" | "medium" | "large"
+  affectedFiles: number
+  isTestFile:    boolean
+  isConfigFile:  boolean
+}
+```
+
+Risk-adjusted prompts: high-risk changes always prompt, low-risk changes can auto-approve.
+
+### Consequences
+
+**Positive:**
+- User decisions improve the system over time.
+- Semantic analysis reduces false positives (fewer unnecessary prompts).
+- Management UI gives users control and transparency.
+- Prefix blocking enables project-level safety policies.
+
+**Negative:**
+- Cross-session learning requires calibration; bad patterns can cause under-prompting.
+- Semantic analysis adds latency before permission decisions.
+- Complexity compounds Phase 1 — requires stable Phase 1 foundation.
+
+### Comparison with Claude Code
+
+| Feature | Claude Code | DiriCode Phase 1 | DiriCode Phase 2 |
+|---------|------------|-----------------|-----------------|
+| Multi-context handlers | ✅ | ✅ | ✅ |
+| Granular levels | ✅ | ✅ | ✅ |
+| Audit logging | ✅ | ✅ | ✅ (enhanced) |
+| Prefix blocking | ✅ | ❌ | ✅ |
+| Permission UI | ✅ | ❌ | ✅ |
+| Cross-session learning | ✅ | ❌ | ✅ |
+| Semantic analysis | ✅ | ❌ | ✅ |
+
+Phase 2 reaches parity with Claude Code and exceeds it in learning sophistication.
+
+### Delivery
+
+- **Scope**: v2
+- **Issues**: DC-SAFE-006d (Prefix Blocking), DC-SAFE-006e (Permission UI), DC-SAFE-006f (Cross-Session Learning), DC-SAFE-006g (Semantic Analysis)
+- **Phase 1**: See ADR-051

--- a/docs/adr/adr-053-router-cost-tracking.md
+++ b/docs/adr/adr-053-router-cost-tracking.md
@@ -1,0 +1,83 @@
+## ADR-053 — Router-Centric Cost Tracking
+
+| Field       | Value                                                                 |
+|-------------|-----------------------------------------------------------------------|
+| Status      | Accepted                                                              |
+| Date        | 2026-03-31                                                            |
+| Scope       | MVP-2 (core) + v2 (intelligence)                                      |
+| References  | ADR-025 (Router), ADR-042 (Multi-Subscription), DC-SAFE-004 (Token Guardrails) |
+
+### Context
+
+DiriCode supports multiple provider types with fundamentally different billing models:
+
+- **API providers** (OpenAI, Anthropic, Azure paygo): pay-per-token with real-time cost calculation
+- **Subscription providers** (GitHub Copilot, Azure subscription): flat rate with quota limits; effective cost is deferred and estimated
+
+The existing DC-SAFE-004 (token guardrails) handles session budgets but lacks provider-type awareness. ADR-042 (Multi-Subscription) manages subscription health but not cross-provider cost aggregation.
+
+Cost tracking must be **router-centric**: the router (ADR-025) is the single point through which all provider calls flow, making it the natural owner of cross-provider cost statistics.
+
+### Decision
+
+**Extend the Diri-Router with a cost tracking engine that understands both provider types and aggregates statistics centrally.**
+
+**Provider Types**
+
+```typescript
+interface ApiProvider {
+  type: "api";
+  pricing: { inputPer1k: number; outputPer1k: number };
+  // Cost = tokens × price / 1000 (immediate, accurate)
+}
+
+interface SubscriptionProvider {
+  type: "subscription";
+  monthlyPrice: number;
+  limits: { rpm: number; tpm: number; dailyTokens: number };
+  // Cost = $0 when in limit, else estimated from monthly/30
+}
+
+interface HybridProvider {
+  type: "hybrid";
+  // Base subscription + per-token overage (e.g., Azure)
+}
+```
+
+**Cost Tracking Engine (DC-ROUTER-021)**
+
+Centralized in the router:
+- `calculateCallCost(provider, usage)` — type-aware cost calculation per call
+- `getSessionCost(sessionId)` — aggregated cost for a session
+- `getProviderStats(providerId)` — efficiency statistics per provider
+- Real-time cost for API providers; deferred/estimated cost for subscription providers
+
+**Provider Type Registry Extension (DC-ROUTER-020)**
+
+Extend the existing Provider Registry (DC-PROV-001) to record provider types and pricing configurations.
+
+**Cost Optimization Routing (DC-ROUTER-022)**
+
+Router strategy that prefers subscription providers (within quota) over API providers:
+- "Cheapest first": use subscription capacity before paying per-token
+- Automatic fallback when quota exhausted
+- Track savings from optimization
+
+### Consequences
+
+**Positive:**
+- Single authoritative cost view across all providers.
+- Cost-optimized routing reduces API spend for users with subscriptions.
+- Transparency: users see what execution costs across provider types.
+- Router-centric design avoids duplicating cost logic in every agent.
+
+**Negative:**
+- Subscription cost is inherently estimated, not exact; must communicate this clearly.
+- Router becomes more complex with cost-tracking responsibility.
+- Deferred cost calculation means end-of-period reconciliation is needed for accurate subscription costs.
+
+### Delivery
+
+- **Scope**: MVP-2 (core infrastructure); v2 (cost intelligence, forecasting, optimization suggestions)
+- **Issues**: DC-ROUTER-020 (Provider Type Registry), DC-ROUTER-021 (Cost Tracking Engine), DC-ROUTER-022 (Cost Optimization Routing)
+- **Not urgent**: Cost tracking is low priority in MVP-2 compared to core router functionality

--- a/docs/mvp/dependency-graph.md
+++ b/docs/mvp/dependency-graph.md
@@ -1,0 +1,131 @@
+# DiriCode: MVP Dependency Graph
+
+> **Last updated**: 2026-03-31  
+> **Purpose**: Tracks dependencies between epics and issue groups to guide delivery sequencing.
+
+## Epic Dependency Graph
+
+```mermaid
+graph TD
+    MONO[epic-monorepo-setup]
+    TEST[epic-testing-infra]
+    CONF[epic-config]
+    SAFE[epic-safety]
+    TOOL[epic-tools]
+    PROV[epic-providers]
+    CORE[epic-agents-core]
+    PIPE[epic-pipeline]
+    SKILL[epic-skills]
+    MEM[epic-memory]
+    OBS[epic-observability]
+    SRV[epic-server]
+    CLI[epic-cli]
+    WEB[epic-web-ui]
+    HOOK[epic-hooks]
+    CTX[epic-context]
+    ROST[epic-agents-roster]
+    LLM[epic-llm-picker]
+    ROUTER[epic-router]
+
+    MONO --> TEST
+    MONO --> CONF
+    CONF --> CORE
+    PROV --> CORE
+    CORE --> PIPE
+    CORE --> SKILL
+    CORE --> OBS
+    CORE --> SRV
+    CORE --> ROST
+    CORE --> CTX
+    TOOL --> PIPE
+    TOOL --> SKILL
+    TOOL --> HOOK
+    TOOL --> CTX
+    SAFE --> PIPE
+    SAFE --> HOOK
+    PROV --> LLM
+    PROV --> ROUTER
+    SKILL --> ROST
+    PIPE --> ROST
+    SRV --> CLI
+    SRV --> WEB
+```
+
+## Issue Group Dependencies
+
+| Issue Group | Depends On | Blocks | Phase |
+| :--- | :--- | :--- | :--- |
+| DC-MONO-* | None | Everything | POC |
+| DC-TEST-* | DC-MONO | Quality Gates | POC |
+| DC-CONF-* | DC-MONO | CORE, PROV | POC |
+| DC-PROV-001 | None | PROV-002..007, CORE | POC |
+| DC-PROV-002/007 | DC-PROV-001 | CORE | POC |
+| DC-PROV-003 | DC-PROV-001 | PROV-004/006 | POC |
+| DC-PROV-004 | DC-PROV-003 | PROV-005/006 | POC |
+| DC-PROV-005 | DC-PROV-002/004/007 | High-level orchestration | POC |
+| DC-PROV-006 | DC-PROV-003/004 | High-level orchestration | POC |
+| DC-CORE-* | DC-CONF, DC-PROV | PIPE, SKILL, ROST, SRV | POC |
+| DC-SAFE-001..005 | DC-CORE-001, TOOL Primitives | Mutating Tools, PIPE | POC |
+| DC-TOOL-001..006 | DC-SAFE-001, DC-CORE-001 | PIPE, SKILL | POC |
+| DC-MEM (SQLite) | None | Persistence | POC/MVP-1 |
+| DC-OBS-* | DC-CORE | Visibility | MVP-1 |
+| DC-PIPE-* | DC-CORE, DC-TOOL, DC-SAFE | E2E Execution | MVP-1 |
+| DC-TOOL-007..008 | DC-TOOL-004, DC-SAFE-003 | MVP-1 Features | MVP-1 |
+| DC-SKILL-001..007 | DC-CORE, DC-TOOL-001..012 | ROST | MVP-1/MVP-2 |
+| DC-SRV-* | DC-CORE | CLI, WEB | MVP-1 |
+| DC-CLI-* | DC-SRV | End-user Access | MVP-1 |
+| DC-WEB-* | DC-SRV | End-user Access | MVP-1 |
+| DC-HOOK-* | DC-SAFE, DC-TOOL | Cross-cutting logic | MVP-1 |
+| DC-CTX-* | DC-TOOL, DC-CORE | Context Management | MVP-1 |
+| DC-AGENT-* | DC-CORE, DC-SKILL, DC-PIPE | Production Roster | MVP-1 |
+| DC-SAFE-006 | DC-SAFE-005, SQLite | Advanced Permissions | MVP-2 |
+| DC-TOOL-009..018 | DC-TOOL-001..008, SQLite | Advanced Tools | MVP-2 |
+| DC-ROUTER-020..022| DC-PROV-001..007 | Advanced Routing | MVP-2 |
+| DC-LLM-* | DC-PROV-001..007 | LLM Picking | MVP-2 |
+| DC-MEM-R001/002 | Research Required | Advanced Memory | v2+ |
+
+## Delivery Phases
+
+### POC
+Foundational elements required to prove the core agent-loop and basic tool usage.
+- **DC-MONO**: Repository structure and package management.
+- **DC-TEST**: Initial testing frameworks.
+- **DC-CONF**: Basic configuration management.
+- **DC-PROV-001..007**: Initial provider integration.
+- **DC-CORE**: Basic agent runtime and event stream.
+- **DC-SAFE-001..005**: Initial safety boundaries.
+- **DC-TOOL-001..006**: Fundamental tool primitives.
+
+### MVP-1
+Functional system capable of end-to-end task execution with observability and CLI/Web interfaces.
+- **DC-PIPE**: Pipeline execution engine.
+- **DC-OBS**: Basic telemetry and tracing.
+- **DC-SRV**: API server for UI/CLI communication.
+- **DC-CLI / DC-WEB**: User-facing interfaces.
+- **DC-AGENT**: Initial roster of specialized agents.
+- **DC-SKILL**: Basic skill system for agents.
+- **DC-MEM**: SQLite-backed persistence for sessions.
+
+### MVP-2
+Enhanced capabilities, advanced safety, and refined routing.
+- **DC-LLM**: Intelligent LLM selection.
+- **DC-ROUTER**: Advanced provider routing logic.
+- **DC-SAFE-006**: Refined permission systems.
+- **DC-TOOL-009..018**: Advanced tools (e.g., browser automation, complex file ops).
+- **DC-SKILL-004..006**: Advanced agent skills.
+
+### v2+
+Long-term architectural enhancements.
+- **DC-MEM-R001**: ReasoningBank for long-term pattern storage.
+- **DC-MEM-R002**: MemoryDir for structured experience retrieval.
+
+## Critical Path (MVP-1 Exit)
+
+1. **Monorepo & Config Setup** (DC-MONO, DC-CONF)
+2. **Provider Foundation** (DC-PROV-001)
+3. **Core Runtime** (DC-CORE)
+4. **Safety Primitives** (DC-SAFE-001..005)
+5. **Tool Primitives** (DC-TOOL-001..006)
+6. **Pipeline Engine** (DC-PIPE)
+7. **API Server** (DC-SRV)
+8. **UI/CLI Integration** (DC-CLI, DC-WEB)

--- a/docs/mvp/epic-router.md
+++ b/docs/mvp/epic-router.md
@@ -276,6 +276,74 @@ Implement Kimi adapter (priority 2) as fallback-capable Provider:
 
 ---
 
+---
+
+## MVP-2: Cost Tracking Extension
+
+> **Note**: These issues extend the router for cost tracking and provider type awareness. Not part of the initial MVP-1 router epic but planned for MVP-2.
+
+### Issue: DC-ROUTER-020 — Provider Type Registry
+
+#### Description
+Extend the existing Provider Registry (DC-PROV-001) to support typed providers:
+- `type: "api" | "subscription" | "hybrid"`
+- `ApiProvider`: per-token pricing configuration
+- `SubscriptionProvider`: monthly price + quota limits
+- `HybridProvider`: subscription base + overage pricing
+
+#### Acceptance Criteria
+- Provider registry supports all three types with type-safe interfaces
+- Existing provider adapters (Copilot, Kimi) are classified and migrated
+- Type information is available to routing decisions
+
+#### References
+- ADR-053 Router Cost Tracking
+- ADR-042 Multi-Subscription Management
+
+---
+
+### Issue: DC-ROUTER-021 — Cost Tracking Engine
+
+#### Description
+Centralized cost tracking module in the router:
+- `calculateCallCost(provider, usage)` — type-aware calculation per call
+- `getSessionCost(sessionId)` — session aggregation
+- `getProviderStats(providerId)` — per-provider efficiency statistics
+- Real-time cost for API providers; deferred/estimated for subscriptions
+
+#### Acceptance Criteria
+- Real-time cost calculation for API providers
+- Deferred/estimated cost for subscription providers with clear "estimated" flag
+- Hybrid calculation for Azure-style providers
+- Statistics queryable per-provider, per-model, per-session
+
+#### References
+- ADR-053 Router Cost Tracking
+- DC-SAFE-004 (Token Guardrails)
+
+---
+
+### Issue: DC-ROUTER-022 — Cost Optimization Routing Strategy
+
+#### Description
+Router strategy that prefers subscription providers (within quota) over pay-per-token:
+- "Cheapest first" strategy: exhaust subscription quota before using API providers
+- Automatic fallback when subscription quota exhausted
+- Track cost savings from optimization
+- User preference setting: `speed` vs `cost`
+
+#### Acceptance Criteria
+- `cost-optimized` strategy implemented in router
+- Automatic subscription → API fallback when quota reached
+- Savings tracked and surfaced via stats
+- User preference configurable
+
+#### References
+- ADR-053 Router Cost Tracking
+- DC-PROV-005 Provider Fallback Chain
+
+---
+
 ## Must NOT (Epic-specific)
 
 - Must NOT introduce LiteLLM (or any Python sidecar/proxy) in MVP
@@ -319,3 +387,10 @@ MVP-1 exit requires full retry/fallback/error/stream behavior with Copilot→Kim
 ### DC-ROUT-001 — Load-aware model routing and cooldown policy
 
 After the baseline router is stable, add health-aware routing inputs such as recent failures, cooldown windows, and basic load-aware selection without jumping straight to full adaptive orchestration.
+
+---
+
+## Cross-References (Post-ADR Review)
+
+- **DC-SAFE-004** (Token/Cost Guardrails): Session budget enforcement lives in safety layer; DC-ROUTER-021 extends this with type-aware cost calculation. Safety guardrails remain upstream gatekeepers; router provides detailed tracking.
+- **DC-SAFE-006** (Permission Context Engine): Outbound provider calls from the router are subject to permission context rules (e.g., coordinator vs. interactive contexts may have different provider usage policies). DC-ROUTER-020 provider type metadata informs permission-level decisions.

--- a/docs/mvp/epic-safety.md
+++ b/docs/mvp/epic-safety.md
@@ -148,6 +148,37 @@ Safety controls are default-on and fail-closed for high-risk actions. The system
 - ADR-015 tool annotations
 - ADR-031 EventStream for approval telemetry
 
+---
+
+### DC-SAFE-006 — Permission Context Engine (MVP-2, Phase 1)
+
+**Goal**: Multi-context permission handling with audit logging and granular permission levels.
+
+**Scope**
+- Four context-specific permission handlers (Coordinator, Interactive, SwarmWorker, Default)
+- Four granular permission levels: `always-allow`, `auto-allow`, `ask`, `never-allow`
+- SQLite-backed audit log of all permission decisions
+- Backwards compatible with DC-SAFE-005
+
+**Sub-issues**
+- DC-SAFE-006a: Multi-Context Permission Handlers
+- DC-SAFE-006b: Permission Audit Logging
+- DC-SAFE-006c: Granular Permission Levels
+
+**Acceptance criteria**
+- Four context handlers with distinct permission strategies
+- All permission decisions logged to SQLite with timestamp, context, tool, and outcome
+- Granular levels configurable per context and operation risk class
+- DefaultHandler preserves DC-SAFE-005 behavior (backwards compatible)
+
+**Phase 2** (v2): smart features — prefix blocking, `/permissions` command, cross-session learning, semantic risk analysis. See ADR-052.
+
+**ADR references**
+- ADR-051 Permission Context Engine Phase 1
+- ADR-052 Permission Context Engine Phase 2
+- ADR-014 Smart Hybrid Approval
+- ADR-015 Tool Annotations
+
 ## Must NOT
 
 - Must NOT allow bypass of hard safety rails in default modes.
@@ -186,3 +217,10 @@ Safety controls are default-on and fail-closed for high-risk actions. The system
 - Full secret-prevent-commit integration.
 - DC-SAFE-005 approval workflow with EventStream + timeout auto-deny.
 - End-to-end UX refinement honoring UX-002 human decision authority.
+
+---
+
+## Cross-References (Post-ADR Review)
+
+- **DC-ROUTER-021** (Cost Tracking Engine): DC-SAFE-004 token guardrails feed into router-centric cost tracking. The router aggregates all cost data; safety guardrails provide session budget enforcement as an upstream input.
+- **DC-TOOL-018** (Pattern Recorder): Permission sequences approved by DC-SAFE-005/006 can be recorded as reusable patterns via DC-TOOL-018, allowing users to replay pre-approved workflows without repeated approval overhead.

--- a/docs/mvp/epic-skills.md
+++ b/docs/mvp/epic-skills.md
@@ -216,3 +216,13 @@ Integrate skills with 4-dimension work modes so behavior adapts per prompt/sessi
 ## Epic Dependencies
 - **Blocked by**: agent runtime/prompt builder and tool contracts.
 - **Blocks**: higher-fidelity specialist agent behavior and work-mode-consistent execution in MVP-3.
+
+---
+
+## Cross-References (Post-ADR Review)
+
+- **DC-TOOL-018** (Pattern Recorder): DC-SKILL-* and DC-TOOL-018 are deliberately separate systems:
+  - **DC-SKILL-*** = agent specialization definitions (who the agent is, what it knows, tool allowlists)
+  - **DC-TOOL-018** = operational workflow recorder (captures and replays sequences of tool calls as reusable patterns)
+  
+  These systems are complementary: a DC-SKILL definition provides agent identity, while DC-TOOL-018 patterns provide repeatable execution recipes. Future synergy: a skill can reference recommended patterns from DC-TOOL-018 as part of its guidance.

--- a/docs/mvp/epic-tools.md
+++ b/docs/mvp/epic-tools.md
@@ -274,3 +274,132 @@ Implement URL fetch with timeout and markdown conversion for external context in
 - [ ] Implement ToolRetry middleware: exponential backoff + jitter, configurable retry_on filter, max_retries=3 (ADR-036)
 - [ ] Implement LLMToolEmulator wrapper: replaces tool execution with LLM-simulated responses for dev/test/CI mode (ADR-037, v2 scope)
 - [ ] Implement LLMToolSelector wrapper: cheap model pre-filters tool list before main model call to reduce token usage (ADR-038, v2 scope)
+
+---
+
+## MVP-2: New Tool Issues (Claude Code Pattern Survey)
+
+> These issues were identified during a Claude Code pattern analysis (2026-03-31). They represent patterns observed in advanced agentic systems, adapted for DiriCode's tool-first architecture.
+
+### DC-TOOL-013: Bulk Operation Runner
+**Iteration**: MVP-2
+**Priority**: P1
+
+**Description**:
+Execute the same operation across multiple files/targets as a single atomic operation. Optimizes token usage through context batching. Supports sequential and parallel execution modes with per-target status reporting.
+
+**Acceptance Criteria**:
+- [ ] Accepts list of targets (files/paths/globs)
+- [ ] Accepts operation definition (tool name + params template)
+- [ ] Configurable sequential or parallel execution
+- [ ] Respects maxConcurrency limit
+- [ ] Aggregated result with per-target status
+- [ ] Rollback on failure (atomic mode)
+- [ ] Progress events emitted
+
+**Dependencies**: DC-TOOL-001..012
+
+---
+
+### DC-TOOL-014: Iterative Refinement Engine
+**Iteration**: MVP-1 (PRIORITY)
+**Priority**: P0
+
+**Description**:
+Automatic "execute → verify → correct" loop with configurable success condition and stuck detection. Manages iteration cycle, monitors progress, and stops when goal achieved or stuck/limit reached. Addresses the common agent pattern of running tests until they pass.
+
+**Acceptance Criteria**:
+- [ ] Definable goal (success condition)
+- [ ] Configurable operation in loop (tool + command)
+- [ ] Max iterations limit (default: 10)
+- [ ] Stuck detection: no progress in N iterations
+- [ ] Cost tracking per iteration
+- [ ] Auto-stop when goal achieved
+- [ ] Failure escalation after max iterations
+
+**Dependencies**: DC-TOOL-015
+
+---
+
+### DC-TOOL-015: Change Verification Agent
+**Iteration**: MVP-2
+**Priority**: P1
+
+**Description**:
+Isolated verification tool that checks changes without polluting the main agent's context. Runs as an independent context with dedicated verification prompt. Returns structured verdict (PASS/FAIL/WARN) with reasoning and suggestions.
+
+**Acceptance Criteria**:
+- [ ] Isolated execution context
+- [ ] Input: diff/changed files/original request
+- [ ] Output: verdict (PASS/FAIL/WARN) + confidence + reasoning + suggestions
+- [ ] Integration with LSP diagnostics
+- [ ] Configurable check types: syntax, types, tests, lsp
+- [ ] Optional separate model for verification
+
+**Dependencies**: DC-TOOL-001..007, DC-TOOL-008
+
+---
+
+### DC-TOOL-016: Diagnostic Analyzer
+**Iteration**: MVP-1 (PRIORITY)
+**Priority**: P0
+
+**Description**:
+Structured error analysis tool — analyzes root cause without attempting to fix. Aggregates context from multiple sources (stack traces, logs, LSP diagnostics, git diff) and produces a diagnosis report with hypotheses and evidence.
+
+**Acceptance Criteria**:
+- [ ] Aggregates: stack traces, logs, LSP diagnostics, git diff
+- [ ] Root cause analysis with confidence score
+- [ ] Timeline reconstruction
+- [ ] Hypothesis generation with supporting evidence
+- [ ] Output: diagnosis report with recommendations
+
+**Dependencies**: DC-TOOL-004, DC-TOOL-007, DC-TOOL-008
+
+---
+
+### DC-TOOL-017: Context Compactor
+**Iteration**: MVP-2
+**Priority**: P1
+
+**Description**:
+Reduces context size by compressing, summarizing, or extracting key information. Used when context window fills up. Supports extractive and abstractive strategies with configurable preservation criteria and lossless archiving mode.
+
+**Acceptance Criteria**:
+- [ ] Input: text/context to compress with target compression ratio
+- [ ] Preservation criteria (what MUST stay)
+- [ ] Content type-aware compression (conversation/code/logs)
+- [ ] Lossless mode: archive original before compression
+- [ ] Output: compressed text + compression stats
+
+**Dependencies**: ADR-016 (Context Management), ADR-017 (Condenser Pipeline)
+
+---
+
+### DC-TOOL-018: Pattern Recorder
+**Iteration**: MVP-2
+**Priority**: P1
+
+**Description**:
+Records sequences of tool calls as reusable workflows ("patterns"). Users can record a successful solution sequence and replay it later on similar problems. Supports auto-recording and manual definition, with full parameterization and versioning.
+
+**Acceptance Criteria**:
+- [ ] Recording mode: capture tool calls + context
+- [ ] Pattern storage: JSON/YAML definition in SQLite
+- [ ] Pattern execution: replay with variable substitution
+- [ ] Pattern library: browse and search saved patterns
+- [ ] Pattern sharing: export/import
+- [ ] Versioning support
+- [ ] Validation: check if pattern still applies
+- [ ] Synergy with ReasoningBank: patterns can reference reasoning records
+
+**Dependencies**: DC-TOOL-001..012, SQLite storage (ADR-018)
+
+**References**: `.sisyphus/drafts/pattern-recorder-spec.md`
+
+---
+
+## Cross-References (Post-ADR Review)
+
+- **DC-SAFE-006** (Permission Context Engine): All mutating tools (file-write, file-edit, bash, git) are gated by the permission context engine. Context type (Coordinator/Interactive/SwarmWorker) determines whether auto-allow, ask, or always-allow applies per operation.
+- **DC-MEM-R001** (ReasoningBank v2) + **DC-MEM-R002** (MemoryDir): DC-TOOL-018 (Pattern Recorder) has planned synergy with the memory systems — recorded tool patterns can reference ReasoningBank entries, creating a "how to think + what to do" pairing. Both memory systems are v2 and research-required before implementation.

--- a/docs/v2/memory-systems.md
+++ b/docs/v2/memory-systems.md
@@ -1,0 +1,61 @@
+# Memory Systems (v2 Roadmap)
+
+> **Status**: Research Required — Not yet designed or implemented  
+> **Scope**: v2  
+> **Last updated**: 2026-03-31
+
+---
+
+## Overview
+
+DiriCode will ship two complementary memory systems in v2:
+
+| System | Purpose | Status |
+|--------|---------|--------|
+| **ReasoningBank** | Problem-solving memory — stores how agents solved problems | Research required (DC-MEM-001) |
+| **MemoryDir** | General knowledge memory — stores facts, preferences, team conventions | Research required (DC-MEM-002) |
+
+These are separate systems with distinct storage mechanisms, retrieval strategies, and integration points. They are complementary, not competing: ReasoningBank records *how* to solve problems, MemoryDir stores *what* was learned.
+
+## ReasoningBank
+
+See: [`docs/adr/adr-045-reasoningbank.md`](../adr/adr-045-reasoningbank.md)
+
+**Format**: Structured records — `{ problem, approach, outcome, confidence, agentType, tags }`  
+**Storage**: SQLite + FTS5 + sqlite-vec (semantic embeddings)  
+**Integration**: Hook-based (pre-agent injection, post-agent recording)  
+**Retrieval**: Semantic similarity + keyword pre-filter
+
+**Research issue**: DC-MEM-001
+
+## MemoryDir
+
+Inspired by Claude Code's `memdir` subsystem. General-purpose memory for facts, user preferences, project patterns, and team knowledge.
+
+**Format**: Flexible (facts, preferences, patterns, team knowledge)  
+**Storage**: TBD — file-based or SQLite (research required)  
+**Integration**: Explicit API (not hook-based)  
+**Retrieval**: Context-aware + keyword + recency
+
+**Research issue**: DC-MEM-002
+
+## Synergy
+
+Both systems will eventually work together:
+- ReasoningBank records reasoning patterns from agent problem-solving
+- MemoryDir stores team conventions and project-specific facts
+- Pattern Recorder (DC-TOOL-018) generates entries for both systems
+
+## Research Plan
+
+Both systems require deep research before design:
+1. Clone and analyze reference repositories (see DC-MEM-001, DC-MEM-002 for full lists)
+2. Extract patterns, storage schemas, and retrieval mechanisms
+3. Design DiriCode-specific architecture
+4. Create implementation ADRs
+
+**Estimated timeline**: ~7-9 sprints each (research + design + implementation)
+
+---
+
+*This is a planning placeholder. Implementation details will be added after the research phase is complete.*

--- a/docs/v2/permission-context.md
+++ b/docs/v2/permission-context.md
@@ -1,0 +1,57 @@
+# Permission Context Engine (v2 Roadmap)
+
+> **Status**: Phase 1 accepted for MVP-2, Phase 2 planned for v2  
+> **Scope**: MVP-2 (Phase 1) + v2 (Phase 2)  
+> **Last updated**: 2026-03-31
+
+---
+
+## Overview
+
+The Permission Context Engine extends DiriCode's safety system to support context-aware permission decisions across multiple execution modes.
+
+## Phase 1 — Core (MVP-2)
+
+See: [`docs/adr/adr-051-permission-context-engine-phase1.md`](../adr/adr-051-permission-context-engine-phase1.md)
+
+**Delivers**:
+- Four context handlers: `CoordinatorHandler`, `InteractiveHandler`, `SwarmWorkerHandler`, `DefaultHandler`
+- Four permission levels: `always-allow`, `auto-allow`, `ask`, `never-allow`
+- SQLite-backed audit logging of all permission decisions
+
+**Issues**: DC-SAFE-006a, DC-SAFE-006b, DC-SAFE-006c  
+**Epic**: `docs/mvp/epic-safety.md`
+
+## Phase 2 — Smart Features (v2)
+
+See: [`docs/adr/adr-052-permission-context-engine-phase2.md`](../adr/adr-052-permission-context-engine-phase2.md)
+
+**Delivers**:
+- Prefix-level and pattern blocking (block entire tool categories)
+- `/permissions` management command
+- Cross-session learning (detect and suggest based on past decisions)
+- Semantic risk analysis (AST-grep integration for risk scoring)
+
+**Issues**: DC-SAFE-006d, DC-SAFE-006e, DC-SAFE-006f, DC-SAFE-006g
+
+## Context Types
+
+| Context | Description | Default for risky ops |
+|---------|------------|----------------------|
+| **Interactive** | User at keyboard | Always ask |
+| **Coordinator** | Orchestrating sub-agents | Ask for destructive, auto for risky |
+| **SwarmWorker** | Background autonomous agent | Ask for destructive, auto for risky |
+| **Default** | Fallback | Preserves DC-SAFE-005 behavior |
+
+## Permission Levels
+
+| Level | Behavior |
+|-------|---------|
+| `always-allow` | Never prompt, execute immediately |
+| `auto-allow` | Prompt once per session, remember |
+| `ask` | Prompt every time |
+| `never-allow` | Always block, no override |
+
+---
+
+*Phase 1 is in active planning for MVP-2. Phase 2 is roadmap intent for v2.*


### PR DESCRIPTION
## Summary

Applies findings from the Claude Code pattern survey to the DiriCode repository.

### New ADRs
- **ADR-051**: Permission Context Engine Phase 1 (DC-SAFE-006a/b/c)
- **ADR-052**: Permission Context Engine Phase 2 (smart features, v2)
- **ADR-053**: Router cost tracking (DC-ROUTER-020/021/022)
- **ADR-045**: Updated with MemoryDir relationship addendum

### New v2 Research Docs
- `docs/v2/memory-systems.md` — ReasoningBank + MemoryDir research plan (DC-MEM-R001/R002)
- `docs/v2/permission-context.md` — Permission engine Phase 2 design

### Epic & Project Updates
- `epic-tools.md` — DC-TOOL-013..018 added
- `epic-safety.md` — DC-SAFE-006 + cross-references
- `epic-router.md` — DC-ROUTER-020/021/022 + cross-references
- `epic-skills.md` — cross-references appended
- `docs/mvp/dependency-graph.md` — new cross-epic dependency map
- `README.md` and `docs/adr/README.md` — updated with new entries

### GitHub Issues Created
Issues #479–492 created in Project #4 (DC-TOOL-013..018, DC-SAFE-006a/b/c, DC-ROUTER-020/021/022, DC-MEM-R001/R002) with sprint assignments (Sprint 3 & 4).

> Note: Pre-existing test failures (`turndown` missing package) are unrelated to this PR — confirmed failures exist on `main` HEAD before these changes.