### PR TITLE
docs: update ADRs, MVP epics, README and planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ These parts are already real in the repository:
   - SSE transport
   - event emission foundations
 - **Provider layer**
-  - provider registry
-  - router foundations
-  - model scoring / experiment primitives
-  - LLM Picker design (ADR-049)
+  - Vercel AI SDK as transport layer (ADR-054) — `@ai-sdk/github`, `@ai-sdk/google`, `@ai-sdk/moonshotai`
+  - `createProviderRegistry()` for unified model access
+  - static Model Cards (`ModelDescriptor`) for metadata the SDK doesn't expose (context window, capabilities, pricing tier)
+  - error classifier, retry engine, fallback chain (ADR-025)
+  - LLM Picker decision engine (ADR-049) — 3-tier ML cascade for intelligent model selection
 
 The biggest remaining gap is **integration**, not “missing ideas.”
 
@@ -133,9 +134,10 @@ graph TD
     end
 
     subgraph Providers
-        Registry[Provider registry]
-        Picker[LLM Picker]
-        Router[Routing foundations]
+        AISDK[Vercel AI SDK Transport]
+        Cards[Model Cards - static metadata]
+        Picker[LLM Picker - decision engine]
+        ErrorClassifier[Error Classifier + Retry]
     end
 
     CLI --> API
@@ -151,8 +153,9 @@ graph TD
     Dispatcher --> SQLite
     Specialists --> SQLite
     Specialists --> Picker
