### PR TITLE
feat(memory): implement ObservationRepository for DC-MEM-003

### DIFF
--- a/packages/memory/src/__tests__/ObservationRepository.test.ts
+++ b/packages/memory/src/__tests__/ObservationRepository.test.ts
@@ -1,0 +1,175 @@
+import Database from "better-sqlite3";
+import { describe, it, expect, beforeEach } from "vitest";
+import { migration001 } from "../db/migrations/001_initial_schema.js";
+import { migration005 } from "../db/migrations/005_sessions_and_messages.js";
+import { migration006 } from "../db/migrations/006_fts5_search.js";
+import { initSchemaVersions } from "../db/schema/version.js";
+import { ObservationRepository } from "../db/repositories/ObservationRepository.js";
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  initSchemaVersions(db);
+  migration001.up(db);
+  migration005.up(db);
+  migration006.up(db);
+  return db;
+}
+
+describe("ObservationRepository", () => {
+  let db: Database.Database;
+  let repo: ObservationRepository;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new ObservationRepository(db);
+  });
+
+  describe("appendObservation()", () => {
+    it("inserts an observation and returns it with an assigned id", () => {
+      const obs = repo.appendObservation({
+        type: "file_read",
+        content: "Read file src/index.ts",
+      });
+      expect(obs.id).toBeTypeOf("number");
+      expect(obs.id).toBeGreaterThan(0);
+      expect(obs.type).toBe("file_read");
+      expect(obs.content).toBe("Read file src/index.ts");
+      expect(obs.metadata).toEqual({});
+      expect(obs.createdAt).toBeDefined();
+    });
+
+    it("stores optional fields when provided", () => {
+      const obs = repo.appendObservation({
+        type: "decision",
+        content: "Chose to refactor module X",
+        sessionId: "sess-1",
+        agentId: "agent-1",
+        taskId: "task-1",
+        metadata: { confidence: 0.9 },
+        timestamp: "2026-01-01T00:00:00.000Z",
+      });
+      expect(obs.sessionId).toBe("sess-1");
+      expect(obs.agentId).toBe("agent-1");
+      expect(obs.taskId).toBe("task-1");
+      expect(obs.metadata).toEqual({ confidence: 0.9 });
+      expect(obs.timestamp).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("assigns auto-incrementing integer ids", () => {
+      const obs1 = repo.appendObservation({ type: "discovery", content: "Found pattern A" });
+      const obs2 = repo.appendObservation({ type: "discovery", content: "Found pattern B" });
+      expect(obs2.id).toBeGreaterThan(obs1.id);
+    });
+
+    it("rejects invalid observation type", () => {
+      expect(() =>
+        repo.appendObservation({
+          type: "invalid_type" as "file_read",
+          content: "some content",
+        }),
+      ).toThrow();
+    });
+
+    it("rejects empty content", () => {
+      expect(() =>
+        repo.appendObservation({
+          type: "error",
+          content: "",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("getTimeline()", () => {
+    beforeEach(() => {
+      repo.appendObservation({
+        type: "file_read",
+        content: "Read A",
+        sessionId: "sess-1",
+        agentId: "agent-1",
+        taskId: "task-1",
+        timestamp: "2026-01-01T00:01:00.000Z",
+      });
+      repo.appendObservation({
+        type: "file_write",
+        content: "Write B",
+        sessionId: "sess-1",
+        agentId: "agent-2",
+        taskId: "task-1",
+        timestamp: "2026-01-01T00:02:00.000Z",
+      });
+      repo.appendObservation({
+        type: "command_run",
+        content: "Run C",
+        sessionId: "sess-2",
+        agentId: "agent-1",
+        taskId: "task-2",
+        timestamp: "2026-01-01T00:03:00.000Z",
+      });
+    });
+
+    it("returns all observations when no filter is provided", () => {
+      const timeline = repo.getTimeline();
+      expect(timeline).toHaveLength(3);
+    });
+
+    it("filters by sessionId", () => {
+      const timeline = repo.getTimeline({ sessionId: "sess-1" });
+      expect(timeline).toHaveLength(2);
+      for (const obs of timeline) {
+        expect(obs.sessionId).toBe("sess-1");
+      }
+    });
+
+    it("filters by agentId", () => {
+      const timeline = repo.getTimeline({ agentId: "agent-1" });
+      expect(timeline).toHaveLength(2);
+      for (const obs of timeline) {
+        expect(obs.agentId).toBe("agent-1");
+      }
+    });
+
+    it("filters by taskId", () => {
+      const timeline = repo.getTimeline({ taskId: "task-2" });
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0]?.taskId).toBe("task-2");
+    });
+
+    it("filters by type", () => {
+      const timeline = repo.getTimeline({ type: "file_write" });
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0]?.type).toBe("file_write");
+    });
+
+    it("filters by fromTimestamp (inclusive)", () => {
+      const timeline = repo.getTimeline({ fromTimestamp: "2026-01-01T00:02:00.000Z" });
+      expect(timeline).toHaveLength(2);
+    });
+
+    it("filters by toTimestamp (inclusive)", () => {
+      const timeline = repo.getTimeline({ toTimestamp: "2026-01-01T00:02:00.000Z" });
+      expect(timeline).toHaveLength(2);
+    });
+
+    it("AND-composes multiple filters", () => {
+      const timeline = repo.getTimeline({
+        sessionId: "sess-1",
+        type: "file_write",
+      });
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0]?.content).toBe("Write B");
+    });
+
+    it("returns empty array when no observations match", () => {
+      const timeline = repo.getTimeline({ sessionId: "nonexistent-session" });
+      expect(timeline).toHaveLength(0);
+    });
+
+    it("returns results ordered by created_at ascending", () => {
+      const timeline = repo.getTimeline();
+      const contents = timeline.map((o) => o.content);
+      expect(contents).toEqual(["Read A", "Write B", "Run C"]);
+    });
+  });
+});

--- a/packages/memory/src/db/repositories/ObservationRepository.ts
+++ b/packages/memory/src/db/repositories/ObservationRepository.ts
@@ -1,0 +1,109 @@
+import type { Database } from "better-sqlite3";
+import {
+  type Observation,
+  type ObservationType,
+  ObservationSchema,
+  CreateObservationInputSchema,
+  type CreateObservationInput,
+} from "../schemas/search.js";
+
+interface ObservationRow {
+  id: number;
+  type: ObservationType;
+  content: string;
+  metadata: string;
+  created_at: string;
+  session_id: string | null;
+  agent_id: string | null;
+  task_id: string | null;
+  timestamp: string | null;
+}
+
+function rowToObservation(row: ObservationRow): Observation {
+  return ObservationSchema.parse({
+    id: row.id,
+    type: row.type,
+    content: row.content,
+    metadata: JSON.parse(row.metadata) as Record<string, unknown>,
+    createdAt: row.created_at,
+    sessionId: row.session_id,
+    agentId: row.agent_id,
+    taskId: row.task_id,
+    timestamp: row.timestamp,
+  });
+}
+
+export interface TimelineFilter {
+  sessionId?: string;
+  agentId?: string;
+  taskId?: string;
+  type?: ObservationType;
+  fromTimestamp?: string;
+  toTimestamp?: string;
+}
+
+export class ObservationRepository {
+  private readonly stmtInsert;
+
+  constructor(private readonly db: Database) {
+    this.stmtInsert = db.prepare<
+      [string, string, string, string | null, string | null, string | null, string | null],
+      ObservationRow
+    >(
+      `INSERT INTO observations (type, content, metadata, session_id, agent_id, task_id, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))
+       RETURNING *`,
+    );
+  }
+
+  appendObservation(input: CreateObservationInput): Observation {
+    const parsed = CreateObservationInputSchema.parse(input);
+    const row = this.stmtInsert.get(
+      parsed.type,
+      parsed.content,
+      JSON.stringify(parsed.metadata ?? {}),
+      parsed.sessionId ?? null,
+      parsed.agentId ?? null,
+      parsed.taskId ?? null,
+      parsed.timestamp ?? null,
+    );
+    if (!row) throw new Error("Observation not found after insert");
+    return rowToObservation(row);
+  }
+
+  getTimeline(filter: TimelineFilter = {}): Observation[] {
+    const conditions: string[] = [];
+    const params: (string | null)[] = [];
+
+    if (filter.sessionId !== undefined) {
+      conditions.push("session_id = ?");
+      params.push(filter.sessionId);
+    }
+    if (filter.agentId !== undefined) {
+      conditions.push("agent_id = ?");
+      params.push(filter.agentId);
+    }
+    if (filter.taskId !== undefined) {
+      conditions.push("task_id = ?");
+      params.push(filter.taskId);
+    }
+    if (filter.type !== undefined) {
+      conditions.push("type = ?");
+      params.push(filter.type);
+    }
+    if (filter.fromTimestamp !== undefined) {
+      conditions.push("timestamp >= ?");
+      params.push(filter.fromTimestamp);
+    }
+    if (filter.toTimestamp !== undefined) {
+      conditions.push("timestamp <= ?");
+      params.push(filter.toTimestamp);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const sql = `SELECT * FROM observations ${where} ORDER BY created_at ASC`;
+    const stmt = this.db.prepare<(string | null)[], ObservationRow>(sql);
+    const rows = stmt.all(...params);
+    return rows.map(rowToObservation);
+  }
+}

--- a/packages/memory/src/db/schemas/search.ts
+++ b/packages/memory/src/db/schemas/search.ts
@@ -55,3 +55,15 @@ export const SearchFilterSchema = z.object({
 export type SearchFilter = z.input<typeof SearchFilterSchema>;
 
 export type ParsedSearchFilter = z.infer<typeof SearchFilterSchema>;
+
+export const CreateObservationInputSchema = z.object({
+  type: ObservationTypeSchema,
+  content: z.string().min(1),
+  sessionId: z.string().optional(),
+  agentId: z.string().optional(),
+  taskId: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+  timestamp: z.string().optional(),
+});
+
+export type CreateObservationInput = z.infer<typeof CreateObservationInputSchema>;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -39,11 +39,14 @@ export {
   InvalidSessionTransition,
 } from "./db/schemas/session.js";
 export { SearchRepository } from "./db/repositories/SearchRepository.js";
+export { ObservationRepository } from "./db/repositories/ObservationRepository.js";
+export type { TimelineFilter } from "./db/repositories/ObservationRepository.js";
 export type {
   SearchResult,
   SearchFilter,
   Observation,
   ObservationType,
+  CreateObservationInput,
 } from "./db/schemas/search.js";
 export { TurnRepository } from "./db/repositories/TurnRepository.js";
 export type {


### PR DESCRIPTION
## Summary
- Implement append-only `ObservationRepository` for timeline-based memory
- `appendObservation()` with Zod-validated type enum (file_read, file_write, command_run, decision, discovery, error)
- `getTimeline(filter)` with AND-composed filters (session_id, agent_id, task_id, type, from/toTimestamp)
- 15 unit tests covering all acceptance criteria

## DC-MEM-003 Acceptance Criteria
- [x] Observations stored chronologically with monotonic timestamps
- [x] Six MVP observation types validated on insert
- [x] Timeline queries support session/agent/task/time-range filters with AND composition
- [x] Metadata supports extensible JSON
- [x] Invalid type/payload combinations fail with typed validation errors
- [x] Append-only semantics enforced
- [x] Indexed for efficient queries

Closes #92