### PR TITLE
feat(memory): implement session storage DC-MEM-002

### DIFF
--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -19,7 +19,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "better-sqlite3": "^12.8.0"
+    "better-sqlite3": "^12.8.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/memory/src/__tests__/MessageRepository.test.ts
+++ b/packages/memory/src/__tests__/MessageRepository.test.ts
@@ -1,0 +1,204 @@
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach } from "vitest";
+import { migration005 } from "../db/migrations/005_sessions_and_messages.js";
+import { initSchemaVersions } from "../db/schema/version.js";
+import { MessageRepository } from "../db/repositories/MessageRepository.js";
+import { SessionRepository } from "../db/repositories/SessionRepository.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  initSchemaVersions(db);
+  migration005.up(db);
+  return db;
+}
+
+describe("MessageRepository", () => {
+  let db: Database.Database;
+  let msgRepo: MessageRepository;
+  let sessionRepo: SessionRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    msgRepo = new MessageRepository(db);
+    sessionRepo = new SessionRepository(db);
+    sessionRepo.create({ id: "sess-1" });
+  });
+
+  describe("append()", () => {
+    it("appends a message to a session", () => {
+      const msg = msgRepo.append({
+        id: "msg-1",
+        sessionId: "sess-1",
+        role: "user",
+        content: "Hello",
+      });
+      expect(msg.id).toBe("msg-1");
+      expect(msg.sessionId).toBe("sess-1");
+      expect(msg.role).toBe("user");
+      expect(msg.content).toBe("Hello");
+      expect(msg.tokens).toBe(0);
+      expect(msg.cost).toBe(0);
+      expect(msg.timestamp).toBeDefined();
+    });
+
+    it("appends a message with tokens, cost, and agentId", () => {
+      const msg = msgRepo.append({
+        id: "msg-2",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "Hi there",
+        tokens: 42,
+        cost: 0.003,
+        agentId: "planner",
+      });
+      expect(msg.tokens).toBe(42);
+      expect(msg.cost).toBe(0.003);
+      expect(msg.agentId).toBe("planner");
+    });
+
+    it("rejects invalid role", () => {
+      expect(() =>
+        msgRepo.append({
+          id: "msg-bad",
+          sessionId: "sess-1",
+          role: "invalid" as "user",
+          content: "test",
+        }),
+      ).toThrow();
+    });
+
+    it("rejects duplicate message id", () => {
+      msgRepo.append({ id: "msg-dup", sessionId: "sess-1", role: "user", content: "a" });
+      expect(() =>
+        msgRepo.append({ id: "msg-dup", sessionId: "sess-1", role: "user", content: "b" }),
+      ).toThrow();
+    });
+
+    it("enforces foreign key to sessions", () => {
+      expect(() =>
+        msgRepo.append({ id: "msg-fk", sessionId: "nonexistent", role: "user", content: "x" }),
+      ).toThrow();
+    });
+
+    it("supports all valid roles", () => {
+      for (const role of ["user", "assistant", "system", "tool"] as const) {
+        const msg = msgRepo.append({
+          id: `msg-role-${role}`,
+          sessionId: "sess-1",
+          role,
+          content: `test ${role}`,
+        });
+        expect(msg.role).toBe(role);
+      }
+    });
+  });
+
+  describe("getById()", () => {
+    it("returns the message when found", () => {
+      msgRepo.append({ id: "msg-1", sessionId: "sess-1", role: "user", content: "hi" });
+      const found = msgRepo.getById("msg-1");
+      expect(found).toBeDefined();
+      expect(found?.content).toBe("hi");
+    });
+
+    it("returns undefined when not found", () => {
+      expect(msgRepo.getById("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("getBySessionId()", () => {
+    it("returns messages in chronological order", () => {
+      msgRepo.append({ id: "msg-1", sessionId: "sess-1", role: "system", content: "prompt" });
+      msgRepo.append({ id: "msg-2", sessionId: "sess-1", role: "user", content: "hello" });
+      msgRepo.append({ id: "msg-3", sessionId: "sess-1", role: "assistant", content: "hi" });
+
+      const messages = msgRepo.getBySessionId("sess-1");
+      expect(messages).toHaveLength(3);
+      expect(messages.map((m) => m.id)).toEqual(["msg-1", "msg-2", "msg-3"]);
+    });
+
+    it("returns empty array for session with no messages", () => {
+      expect(msgRepo.getBySessionId("sess-1")).toEqual([]);
+    });
+  });
+
+  describe("getBySessionIdPaginated()", () => {
+    beforeEach(() => {
+      for (let i = 0; i < 10; i++) {
+        msgRepo.append({
+          id: `msg-${String(i)}`,
+          sessionId: "sess-1",
+          role: "user",
+          content: `message ${String(i)}`,
+        });
+      }
+    });
+
+    it("returns first page with default page size", () => {
+      const result = msgRepo.getBySessionIdPaginated("sess-1");
+      expect(result.messages).toHaveLength(10);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("returns paginated results with custom page size", () => {
+      const result = msgRepo.getBySessionIdPaginated("sess-1", { pageSize: 4 });
+      expect(result.messages).toHaveLength(4);
+      expect(result.hasMore).toBe(true);
+      expect(result.messages.map((m) => m.id)).toEqual(["msg-0", "msg-1", "msg-2", "msg-3"]);
+    });
+
+    it("returns next page using cursor", () => {
+      const page1 = msgRepo.getBySessionIdPaginated("sess-1", { pageSize: 4 });
+      const lastMsg = page1.messages[page1.messages.length - 1];
+      if (!lastMsg) throw new Error("Expected messages");
+
+      const page2 = msgRepo.getBySessionIdPaginated("sess-1", {
+        cursor: { lastTimestamp: lastMsg.timestamp, lastId: lastMsg.id },
+        pageSize: 4,
+      });
+
+      expect(page2.messages).toHaveLength(4);
+      expect(page2.messages.map((m) => m.id)).toEqual(["msg-4", "msg-5", "msg-6", "msg-7"]);
+      expect(page2.hasMore).toBe(true);
+    });
+
+    it("returns last page with hasMore=false", () => {
+      const page1 = msgRepo.getBySessionIdPaginated("sess-1", { pageSize: 4 });
+      const last1 = page1.messages[page1.messages.length - 1];
+      if (!last1) throw new Error("Expected messages");
+
+      const page2 = msgRepo.getBySessionIdPaginated("sess-1", {
+        cursor: { lastTimestamp: last1.timestamp, lastId: last1.id },
+        pageSize: 4,
+      });
+      const last2 = page2.messages[page2.messages.length - 1];
+      if (!last2) throw new Error("Expected messages");
+
+      const page3 = msgRepo.getBySessionIdPaginated("sess-1", {
+        cursor: { lastTimestamp: last2.timestamp, lastId: last2.id },
+        pageSize: 4,
+      });
+      expect(page3.messages).toHaveLength(2);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.messages.map((m) => m.id)).toEqual(["msg-8", "msg-9"]);
+    });
+
+    it("returns empty for session with no messages", () => {
+      sessionRepo.create({ id: "sess-empty" });
+      const result = msgRepo.getBySessionIdPaginated("sess-empty");
+      expect(result.messages).toEqual([]);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe("CASCADE delete", () => {
+    it("deletes messages when session is deleted", () => {
+      msgRepo.append({ id: "msg-1", sessionId: "sess-1", role: "user", content: "hi" });
+      msgRepo.append({ id: "msg-2", sessionId: "sess-1", role: "assistant", content: "hello" });
+
+      db.prepare("DELETE FROM sessions WHERE id = ?").run("sess-1");
+      expect(msgRepo.getBySessionId("sess-1")).toEqual([]);
+    });
+  });
+});

--- a/packages/memory/src/__tests__/SessionRepository.test.ts
+++ b/packages/memory/src/__tests__/SessionRepository.test.ts
@@ -1,0 +1,177 @@
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach } from "vitest";
+import { migration005 } from "../db/migrations/005_sessions_and_messages.js";
+import { initSchemaVersions } from "../db/schema/version.js";
+import { SessionRepository } from "../db/repositories/SessionRepository.js";
+import { InvalidSessionTransition } from "../db/schemas/session.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  initSchemaVersions(db);
+  migration005.up(db);
+  return db;
+}
+
+describe("SessionRepository", () => {
+  let db: Database.Database;
+  let repo: SessionRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new SessionRepository(db);
+  });
+
+  describe("create()", () => {
+    it("creates a session with status 'created' and default metadata", () => {
+      const session = repo.create({ id: "sess-1" });
+      expect(session.id).toBe("sess-1");
+      expect(session.status).toBe("created");
+      expect(session.metadata).toEqual({});
+      expect(session.createdAt).toBeDefined();
+      expect(session.updatedAt).toBeDefined();
+    });
+
+    it("creates a session with custom metadata", () => {
+      const session = repo.create({
+        id: "sess-2",
+        metadata: { agent: "planner", priority: 1 },
+      });
+      expect(session.metadata).toEqual({ agent: "planner", priority: 1 });
+    });
+
+    it("rejects duplicate session id", () => {
+      repo.create({ id: "sess-dup" });
+      expect(() => repo.create({ id: "sess-dup" })).toThrow();
+    });
+  });
+
+  describe("getById()", () => {
+    it("returns the session when found", () => {
+      repo.create({ id: "sess-1" });
+      const found = repo.getById("sess-1");
+      expect(found).toBeDefined();
+      expect(found?.id).toBe("sess-1");
+    });
+
+    it("returns undefined when not found", () => {
+      expect(repo.getById("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("updateStatus()", () => {
+    it("transitions created → active", () => {
+      repo.create({ id: "sess-1" });
+      repo.updateStatus("sess-1", "active");
+      expect(repo.getById("sess-1")?.status).toBe("active");
+    });
+
+    it("transitions created → active → completed", () => {
+      repo.create({ id: "sess-1" });
+      repo.updateStatus("sess-1", "active");
+      repo.updateStatus("sess-1", "completed");
+      expect(repo.getById("sess-1")?.status).toBe("completed");
+    });
+
+    it("transitions completed → archived", () => {
+      repo.create({ id: "sess-1" });
+      repo.updateStatus("sess-1", "active");
+      repo.updateStatus("sess-1", "completed");
+      repo.updateStatus("sess-1", "archived");
+      expect(repo.getById("sess-1")?.status).toBe("archived");
+    });
+
+    it("rejects invalid transition created → completed", () => {
+      repo.create({ id: "sess-1" });
+      expect(() => {
+        repo.updateStatus("sess-1", "completed");
+      }).toThrow(InvalidSessionTransition);
+    });
+
+    it("rejects invalid transition active → archived", () => {
+      repo.create({ id: "sess-1" });
+      repo.updateStatus("sess-1", "active");
+      expect(() => {
+        repo.updateStatus("sess-1", "archived");
+      }).toThrow(InvalidSessionTransition);
+    });
+
+    it("rejects transition from archived (terminal state)", () => {
+      repo.create({ id: "sess-1" });
+      repo.updateStatus("sess-1", "active");
+      repo.updateStatus("sess-1", "completed");
+      repo.updateStatus("sess-1", "archived");
+      expect(() => {
+        repo.updateStatus("sess-1", "active");
+      }).toThrow(InvalidSessionTransition);
+    });
+
+    it("throws for nonexistent session", () => {
+      expect(() => {
+        repo.updateStatus("nonexistent", "active");
+      }).toThrow("not found");
+    });
+
+    it("updates the updatedAt timestamp", async () => {
+      repo.create({ id: "sess-1" });
+      const sessionBefore = repo.getById("sess-1");
+      expect(sessionBefore).toBeDefined();
+      const before = sessionBefore?.updatedAt;
+      await new Promise((r) => setTimeout(r, 1100));
+      repo.updateStatus("sess-1", "active");
+      const sessionAfter = repo.getById("sess-1");
+      expect(sessionAfter).toBeDefined();
+      const after = sessionAfter?.updatedAt;
+      expect(after).not.toBe(before);
+    });
+  });
+
+  describe("updateMetadata()", () => {
+    it("updates session metadata", () => {
+      repo.create({ id: "sess-1", metadata: { key: "old" } });
+      repo.updateMetadata("sess-1", { key: "new", extra: true });
+      const session = repo.getById("sess-1");
+      expect(session).toBeDefined();
+      expect(session?.metadata).toEqual({ key: "new", extra: true });
+    });
+  });
+
+  describe("list()", () => {
+    it("returns all sessions ordered by createdAt", () => {
+      repo.create({ id: "sess-1" });
+      repo.create({ id: "sess-2" });
+      repo.create({ id: "sess-3" });
+      const sessions = repo.list();
+      expect(sessions).toHaveLength(3);
+      expect(sessions.map((s) => s.id)).toEqual(["sess-1", "sess-2", "sess-3"]);
+    });
+
+    it("filters by status", () => {
+      repo.create({ id: "sess-1" });
+      repo.create({ id: "sess-2" });
+      repo.updateStatus("sess-1", "active");
+      const active = repo.list({ status: "active" });
+      expect(active).toHaveLength(1);
+      const first = active[0];
+      expect(first?.id).toBe("sess-1");
+    });
+
+    it("supports pagination with limit and offset", () => {
+      for (let i = 0; i < 5; i++) {
+        repo.create({ id: `sess-${String(i)}` });
+      }
+      const page1 = repo.list({ limit: 2, offset: 0 });
+      const page2 = repo.list({ limit: 2, offset: 2 });
+      expect(page1).toHaveLength(2);
+      expect(page2).toHaveLength(2);
+      expect(page1.map((s) => s.id)).toEqual(["sess-0", "sess-1"]);
+      expect(page2.map((s) => s.id)).toEqual(["sess-2", "sess-3"]);
+    });
+
+    it("returns empty array when no sessions match filter", () => {
+      repo.create({ id: "sess-1" });
+      const archived = repo.list({ status: "archived" });
+      expect(archived).toHaveLength(0);
+    });
+  });
+});

--- a/packages/memory/src/db/migrations/005_sessions_and_messages.ts
+++ b/packages/memory/src/db/migrations/005_sessions_and_messages.ts
@@ -1,0 +1,35 @@
+import type { Database } from "better-sqlite3";
+import type { Migration } from "./runner.js";
+
+export const migration005: Migration = {
+  version: 5,
+  description: "sessions and messages",
+  up(db: Database): void {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id          TEXT PRIMARY KEY,
+        status      TEXT NOT NULL DEFAULT 'created' CHECK(status IN ('created','active','completed','archived')),
+        metadata    TEXT NOT NULL DEFAULT '{}',
+        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS messages (
+        id          TEXT PRIMARY KEY,
+        session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        role        TEXT NOT NULL CHECK(role IN ('user','assistant','system','tool')),
+        content     TEXT NOT NULL,
+        tokens      INTEGER NOT NULL DEFAULT 0,
+        cost        REAL NOT NULL DEFAULT 0.0,
+        agent_id    TEXT,
+        timestamp   TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_messages_session_time
+        ON messages(session_id, timestamp);
+
+      CREATE INDEX IF NOT EXISTS idx_sessions_status
+        ON sessions(status);
+    `);
+  },
+};

--- a/packages/memory/src/db/migrations/registry.ts
+++ b/packages/memory/src/db/migrations/registry.ts
@@ -3,5 +3,12 @@ import { migration001 } from "./001_initial_schema.js";
 import { migration002 } from "./002_ai_intelligence.js";
 import { migration003 } from "./003_swarm_delegation.js";
 import { migration004 } from "./004_background_tasks.js";
+import { migration005 } from "./005_sessions_and_messages.js";
 
-export const migrations: Migration[] = [migration001, migration002, migration003, migration004];
+export const migrations: Migration[] = [
+  migration001,
+  migration002,
+  migration003,
+  migration004,
+  migration005,
+];

--- a/packages/memory/src/db/repositories/MessageRepository.ts
+++ b/packages/memory/src/db/repositories/MessageRepository.ts
@@ -1,0 +1,122 @@
+import type { Database } from "better-sqlite3";
+import {
+  type Message,
+  type AppendMessageInput,
+  AppendMessageInputSchema,
+  MessageSchema,
+} from "../schemas/session.js";
+
+interface MessageRow {
+  id: string;
+  session_id: string;
+  role: string;
+  content: string;
+  tokens: number;
+  cost: number;
+  agent_id: string | null;
+  timestamp: string;
+}
+
+function rowToMessage(row: MessageRow): Message {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    role: row.role as Message["role"],
+    content: row.content,
+    tokens: row.tokens,
+    cost: row.cost,
+    agentId: row.agent_id ?? undefined,
+    timestamp: row.timestamp,
+  };
+}
+
+export interface PaginatedMessages {
+  messages: Message[];
+  hasMore: boolean;
+}
+
+export class MessageRepository {
+  private stmtInsert;
+  private stmtGetById;
+  private stmtGetBySession;
+  private stmtGetBySessionAfterCursor;
+
+  constructor(private readonly db: Database) {
+    this.stmtInsert = db.prepare(
+      `INSERT INTO messages (id, session_id, role, content, tokens, cost, agent_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *`,
+    );
+
+    this.stmtGetById = db.prepare("SELECT * FROM messages WHERE id = ?");
+
+    this.stmtGetBySession = db.prepare(
+      "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp ASC, id ASC",
+    );
+
+    this.stmtGetBySessionAfterCursor = db.prepare(
+      `SELECT * FROM messages
+       WHERE session_id = ? AND ((timestamp > ?) OR (timestamp = ? AND id > ?))
+       ORDER BY timestamp ASC, id ASC LIMIT ?`,
+    );
+  }
+
+  append(input: AppendMessageInput): Message {
+    const parsed = AppendMessageInputSchema.parse(input);
+    const row = (this.stmtInsert as { get(...args: unknown[]): MessageRow | undefined }).get(
+      parsed.id,
+      parsed.sessionId,
+      parsed.role,
+      parsed.content,
+      parsed.tokens ?? 0,
+      parsed.cost ?? 0,
+      parsed.agentId ?? null,
+    );
+    if (row === undefined) throw new Error(`Message ${parsed.id} not found after insert`);
+    return MessageSchema.parse(rowToMessage(row));
+  }
+
+  getById(id: string): Message | undefined {
+    const row = (this.stmtGetById as { get(id: string): MessageRow | undefined }).get(id);
+    if (!row) return undefined;
+    return MessageSchema.parse(rowToMessage(row));
+  }
+
+  getBySessionId(sessionId: string): Message[] {
+    return (this.stmtGetBySession as { all(sessionId: string): MessageRow[] })
+      .all(sessionId)
+      .map(rowToMessage);
+  }
+
+  getBySessionIdPaginated(
+    sessionId: string,
+    options?: { cursor?: { lastTimestamp: string; lastId: string }; pageSize?: number },
+  ): PaginatedMessages {
+    const pageSize = options?.pageSize ?? 50;
+    const cursor = options?.cursor;
+
+    let rows: MessageRow[];
+
+    if (cursor) {
+      rows = (this.stmtGetBySessionAfterCursor as { all(...args: unknown[]): MessageRow[] }).all(
+        sessionId,
+        cursor.lastTimestamp,
+        cursor.lastTimestamp,
+        cursor.lastId,
+        pageSize + 1,
+      );
+    } else {
+      const stmt = this.db.prepare(
+        "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp ASC, id ASC LIMIT ?",
+      );
+      rows = (stmt as { all(sessionId: string, limit: number): MessageRow[] }).all(
+        sessionId,
+        pageSize + 1,
+      );
+    }
+
+    const hasMore = rows.length > pageSize;
+    const messages = rows.slice(0, pageSize).map(rowToMessage);
+
+    return { messages, hasMore };
+  }
+}

--- a/packages/memory/src/db/repositories/SessionRepository.ts
+++ b/packages/memory/src/db/repositories/SessionRepository.ts
@@ -1,0 +1,106 @@
+import type { Database } from "better-sqlite3";
+import {
+  type Session,
+  type SessionStatus,
+  type CreateSessionInput,
+  CreateSessionInputSchema,
+  SessionSchema,
+  isValidTransition,
+  InvalidSessionTransition,
+} from "../schemas/session.js";
+
+interface SessionRow {
+  id: string;
+  status: SessionStatus;
+  metadata: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToSession(row: SessionRow): Session {
+  return {
+    id: row.id,
+    status: row.status,
+    metadata: JSON.parse(row.metadata) as Record<string, unknown>,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export interface ListSessionsFilter {
+  status?: SessionStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export class SessionRepository {
+  private readonly stmtInsert;
+  private readonly stmtGetById;
+  private readonly stmtUpdateStatus;
+  private readonly stmtUpdateMetadata;
+  private readonly stmtListAll;
+  private readonly stmtListByStatus;
+
+  constructor(private readonly db: Database) {
+    this.stmtInsert = db.prepare<[string, string], SessionRow>(
+      `INSERT INTO sessions (id, status, metadata) VALUES (?, 'created', ?) RETURNING *`,
+    );
+
+    this.stmtGetById = db.prepare<[string], SessionRow>("SELECT * FROM sessions WHERE id = ?");
+
+    this.stmtUpdateStatus = db.prepare<[string, string]>(
+      "UPDATE sessions SET status = ?, updated_at = datetime('now') WHERE id = ?",
+    );
+
+    this.stmtUpdateMetadata = db.prepare<[string, string]>(
+      "UPDATE sessions SET metadata = ?, updated_at = datetime('now') WHERE id = ?",
+    );
+
+    this.stmtListAll = db.prepare<[], SessionRow>("SELECT * FROM sessions ORDER BY created_at ASC");
+
+    this.stmtListByStatus = db.prepare<[string], SessionRow>(
+      "SELECT * FROM sessions WHERE status = ? ORDER BY created_at ASC",
+    );
+  }
+
+  create(input: CreateSessionInput): Session {
+    const parsed = CreateSessionInputSchema.parse(input);
+    const row = this.stmtInsert.get(parsed.id, JSON.stringify(parsed.metadata ?? {}));
+    if (!row) throw new Error(`Session ${parsed.id} not found after insert`);
+    const session = rowToSession(row);
+    return SessionSchema.parse(session);
+  }
+
+  getById(id: string): Session | undefined {
+    const row = this.stmtGetById.get(id);
+    if (!row) return undefined;
+    return SessionSchema.parse(rowToSession(row));
+  }
+
+  updateStatus(id: string, newStatus: SessionStatus): void {
+    const current = this.getById(id);
+    if (!current) throw new Error(`Session ${id} not found`);
+    if (!isValidTransition(current.status, newStatus)) {
+      throw new InvalidSessionTransition(current.status, newStatus);
+    }
+    this.stmtUpdateStatus.run(newStatus, id);
+  }
+
+  updateMetadata(id: string, metadata: Record<string, unknown>): void {
+    this.stmtUpdateMetadata.run(JSON.stringify(metadata), id);
+  }
+
+  list(filter?: ListSessionsFilter): Session[] {
+    let rows: SessionRow[];
+
+    if (filter?.status) {
+      rows = this.stmtListByStatus.all(filter.status);
+    } else {
+      rows = this.stmtListAll.all();
+    }
+
+    const offset = filter?.offset ?? 0;
+    const limit = filter?.limit ?? rows.length;
+    return rows.slice(offset, offset + limit).map(rowToSession);
+  }
+}

--- a/packages/memory/src/db/schemas/session.ts
+++ b/packages/memory/src/db/schemas/session.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+export const SessionStatusSchema = z.enum(["created", "active", "completed", "archived"]);
+
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+
+const VALID_TRANSITIONS: Record<SessionStatus, Set<SessionStatus>> = {
+  created: new Set(["active"]),
+  active: new Set(["completed"]),
+  completed: new Set(["archived"]),
+  archived: new Set(),
+};
+
+export function isValidTransition(from: SessionStatus, to: SessionStatus): boolean {
+  return VALID_TRANSITIONS[from].has(to);
+}
+
+export class InvalidSessionTransition extends Error {
+  constructor(
+    public readonly from: SessionStatus,
+    public readonly to: SessionStatus,
+  ) {
+    super(`Invalid session status transition: ${from} → ${to}`);
+    this.name = "InvalidSessionTransition";
+  }
+}
+
+export const SessionSchema = z.object({
+  id: z.string().min(1),
+  status: SessionStatusSchema,
+  metadata: z.record(z.unknown()).default({}),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type Session = z.infer<typeof SessionSchema>;
+
+export const CreateSessionInputSchema = z.object({
+  id: z.string().min(1),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type CreateSessionInput = z.infer<typeof CreateSessionInputSchema>;
+
+export const MessageRoleSchema = z.enum(["user", "assistant", "system", "tool"]);
+
+export type MessageRole = z.infer<typeof MessageRoleSchema>;
+
+export const MessageSchema = z.object({
+  id: z.string().min(1),
+  sessionId: z.string().min(1),
+  role: MessageRoleSchema,
+  content: z.string(),
+  tokens: z.number().int().nonnegative().default(0),
+  cost: z.number().nonnegative().default(0),
+  agentId: z.string().nullable().optional(),
+  timestamp: z.string(),
+});
+
+export type Message = z.infer<typeof MessageSchema>;
+
+export const AppendMessageInputSchema = z.object({
+  id: z.string().min(1),
+  sessionId: z.string().min(1),
+  role: MessageRoleSchema,
+  content: z.string(),
+  tokens: z.number().int().nonnegative().optional(),
+  cost: z.number().nonnegative().optional(),
+  agentId: z.string().nullable().optional(),
+});
+
+export type AppendMessageInput = z.infer<typeof AppendMessageInputSchema>;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -18,3 +18,23 @@ export type {
   ErrorDetails,
   TaskPriority,
 } from "./db/repositories/BackgroundTaskRepository.js";
+export { SessionRepository } from "./db/repositories/SessionRepository.js";
+export type { ListSessionsFilter } from "./db/repositories/SessionRepository.js";
+export { MessageRepository } from "./db/repositories/MessageRepository.js";
+export type { PaginatedMessages } from "./db/repositories/MessageRepository.js";
+export {
+  type Session,
+  type SessionStatus,
+  type CreateSessionInput,
+  type Message,
+  type MessageRole,
+  type AppendMessageInput,
+  SessionSchema,
+  SessionStatusSchema,
+  CreateSessionInputSchema,
+  MessageSchema,
+  MessageRoleSchema,
+  AppendMessageInputSchema,
+  isValidTransition,
+  InvalidSessionTransition,
+} from "./db/schemas/session.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13


### PR DESCRIPTION
## Summary
- Implement session storage for @diricode/memory (DC-MEM-002)
- Sessions table with state machine (created → active → completed → archived)
- Messages table with composite cursor pagination
- Zod validation schemas for all inputs
- SessionRepository and MessageRepository with full CRUD
- Comprehensive test coverage (34 tests)

## Changes
- `005_sessions_and_messages.ts` - SQLite migration with FK cascade
- `schemas/session.ts` - Zod schemas (SessionStatus, Session, Message, etc.)
- `SessionRepository.ts` - create, getById, updateStatus, updateMetadata, list
- `MessageRepository.ts` - append, getById, getBySessionId, getBySessionIdPaginated
- Full test coverage for both repositories