-    Picker --> Router
-    Router --> Registry
+    Picker --> Cards
+    Picker --> AISDK
+    AISDK --> ErrorClassifier
 ```
 
 ## Key Architectural Decisions
@@ -244,22 +247,22 @@ docs/
 
 ## Current Status
 
-| Area                                          | Status          | Notes                                                             |
-| --------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| Dispatcher / delegation                       | ✅ Partial-real | Strong runtime foundation exists                                  |
-| Tool layer                                    | ✅ Partial-real | File/search/bash/LSP/AST foundations exist                        |
-| SQLite memory backbone                        | ✅ Partial-real | Repositories and local-first direction are real                   |
-| SSE / transport                               | ✅ Partial-real | Transport exists; full event model still in progress              |
-| Provider layer                                | ✅ Partial-real | Registry exists; richer routing still evolving                    |
-| LLM Picker                                    | 📐 Designed     | ADR-049 accepted; implementation in MVP-2                         |
-| End-to-end pipeline                           | 🏗️ In progress  | Core integration still being wired                                |
-| Checkpoint / resume                           | 🏗️ In progress  | Explicit MVP-1 requirement                                        |
-| Semantic navigation / refactoring             | 🏗️ In progress  | High-priority prototype multiplier                                |
-| Full context budgeting / compaction           | 📋 Later        | Deliberately not first-wave                                       |
-| Full swarm / broad autonomy                   | 📋 Later        | Architectural direction kept, delivery delayed                    |
-| Permission Context Engine                     | 📐 Designed     | ADR-051/052 accepted; Faza 1 in MVP-2, smart features in v2       |
-| Router Cost Tracking                          | 📐 Designed     | ADR-053 accepted; router-centric, API + subscription types; MVP-2 |
-| Memory Systems (ReasoningBank v2 + MemoryDir) | 🔬 Research     | Two systems; deep research required before implementation; v2     |
+| Area                                          | Status          | Notes                                                                   |
+| --------------------------------------------- | --------------- | ----------------------------------------------------------------------- |
+| Dispatcher / delegation                       | ✅ Partial-real | Strong runtime foundation exists                                        |
+| Tool layer                                    | ✅ Partial-real | File/search/bash/LSP/AST foundations exist                              |
+| SQLite memory backbone                        | ✅ Partial-real | Repositories and local-first direction are real                         |
+| SSE / transport                               | ✅ Partial-real | Transport exists; full event model still in progress                    |
+| Provider layer                                | ✅ Partial-real | Vercel AI SDK transport (ADR-054); Model Cards + error classifier exist |
+| LLM Picker                                    | 📐 Designed     | ADR-049 accepted; AI SDK is transport, Model Cards are metadata         |
+| End-to-end pipeline                           | 🏗️ In progress  | Core integration still being wired                                      |
+| Checkpoint / resume                           | 🏗️ In progress  | Explicit MVP-1 requirement                                              |
+| Semantic navigation / refactoring             | 🏗️ In progress  | High-priority prototype multiplier                                      |
+| Full context budgeting / compaction           | 📋 Later        | Deliberately not first-wave                                             |
+| Full swarm / broad autonomy                   | 📋 Later        | Architectural direction kept, delivery delayed                          |
+| Permission Context Engine                     | 📐 Designed     | ADR-051/052 accepted; Faza 1 in MVP-2, smart features in v2             |
+| Router Cost Tracking                          | 📐 Designed     | ADR-053 accepted; router-centric, API + subscription types; MVP-2       |
+| Memory Systems (ReasoningBank v2 + MemoryDir) | 🔬 Research     | Two systems; deep research required before implementation; v2           |
 
 ## Getting Started
 
@@ -299,9 +302,11 @@ The project is still in active architectural shaping. If you want to understand 
 
 1. `docs/adr/adr-002-dispatcher-first-agent-architecture.md`
 2. `docs/adr/adr-013-project-pipeline.md`
-3. `docs/adr/adr-031-observability-eventstream-agent-tree.md`
-4. `docs/adr/adr-048-sqlite-issue-system.md`
-5. `docs/mvp/index.md`
+3. `docs/adr/adr-054-ai-sdk-transport-layer.md`
+4. `docs/adr/adr-049-llm-picker.md`
+5. `docs/adr/adr-031-observability-eventstream-agent-tree.md`
+6. `docs/adr/adr-048-sqlite-issue-system.md`
+7. `docs/mvp/index.md`
 
 ## License
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@
 | [051](adr-051-permission-context-engine-phase1.md) | Permission Context Engine: Phase 1 (Core) | MVP-2 | Safety |
 | [052](adr-052-permission-context-engine-phase2.md) | Permission Context Engine: Phase 2 (Smart) | v2 | Safety |
 | [053](adr-053-router-cost-tracking.md) | Router-Centric Cost Tracking | MVP-2+v2 | Router |
+| [054](adr-054-ai-sdk-transport-layer.md) | Vercel AI SDK as Transport Layer | MVP-1 | Router |
 
 ## Template
 

--- a/docs/adr/adr-025-native-ts-router-fallback-chain.md
+++ b/docs/adr/adr-025-native-ts-router-fallback-chain.md
@@ -5,7 +5,7 @@
 | Status      | Accepted                                      |
 | Date        | 2026-03-09                                    |
 | Scope       | MVP                                           |
-| References  | analiza-router.md                             |
+| References  | analiza-router.md, ADR-054                   |
 
 ### Context
 

--- a/docs/adr/adr-042-multi-subscription-management.md
+++ b/docs/adr/adr-042-multi-subscription-management.md
@@ -5,7 +5,7 @@
 | Status      | Accepted                                                      |
 | Date        | 2026-03-21                                                    |
 | Scope       | MVP-2 (subscription rotation), v2 (quality scoring), v3 (A/B testing) |
-| References  | ADR-004 (agent roster 3 tiers), ADR-005 (families), ADR-006 (4 fallback types), ADR-025 (native TS router + fallback chain), Survey Decision E1 |
+| References  | ADR-004 (agent roster 3 tiers), ADR-005 (families), ADR-006 (4 fallback types), ADR-025 (native TS router + fallback chain), ADR-054 (Vercel AI SDK transport layer), Survey Decision E1 |
 
 ### Context
 
@@ -408,4 +408,20 @@ Dispatcher/Agent ──► Picker (ADR-049) ──► SubscriptionRouter (this A
 The Picker consumes subscription health data from this ADR to inform cost and latency estimates in its scoring algorithm, but it does not manage subscription state itself. The SubscriptionRouter's auto-recovery, cooldown, and rotation logic remain unchanged.
 
 When the Picker is unavailable (e.g., during bootstrap or failure), the existing `ModelTierResolver` + SubscriptionRouter path serves as a degraded fallback — static tier mapping without policy scoring.
+
+### Addendum — Vercel AI SDK Provider Registry (2026-04-01)
+
+ADR-054 establishes Vercel AI SDK (`@ai-sdk/*`) as the LLM transport layer. This affects how the SubscriptionRouter interacts with provider APIs:
+
+**What changes:**
+- The SubscriptionRouter no longer calls provider APIs directly. Instead, it resolves the target subscription's credentials and passes them to the AI SDK provider registry (`createProviderRegistry()` from the `ai` package).
+- AI SDK handles all HTTP transport (`generateText()`, `streamText()`), protocol normalization, and streaming primitives.
+- Post-call health data extraction (`response.headers` for rate-limit headers, `usage` for token counts) comes from AI SDK response objects rather than raw HTTP responses.
+
+**What does NOT change:**
+- The `Subscription` entity, `SubscriptionHealth` tracking, routing strategy (filter → exclude → rank → select), cooldown logic, and auto-recovery all remain unchanged.
+- The 3D model classification (Tier × Family × ContextGroup) remains unchanged.
+- Static **Model Cards** (`ModelDescriptor[]`) are bundled per provider for metadata AI SDK doesn't expose (context window, capabilities, pricing tier). These cards feed into the routing strategy's cost and capability scoring.
+
+See `docs/adr/adr-054-ai-sdk-transport-layer.md` for the full AI SDK adoption decision.
 

--- a/docs/adr/adr-049-llm-picker.md
+++ b/docs/adr/adr-049-llm-picker.md
@@ -245,3 +245,26 @@ Persistent storage uses 6 tables: `models`, `policies`, `decisions`, `execution_
 | Phase 4 | ML Cascade | ONNX setup, Tier 2 (BERT), Tier 3 (TinyLLM), Orchestrator |
 | Phase 5 | Dashboard | All UI tabs (Map, Logs, Rules, Analytics) |
 | Phase 6 | Optimization | Auto-training pipeline, historical analytics |
+
+### Addendum — Vercel AI SDK as Transport Layer (2026-04-01)
+
+ADR-054 establishes Vercel AI SDK (`@ai-sdk/*`) as the LLM transport layer for DiriCode. This has specific implications for the Picker's provider interface:
+
+**What changes:**
+- The `ProviderAdapter` interface (Section 7) no longer needs to handle raw HTTP transport to LLM APIs. All `generateText()` / `streamText()` calls go through AI SDK provider packages (`@ai-sdk/github`, `@ai-sdk/moonshotai`, `@ai-sdk/google`, etc.).
+- Provider adapters become **metadata + health reporters** rather than transport wrappers. Their primary job is to supply static **Model Cards** (`ModelDescriptor[]`) — metadata AI SDK does not expose (context window, max output, capabilities, pricing tier, tool-call support).
+- Post-call data from AI SDK (`usage.inputTokens`, `usage.outputTokens.reasoning`, `response.headers` for rate-limit extraction) feeds into the Picker's feedback loop and subscription health tracking.
+
+**What does NOT change:**
+- The Picker remains a pure **decision engine** — it never makes LLM API calls.
+- The 3-tier ML cascade, policy scoring, candidate ranking, and explainability trace are unaffected.
+- The `ModelResolver` interface, `DecisionRequest`/`DecisionResponse` contracts, and SQLite persistence are unaffected.
+- All 6 delivery phases remain valid.
+
+**Two-registry architecture:**
+```
+Model Card Registry (ours)     →  "should I pick this model?" (Picker decision)
+AI SDK Provider Registry       →  "can I call this model?" (transport execution)
+```
+
+See `docs/adr/adr-054-ai-sdk-transport-layer.md` for the full AI SDK adoption decision.

--- a/docs/adr/adr-054-ai-sdk-transport-layer.md
+++ b/docs/adr/adr-054-ai-sdk-transport-layer.md
@@ -1,0 +1,167 @@
+# ADR-054 — Vercel AI SDK as Transport Layer
+
+| Field       | Value                                                                                          |
+|-------------|------------------------------------------------------------------------------------------------|
+| Status      | Accepted                                                                                       |
+| Date        | 2026-04-01                                                                                     |
+| Scope       | MVP-1 (transport migration), MVP-2 (LLM Picker integration)                                   |
+| References  | ADR-025, ADR-042, ADR-049, Vercel AI SDK v4                                                    |
+
+### Context
+
+DiriCode's provider layer (`@diricode/providers`) currently defines a custom `Provider` interface (`isAvailable`, `generate`, `stream`) and custom per-provider adapters (GeminiProvider, KimiProvider, etc.). Alongside this, the LLM Picker (ADR-049) requires a separate metadata layer — `ModelDescriptor`, `ModelQuota`, `ProviderAdapter` — for intelligent model selection.
+
+Maintaining custom transport adapters is redundant work. The **Vercel AI SDK** (`ai`, `@ai-sdk/*`) already provides:
+
+1. **Unified `LanguageModelV4` interface** with `doGenerate()` and `doStream()` methods — identical to our `Provider.generate()` / `Provider.stream()`.
+2. **Official provider packages** for all DiriCode-supported providers:
+   - `@ai-sdk/github` — GitHub Copilot / GitHub Models
+   - `@ai-sdk/google` — Google Gemini
+   - `@ai-sdk/moonshotai` — Kimi (Moonshot AI)
+   - `@ai-sdk/alibaba` — Qwen / Alibaba
+   - `vercel-minimax-ai-provider` — MiniMax (community, MiniMax-maintained)
+   - Community providers for z.ai / Zhipu
+3. **`createProviderRegistry()`** — a built-in registry for aggregating multiple providers under a single lookup, replacing our custom `Registry`.
+4. **Rich post-call metadata** — `usage.inputTokens`, `usage.outputTokens.reasoning`, `response.headers` (for rate limit extraction), `finishReason`.
+
+However, AI SDK's `LanguageModelV4` interface has **zero model metadata**:
+
+```typescript
+type LanguageModelV4 = {
+  readonly specificationVersion: 'v4';
+  readonly provider: string;        // e.g. "google.generative-ai"
+  readonly modelId: string;         // e.g. "gemini-2.5-flash"
+  supportedUrls: Record<string, RegExp[]>;
+  doGenerate(options): PromiseLike<...>;
+  doStream(options): PromiseLike<...>;
+}
+```
+
+No `contextWindow`, no `maxOutput`, no capability flags (`canReason`, `toolCall`, `vision`), no pricing data. Some providers have internal capability detection (e.g., OpenAI's private `getOpenAILanguageModelCapabilities()`) but none expose it on the interface.
+
+**Community research confirms the gap is universal.** Projects using AI SDK maintain separate model metadata through:
+
+- **Static bundles**: `llm-info` (npm), `@continuedev/llm-info` (Continue IDE) — hardcoded model cards
+- **Community catalogs**: `models.dev` (3,100+ stars, used by LangChain and Mastra) — TOML-based model registry
+- **Live APIs**: `pricetoken` (Bayesian-scored pricing), Vercel AI Gateway (`/v1/models` endpoint)
+- **In-app registries**: Every serious AI SDK project maintains its own model card layer
+
+This confirms that DiriCode's `ModelDescriptor` / `ModelQuota` / `ProviderAdapter` layer is not only valid but industry-standard practice.
+
+### Decision
+
+Adopt **Vercel AI SDK as the transport layer** for all LLM communication, while preserving DiriCode's **Model Card layer** (`ModelDescriptor`, `ModelQuota`, `ProviderAdapter`) as the metadata/decision layer for the LLM Picker.
+
+#### 1. Two Parallel Registries
+
+```
+Model Card Registry (ours)          →  "should I pick this model?" (routing decision)
+AI SDK Provider Registry            →  "can I call this model?" (transport execution)
+```
+
+- **Model Card Registry** (`ProviderAdapter.listModels()` → `ModelDescriptor[]`) provides context window, capabilities, pricing tier, and quota data for the LLM Picker's scoring engine.
+- **AI SDK Provider Registry** (`createProviderRegistry()`) provides callable `LanguageModelV4` instances for actual LLM communication.
+
+Both registries are keyed by `(providerId, modelId)` — they are two views of the same model.
+
+#### 2. Transport Layer Migration
+
+Replace the custom `Provider` interface with AI SDK:
+
+| Before (Custom)                         | After (AI SDK)                              |
+|-----------------------------------------|---------------------------------------------|
+| `Provider.generate(options)`            | `generateText({ model, ... })`              |
+| `Provider.stream(options)`              | `streamText({ model, ... })`                |
+| `Provider.isAvailable()`               | Provider constructor (throws on bad auth)   |
+| `Registry.register(provider)`           | `createProviderRegistry({ ... })`           |
+| `Registry.get(name)`                    | `registry.languageModel("provider:model")`  |
+| `GeminiProvider` (custom)               | `@ai-sdk/google` (official)                 |
+| `KimiProvider` (custom)                 | `@ai-sdk/moonshotai` (official)             |
+| `CopilotProvider` (custom via ai-sdk)   | `@ai-sdk/github` (already used internally)  |
+
+#### 3. Model Cards Remain Bundled (No SQLite)
+
+Model card data (`ModelDescriptor`) must be **statically bundled** with the application — as TypeScript constants or JSON files, one entry per `(provider, modelId)`. This ensures:
+
+- Model metadata is available **without runtime database access**
+- Cards ship as part of the application bundle
+- Updates require code changes (intentional — model metadata changes are breaking decisions, not runtime data)
+
+```typescript
+// Example: packages/providers/src/model-cards/google.ts
+export const googleModelCards: ModelDescriptor[] = [
+  {
+    apiModel: "gemini-2.5-flash",
+    contextWindow: 1048576,
+    maxOutput: 8192,
+    canReason: true,
+    toolCall: true,
+    vision: true,
+    attachment: true,
+    quotaMultiplier: 1,
+  },
+  // ...
+];
+```
+
+#### 4. Post-Call Data Extraction
+
+AI SDK's `generateText` / `streamText` return rich metadata that feeds back into the LLM Picker:
+
+- `usage.inputTokens.total` / `.cacheRead` / `.cacheWrite` — for cost tracking
+- `usage.outputTokens.total` / `.reasoning` — reasoning token separation for pricing
+- `response.headers` — extract `x-ratelimit-remaining-*` for reactive quota updates in `ModelQuota`
+- `finishReason` — success/failure detection for feedback loop
+
+#### 5. Error Classification Preserved
+
+The custom error classifier (ADR-025, DC-PROV-003) remains as middleware around AI SDK calls. AI SDK throws provider-specific errors; our classifier normalizes them to the 7-kind `ProviderErrorKind` enum. This is consistent with the existing architecture — the classifier was already designed to wrap raw errors.
+
+#### 6. What Gets Deleted
+
+- `packages/providers/src/providers/gemini.ts` — replaced by `@ai-sdk/google`
+- `packages/providers/src/providers/kimi.ts` — replaced by `@ai-sdk/moonshotai`
+- Custom `Provider` interface (`isAvailable`, `generate`, `stream`) — replaced by `LanguageModelV4`
+- Custom `Registry` class — replaced by `createProviderRegistry()`
+
+#### 7. What Gets Kept
+
+- `ModelDescriptor` — model metadata for LLM Picker decisions
+- `ModelQuota` — per-model quota tracking
+- `ProviderAdapter` — interface for listing models and quotas per provider
+- `ProviderErrorKind` / `ClassifiedError` — error normalization layer
+- `ProviderRouter` — error-kind-based routing logic (wraps AI SDK calls)
+- Stream Manager — timeout/lifecycle management around AI SDK streams
+
+### Consequences
+
+- **Positive:**
+  - Eliminates ~500 lines of custom provider adapter code
+  - Official SDK packages are maintained by Vercel and provider teams — bug fixes, new models, API changes handled upstream
+  - `createProviderRegistry()` gives us string-based model lookup (`"google:gemini-2.5-flash"`) matching AI SDK ecosystem conventions
+  - Post-call `usage` data is richer than what our custom adapters captured (cache tokens, reasoning tokens)
+  - Community tooling (tracing, observability) works out of the box with AI SDK
+  - Model cards remain fully under our control — no dependency on AI SDK for metadata
+
+- **Negative:**
+  - Must maintain model card data manually (mitigated: can augment with `llm-info`, `models.dev`, or `pricetoken` packages)
+  - AI SDK version upgrades may require adapter updates (mitigated: we only use the stable `LanguageModelV4` interface)
+  - Two registries to keep in sync (mitigated: both keyed by same `providerId:modelId`, can validate at startup)
+
+- **Neutral:**
+  - Error classifier wrapping pattern is unchanged — it already assumed raw errors from providers
+  - LLM Picker architecture (ADR-049) is completely unaffected — it only consumes `ModelDescriptor` and `ModelQuota`, never calls providers directly
+
+### Community Metadata Patterns (Research Summary)
+
+For future reference, these are the established patterns for model metadata alongside AI SDK:
+
+| Package/Source | Type | Coverage | Key Feature |
+|---|---|---|---|
+| `llm-info` | Static npm bundle | 50+ models | Tokenizer IDs for `@xenova/transformers` |
+| `@continuedev/llm-info` | Static npm bundle | 100+ models | Regex-based model ID matching |
+| `models.dev` | Community catalog | 600+ models | TOML files, used by LangChain/Mastra |
+| `pricetoken` | Live API + seed data | 200+ models | Bayesian confidence scoring for pricing |
+| Vercel AI Gateway | Dynamic API | All AI SDK models | `/v1/models` with context_window, pricing |
+
+DiriCode may adopt one or more of these as **seed data sources** for `ModelDescriptor` initialization, while maintaining the authority to override values based on operational experience.

--- a/docs/mvp/epic-llm-picker.md
+++ b/docs/mvp/epic-llm-picker.md
@@ -186,17 +186,23 @@ The scorer calculates a final score based on:
 
 ## Phase 2 — Providers (Sub-epic #391)
 
+> **AI SDK Integration (ADR-054):** Phase 2 adapters are thin wrappers around Vercel AI SDK's `@ai-sdk/*` provider packages for transport. Each adapter's primary job is to supply **static Model Cards** (`ModelDescriptor[]`) — metadata AI SDK doesn't expose (context window, capabilities, pricing tier, tool-call support) — and wire health/rate-limit reporting into the Picker's scoring engine. The actual LLM transport (`generateText`, `streamText`) is handled by AI SDK.
+
 ### Issue: DC-LLP-008 — ProviderAdapter interface + GitHub adapter
 
 **GitHub**: #403 | **Sub-epic**: #391
 
 #### Description
-Define the `ProviderAdapter` interface for external model providers and implement the GitHub Models adapter.
+Define the `ProviderAdapter` interface for external model providers and implement the GitHub Models adapter. Transport uses `@ai-sdk/github` (ADR-054); the adapter focuses on metadata and health reporting that AI SDK does not provide.
 
 #### Acceptance Criteria
-- [ ] Unified interface for model discovery and capability reporting.
-- [ ] GitHub adapter supports token-based authentication and model listing.
+- [ ] Unified `ProviderAdapter` interface for model discovery and capability reporting.
+- [ ] GitHub adapter uses `@ai-sdk/github` for transport; supplies static `ModelDescriptor[]` for Copilot-accessible models.
+- [ ] Health/rate-limit state extracted from AI SDK response headers (`usage`, `response.headers`).
 - [ ] Error handling for provider-specific rate limits.
+
+#### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md` (AI SDK adoption, two-registry architecture)
 
 #### Dependencies
 - Depends on: DC-LLP-001
@@ -208,11 +214,15 @@ Define the `ProviderAdapter` interface for external model providers and implemen
 **GitHub**: #404 | **Sub-epic**: #391
 
 #### Description
-Implement the adapter for the z.ai model provider.
+Implement the adapter for the z.ai model provider. Transport via community AI SDK provider package; adapter supplies static `ModelDescriptor[]` and maps z.ai capabilities to DiriCode tags.
 
 #### Acceptance Criteria
-- [ ] Integration with z.ai API for model metadata.
+- [ ] Integration with z.ai via AI SDK-compatible provider package for transport.
+- [ ] Static `ModelDescriptor[]` bundled for z.ai models (context window, capabilities, pricing).
 - [ ] Correct mapping of z.ai capabilities to internal DiriCode tags.
+
+#### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md`
 
 ---
 
@@ -221,11 +231,15 @@ Implement the adapter for the z.ai model provider.
 **GitHub**: #405 | **Sub-epic**: #391
 
 #### Description
-Implement the adapter for the MiniMax AI provider.
+Implement the adapter for the MiniMax AI provider. Transport via `vercel-minimax-ai-provider` (community, MiniMax-maintained); adapter supplies static `ModelDescriptor[]`.
 
 #### Acceptance Criteria
-- [ ] Full support for MiniMax model registry.
-- [ ] Latency tracking for MiniMax endpoints.
+- [ ] Transport via `vercel-minimax-ai-provider` AI SDK package.
+- [ ] Static `ModelDescriptor[]` bundled for MiniMax models.
+- [ ] Latency tracking for MiniMax endpoints via AI SDK response metadata.
+
+#### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md`
 
 ---
 
@@ -234,11 +248,16 @@ Implement the adapter for the MiniMax AI provider.
 **GitHub**: #406 | **Sub-epic**: #391
 
 #### Description
-Enhance the existing Kimi provider adapter to support the new `ProviderAdapter` interface and reporting requirements.
+Enhance the existing Kimi provider adapter to support the new `ProviderAdapter` interface and reporting requirements. Transport via `@ai-sdk/moonshotai` (official AI SDK package); adapter supplies static `ModelDescriptor[]`.
 
 #### Acceptance Criteria
+- [ ] Kimi transport via `@ai-sdk/moonshotai` (thin OpenAI-compatible wrapper).
+- [ ] Static `ModelDescriptor[]` bundled for Kimi models with capabilities and pricing.
 - [ ] Kimi models correctly reported to the Picker registry.
 - [ ] Support for Kimi-specific tool-calling flags.
+
+#### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md`
 
 ---
 
@@ -597,7 +616,7 @@ Add time-series visualizations for long-term trends in model efficiency, cost, a
 - Must NOT skip ONNX/ML tiers — they are non-negotiable for the cascade.
 - Must NOT separate dashboard into multiple panels — must be one panel with tabs.
 - Must NOT make LLM API calls from the Picker — it is a decision engine only.
-- Must NOT handle streaming, retries, or provider failures — those remain with ADR-025/ADR-042.
+- Must NOT handle streaming, retries, or provider failures — those remain with the AI SDK transport layer (ADR-025/ADR-054) and SubscriptionRouter (ADR-042).
 - Must NOT store conversation content or agent outputs — only decision metadata and metrics.
 
 ---
@@ -605,6 +624,8 @@ Add time-series visualizations for long-term trends in model efficiency, cost, a
 ## Dependencies
 
 ### Upstream / External
+- Vercel AI SDK provider packages (`@ai-sdk/*`) for LLM transport (ADR-054); Phase 2 adapters wrap these.
+- Static Model Cards (`ModelDescriptor[]`) bundled per provider for metadata AI SDK doesn't expose.
 - Existing model registry data (provider capabilities, pricing) for seed data.
 - WebSocket infrastructure coexisting with SSE (ADR-001).
 - React Flow library for LineageGraph visualization.
@@ -612,7 +633,7 @@ Add time-series visualizations for long-term trends in model efficiency, cost, a
 - ONNX Runtime for Tier 2/3 classification.
 
 ### Cross-epic
-- **epic-router**: Picker feeds recommendations into the retry/fallback pipeline.
+- **epic-router**: Picker feeds recommendations into the AI SDK transport + retry/fallback pipeline (ADR-054, ADR-025).
 - **epic-memory**: Picker uses SQLite repositories for persistence.
 - **epic-observability**: Picker emits events through the EventStream.
 - **epic-agents-core**: Agent requests flow through the Picker resolver.

--- a/docs/mvp/epic-router.md
+++ b/docs/mvp/epic-router.md
@@ -3,50 +3,50 @@
 ## Summary
 
 Provider Router is the highest-priority implementation epic in MVP bootstrap ("router first").
-It delivers a native TypeScript routing layer over Vercel AI SDK for provider selection, structured error classification, retry/backoff, provider-level fallback, and resilient streaming.
+It delivers a native TypeScript routing layer using **Vercel AI SDK** (`@ai-sdk/*`) as the transport layer for LLM communication, with structured error classification, retry/backoff, provider-level fallback, and resilient streaming on top.
+
+**Architecture (ADR-054):** AI SDK handles all LLM transport (`generateText`, `streamText`, `createProviderRegistry`). DiriCode adds error classification, retry engine, fallback chain, stream lifecycle management, and static **Model Cards** (`ModelDescriptor`) for metadata that AI SDK does not expose (context window, capabilities, pricing tier).
 
 Scope spans **POC → MVP-1**:
-- **POC**: provider abstraction, registry, Copilot adapter, baseline routing path
-- **MVP-1**: full error classifier, retry engine, fallback chain, stream manager, Kimi adapter
+- **POC**: AI SDK provider registry, Copilot adapter via `@ai-sdk/github`, baseline routing path
+- **MVP-1**: full error classifier, retry engine, fallback chain, stream manager, Kimi adapter via `@ai-sdk/moonshotai`
 
 MVP provider priority order:
-1. **Copilot** (priority 1, default)
-2. **Kimi** (priority 2, fallback)
+1. **Copilot** (priority 1, default) — via `@ai-sdk/github`
+2. **Kimi** (priority 2, fallback) — via `@ai-sdk/moonshotai`
 
 Primary reference: `analiza-router.md` (architecture, constants, retry/fallback/stream patterns).
-Architecture target: **Provider Registry + Error Classifier + Retry Engine + Stream Manager**, wrapping `@ai-sdk/*`.
+Architecture target: **AI SDK Provider Registry + Error Classifier + Retry Engine + Stream Manager**, using `@ai-sdk/*` provider packages.
+Transport decision: `docs/adr/adr-054-ai-sdk-transport-layer.md`
 
 ---
 
-## Issue: DC-PROV-001 — Provider interface and registry
+## Issue: DC-PROV-001 — Provider registry (AI SDK)
 
 ### Description
-Define core provider abstraction and registry in `@diricode/providers`:
-- Abstract Provider interface wrapping Vercel AI SDK model access + streaming entrypoint
-- Provider metadata model: `name`, `models`, `capabilities`, `priority`, `rateLimits`
-- Registry API:
-  - `register(provider)`
-  - `get(name)`
-  - `list()`
+Configure the AI SDK provider registry using `createProviderRegistry()` from the `ai` package:
+- Register all MVP providers via their official `@ai-sdk/*` packages
+- Provider metadata model for DiriCode-specific concerns: `name`, `priority`, `rateLimits`
+- Registry API wrapping AI SDK:
+  - `registry.languageModel("provider:model")` for model lookup
+  - `list()` for enumerating available providers
   - `getDefault()` (priority-based or explicit default)
-- Registry validation:
-  - no duplicate provider names
-  - no invalid priority values
-  - deterministic ordering by priority asc
+- Static **Model Cards** (`ModelDescriptor[]`) bundled per provider for metadata AI SDK doesn't expose (context window, max output, capabilities, pricing tier)
 - Initial support for exactly two MVP providers: Copilot (1), Kimi (2)
 
 ### Acceptance Criteria
-- Provider interface is package-public and used by adapters
-- Registry supports register/get/list/getDefault with typed errors
+- AI SDK `createProviderRegistry()` configured with `@ai-sdk/github` and `@ai-sdk/moonshotai`
+- Static `ModelDescriptor[]` bundled for each provider's models (JSON or TypeScript constants)
 - Default provider resolution returns Copilot when both configured
-- Metadata includes capabilities needed by router decisions (streaming, tool-use support, max context hints if available)
+- Model Cards include capabilities needed by router decisions (context window, tool-use support, vision, reasoning)
 - Unit tests cover:
-  - successful registration
-  - duplicate provider registration failure
-  - missing provider fetch failure
+  - successful model lookup via `registry.languageModel()`
+  - missing provider/model fetch failure
   - default resolution behavior
+  - Model Card data validation
 
 ### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md` (AI SDK adoption, two-registry architecture)
 - `analiza-router.md` (section 4.2/4.3 architecture and public interface)
 - `spec-mvp-diricode.md` (router first, Copilot/Kimi MVP priority)
 - `docs/adr/adr-025-native-ts-router-fallback-chain.md`
@@ -59,28 +59,30 @@ Define core provider abstraction and registry in `@diricode/providers`:
 
 ---
 
-## Issue: DC-PROV-002 — Copilot provider adapter
+## Issue: DC-PROV-002 — Copilot provider adapter (via `@ai-sdk/github`)
 
 ### Description
-Implement GitHub Models/Copilot adapter (priority 1) as Provider interface implementation:
-- Integrate via `@ai-sdk/github` when viable; fallback to custom adapter if required by API shape
+Configure the GitHub Models/Copilot adapter (priority 1) using the official `@ai-sdk/github` package:
 - Auth via GitHub token (`DC_*` env convention per config standards)
 - Model mapping table for MVP-required models (e.g. `gpt-5.4`, `claude-sonnet` variants exposed through GitHub Models)
-- Streaming support normalized to router stream contract
-- Adapter-level error payload preservation for classifier (`raw` error propagation)
+- Streaming via AI SDK's `streamText()` — normalized to router stream contract
+- Error payload preservation for classifier (`raw` error propagation)
+- Static `ModelDescriptor[]` for all Copilot-accessible models (bundled, not fetched at runtime)
 
 ### Acceptance Criteria
-- Copilot adapter registers successfully in Provider Registry with priority 1
+- Copilot adapter configured in AI SDK provider registry with priority 1 via `@ai-sdk/github`
 - Missing/invalid auth is surfaced as structured provider error input (not swallowed)
 - Model mapping is deterministic and test-covered
-- Streaming emits chunks compatible with Stream Manager expectations
+- Streaming via `streamText()` emits chunks compatible with Stream Manager expectations
+- Static `ModelDescriptor[]` bundled for Copilot models (context window, capabilities)
 - Integration tests with mocked AI SDK confirm:
-  - successful non-stream request
-  - successful stream request
+  - successful non-stream request via `generateText()`
+  - successful stream request via `streamText()`
   - auth failure path
   - unmapped model failure path
 
 ### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md` (AI SDK adoption)
 - `analiza-router.md` (OpenCode + Vercel AI SDK patterns; Copilot priority)
 - `spec-mvp-diricode.md` (MVP providers)
 - `docs/adr/adr-025-native-ts-router-fallback-chain.md`
@@ -243,21 +245,23 @@ Implement stream lifecycle manager for resilient streaming behavior:
 
 ---
 
-## Issue: DC-PROV-007 — Kimi provider adapter
+## Issue: DC-PROV-007 — Kimi provider adapter (via `@ai-sdk/moonshotai`)
 
 ### Description
-Implement Kimi adapter (priority 2) as fallback-capable Provider:
-- Kimi API integration (likely OpenAI-compatible path, per analysis recommendation)
+Configure the Kimi adapter (priority 2) as fallback-capable provider using the official `@ai-sdk/moonshotai` package:
+- `@ai-sdk/moonshotai` is a thin wrapper over OpenAI-compatible API — minimal configuration needed
 - Auth wiring via `DC_*` env/config conventions
 - Model mapping for MVP family assignments
-- Streaming support compatible with Stream Manager
+- Streaming via AI SDK's `streamText()` — compatible with Stream Manager
 - Error payload compatibility for classifier
+- Static `ModelDescriptor[]` for Kimi models (bundled)
 
 ### Acceptance Criteria
-- Kimi adapter registers with priority 2 in Provider Registry
+- Kimi adapter configured in AI SDK provider registry with priority 2 via `@ai-sdk/moonshotai`
 - Authentication and model mapping are test-covered
-- Streaming works through common router stream pipeline
+- Streaming works through common AI SDK `streamText()` pipeline
 - Error responses from Kimi are classifiable into 7 error kinds
+- Static `ModelDescriptor[]` bundled for Kimi models
 - Integration tests with mocked API/SDK cover:
   - success path
   - auth failure
@@ -265,6 +269,7 @@ Implement Kimi adapter (priority 2) as fallback-capable Provider:
   - context-overflow failure
 
 ### References
+- `docs/adr/adr-054-ai-sdk-transport-layer.md` (AI SDK adoption)
 - `analiza-router.md` (sections 3.1, 3.6, 6)
 - `spec-mvp-diricode.md` (MVP providers and order)
 - `docs/adr/adr-025-native-ts-router-fallback-chain.md`

--- a/swarm-model-picker-plan.md
+++ b/swarm-model-picker-plan.md
@@ -1,5 +1,7 @@
 # Swarm Model Picker - UI Implementation Plan
 
+> **Transport Layer:** LLM transport uses Vercel AI SDK (`@ai-sdk/*` provider packages) per ADR-054. The Picker dashboard visualizes decisions made by the LLM Picker (ADR-049), which selects models from static Model Cards (`ModelDescriptor[]`) and delegates actual LLM calls to the AI SDK transport layer. See `docs/adr/adr-054-ai-sdk-transport-layer.md`.
+
 ## Epic 1: Core Layout & Global State
 
 **Cel:** Zbudowanie szkieletu aplikacji, nawigacji oraz globalnego zarządzania stanem pod dane realtime.


### PR DESCRIPTION
## Summary

- Update ADR-025 (fallback chain), ADR-042 (multi-subscription), ADR-049 (LLM Picker) with latest design decisions
- Add new ADR-054 (AI SDK transport layer)
- Update `docs/mvp/epic-llm-picker.md` and `docs/mvp/epic-router.md` to reflect current implementation state
- Update README status table and architecture diagrams
- Minor update to `swarm-model-picker-plan.md`

Refs #49