### PR TITLE
feat(core): DC-DR-006 reconcile model resolvers and implement context window tier scoring

### DIFF
--- a/docs/adr/adr-055-addendum-context-tiers.md
+++ b/docs/adr/adr-055-addendum-context-tiers.md
@@ -82,6 +82,64 @@ interface ModelDescriptor {
 
 ---
 
+## Resolver Composition (DC-DR-006)
+
+`ModelTierResolver` and `CascadeModelResolver` serve different roles and compose in a specific order:
+
+### ModelTierResolver — Legacy tier→model mapper
+
+Located in `packages/core/src/agents/model-tier-resolver.ts`.
+
+- Takes a `ModelTier` (heavy/medium/low) and returns which model class to use
+- Does **NOT** implement `ModelResolver` interface
+- Provides **preferred model per tier** as candidate pool entries for `CascadeModelResolver`
+
+### CascadeModelResolver — Full decision engine
+
+Located in `packages/core/src/llm-picker/model-resolver.ts`.
+
+- Implements `ModelResolver` interface
+- Takes a `DecisionRequest`, applies hard rules, constraint filtering, and scoring
+- Returns selected model with full metadata
+
+### Composition seam
+
+```
+ModelTierResolver.resolve(tier)
+         ↓
+  Returns: tier + model class
+         ↓
+  Maps to: candidate pool entries
+         ↓
+CascadeModelResolver.resolve(request)
+         ↓
+  Applies: hard rules + scoring
+         ↓
+  Returns: selected model
+```
+
+`ModelTierResolver` is the **source of truth** for which model is preferred per tier. `CascadeModelResolver` then applies the full selection logic on top, including:
+
+- Hard rules (pricing tier constraints per agent role / task complexity)
+- Constraint filtering (excluded providers, max cost, min context window)
+- **Context window tier scoring** (ADR-055 Addendum — this document)
+- Role/complexity match scoring
+- Preferred provider/model bonuses
+
+### No duplication
+
+Both resolvers operate at different abstraction levels:
+
+| Concern | `ModelTierResolver` | `CascadeModelResolver` |
+|---------|--------------------|-----------------------|
+| Tier → model mapping | ✓ Primary | Uses as candidate source |
+| Hard rule enforcement | ✗ | ✓ |
+| Constraint filtering | ✗ | ✓ |
+| Context window scoring | ✗ | ✓ |
+| Confidence-based cascade | ✗ | ✓ |
+
+---
+
 ## References
 
 - ADR-004: Agent roster 3 tiers

--- a/packages/core/src/agents/model-tier-resolver.ts
+++ b/packages/core/src/agents/model-tier-resolver.ts
@@ -122,6 +122,39 @@ function defaultAvailabilityChecker(_model: ModelClass): boolean {
 /**
  * Configurable tier → model class resolver with fallback support.
  *
+ * ## Resolver Composition (DC-DR-006)
+ *
+ * `ModelTierResolver` and `CascadeModelResolver` serve different roles:
+ *
+ * - **`ModelTierResolver`** — Legacy tier→model mapper. Takes a `ModelTier`
+ *   (heavy/medium/low) and returns which model class to use. Does NOT implement
+ *   `ModelResolver`. Used as a **candidate pool source** for `CascadeModelResolver`.
+ *
+ * - **`CascadeModelResolver`** — Full decision engine (implements `ModelResolver`).
+ *   Takes a `DecisionRequest`, applies hard rules, constraint filtering, and scoring
+ *   to select from the candidate pool.
+ *
+ * ### Composition seam
+ *
+ * ```
+ * ModelTierResolver.resolve(tier)
+ *          ↓
+ *   Returns: tier + model class
+ *          ↓
+ *   Maps to: candidate pool entries
+ *          ↓
+ * CascadeModelResolver.resolve(request)
+ *          ↓
+ *   Applies: hard rules + scoring
+ *          ↓
+ *   Returns: selected model
+ * ```
+ *
+ * `ModelTierResolver` feeds the **preferred model per tier** into the
+ * `CascadeModelResolver` candidate pool. `CascadeModelResolver` then applies
+ * the full selection logic (hard rules, constraint filtering, scoring, ADR-055
+ * context-window tier scoring) on top.
+ *
  * @example
  * ```typescript
  * const resolver = new ModelTierResolver({
@@ -133,6 +166,9 @@ function defaultAvailabilityChecker(_model: ModelClass): boolean {
  * const result = resolver.resolve("heavy");
  * // → { model: "claude-opus-4.6", reason: "preferred", isDegraded: false, ... }
  * ```
+ *
+ * @see CascadeModelResolver
+ * @see ADR-055 Addendum (Context Window Tiers)
  */
 export class ModelTierResolver {
   readonly #mappings: ReadonlyMap<ModelTier, TierMappingConfig>;

--- a/packages/core/src/llm-picker/__tests__/model-resolver.test.ts
+++ b/packages/core/src/llm-picker/__tests__/model-resolver.test.ts
@@ -709,6 +709,130 @@ describe("CascadeModelResolver", () => {
     });
   });
 
+  describe("context window tier scoring", () => {
+    // Use architect agent + complex task to allow premium tier (min: standard, max: premium)
+    // This isolates context window scoring from pricing tier filtering.
+    const baseRequest = (tier: ModelTier): DecisionRequest => ({
+      requestId: "550e8400-e29b-41d4-a716-446655440000",
+      agent: { id: "test-agent", role: "architect" },
+      task: { type: "complex-architecture" },
+      modelDimensions: {
+        tier,
+        family: "coding",
+        tags: ["coding"],
+        fallbackType: null,
+      },
+    });
+
+    it("penalizes models below LOW tier minimum (200k)", async () => {
+      const resolver = new CascadeModelResolver(undefined, {
+        defaultProvider: "ok",
+        defaultModel: "ok-model",
+        candidatePool: [
+          {
+            provider: "tiny",
+            model: "tiny-model",
+            pricingTier: "standard",
+            contextWindow: 32_000,
+            trusted: false,
+            estimatedCostUsd: 0.01,
+            knownForRoles: [],
+            knownForComplexities: [],
+          },
+          {
+            provider: "ok",
+            model: "ok-model",
+            pricingTier: "standard",
+            contextWindow: 200_000,
+            trusted: false,
+            estimatedCostUsd: 0.01,
+            knownForRoles: [],
+            knownForComplexities: [],
+          },
+        ],
+      });
+      const response = await resolver.resolve(baseRequest("low"));
+      const tinyCandidate = response.candidates?.find((c) => c.model === "tiny-model");
+      const okCandidate = response.candidates?.find((c) => c.model === "ok-model");
+      expect(tinyCandidate?.score ?? 0).toBeLessThan(okCandidate?.score ?? 0);
+    });
+
+    it("HEAVY tier selects model with 800k+ over model with 200k", async () => {
+      const resolver = new CascadeModelResolver(undefined, {
+        defaultProvider: "huge",
+        defaultModel: "huge-model",
+        candidatePool: [
+          {
+            provider: "mid",
+            model: "mid-model",
+            pricingTier: "premium",
+            contextWindow: 200_000,
+            trusted: true,
+            estimatedCostUsd: 0.3,
+            knownForRoles: [],
+            knownForComplexities: [],
+          },
+          {
+            provider: "huge",
+            model: "huge-model",
+            pricingTier: "premium",
+            contextWindow: 1_000_000,
+            trusted: true,
+            estimatedCostUsd: 5,
+            knownForRoles: [],
+            knownForComplexities: [],
+          },
+        ],
+      });
+      const response = await resolver.resolve(baseRequest("heavy"));
+      // huge-model (1M) meets HEAVY min, mid-model (200k) is penalized -50
+      expect(response.selected?.model).toBe("huge-model");
+      const hugeCandidate = response.candidates?.find((c) => c.model === "huge-model");
+      const midCandidate = response.candidates?.find((c) => c.model === "mid-model");
+      expect(hugeCandidate?.score).toBeGreaterThan(midCandidate?.score ?? 0);
+    });
+
+    it("LOW tier accepts model with 200k+ context", async () => {
+      const resolver = new CascadeModelResolver(undefined, {
+        defaultProvider: "mid",
+        defaultModel: "mid-model",
+        candidatePool: [
+          {
+            provider: "mid",
+            model: "mid-model",
+            pricingTier: "standard",
+            contextWindow: 200_000,
+            trusted: true,
+            estimatedCostUsd: 0.3,
+            knownForRoles: [],
+            knownForComplexities: [],
+          },
+        ],
+      });
+      const response = await resolver.resolve(baseRequest("low"));
+      expect(response.status).toBe("resolved");
+      expect(response.selected?.model).toBe("mid-model");
+    });
+
+    it("model without contextWindow field is not penalized", async () => {
+      const resolver = new CascadeModelResolver(undefined, {
+        defaultProvider: "unknown",
+        defaultModel: "no-context-field-model",
+        candidatePool: [
+          {
+            provider: "unknown",
+            model: "no-context-field-model",
+            pricingTier: "standard",
+            trusted: true,
+            estimatedCostUsd: 0.5,
+          },
+        ],
+      });
+      const response = await resolver.resolve(baseRequest("heavy"));
+      expect(response.status).toBe("resolved");
+    });
+  });
+
   describe("CascadeModelResolverOptions", () => {
     it("uses custom defaultProvider and defaultModel", async () => {
       const resolver = new CascadeModelResolver(undefined, {

--- a/packages/core/src/llm-picker/model-resolver.ts
+++ b/packages/core/src/llm-picker/model-resolver.ts
@@ -551,6 +551,24 @@ export class CascadeModelResolver implements ModelResolver {
       score += 5;
     }
 
+    // Context window tier scoring — ADR-055 Addendum
+    // Models must meet the minimum context window for the requested tier,
+    // and are rewarded for exceeding it.
+    const TIER_MIN_CONTEXT: Record<string, number> = {
+      low: 200_000,
+      medium: 200_000,
+      heavy: 800_000,
+    };
+    const minRequired = TIER_MIN_CONTEXT[request.modelDimensions.tier];
+    if (descriptor.contextWindow !== undefined && minRequired !== undefined) {
+      if (descriptor.contextWindow < minRequired) {
+        score -= 50; // heavy penalty for insufficient context window
+      } else {
+        // bonus for exceeding minimum (capped at +20)
+        score += Math.min(20, (descriptor.contextWindow - minRequired) / 100_000);
+      }
+    }
+
     return Math.max(0, Math.min(100, score));
   }
 }


### PR DESCRIPTION
## Summary
- Document `ModelTierResolver` + `CascadeModelResolver` composition seam in code comments
- Implement ADR-055 context window tier scoring (200k/800k thresholds) in `scoreCandidate()`
- Add unit tests for all tier/model context window combinations
- Update ADR-055 addendum with resolver composition decision and no-duplication table

## Testing
- All 370 core tests pass
- LSP diagnostics clean on all changed files

## Notes
- Server test failure (`Cannot find package '@diricode/agents'`) is **pre-existing** on `origin/main` — unrelated to this change