### PR TITLE
feat(providers): integrate CascadeModelResolver with ProviderRouter via DiriRouter

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -199,6 +199,8 @@ export type {
   HardRuleEvaluationResult,
   CascadeModelResolverOptions,
   ResolverCandidate,
+  DecisionRequest,
+  DecisionResponse,
 } from "./llm-picker/index.js";
 
 export * from "./agents/dispatcher-contract.js";

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@diricode/core": "workspace:*",
     "@diricode/picker-contracts": "workspace:*",
     "@ai-sdk/openai-compatible": "^2.0.0",
     "@github/models": "0.0.1-beta.2",

--- a/packages/providers/src/__tests__/diri-router.test.ts
+++ b/packages/providers/src/__tests__/diri-router.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { DiriRouter, ProviderPriorities, Registry } from "../index.js";
+import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "../index.js";
+
+interface ProviderStub extends Provider {
+  setNextResponse(response: string): void;
+  setNextStreamChunks(chunks: StreamChunk[]): void;
+  setNextError(error: Error): void;
+  getCallHistory(): GenerateOptions[];
+}
+
+function createProviderStub(name: string): ProviderStub {
+  let nextResponse: string | null = null;
+  let nextStreamChunks: StreamChunk[] | null = null;
+  let nextError: Error | null = null;
+  const callHistory: GenerateOptions[] = [];
+
+  const defaultModel: ModelConfig = {
+    modelId: `${name}-model`,
+    maxTokens: 1000,
+    temperature: 0.2,
+  };
+
+  return {
+    name,
+    defaultModel,
+    isAvailable: () => true,
+    setNextResponse(response: string) {
+      nextResponse = response;
+      nextStreamChunks = null;
+      nextError = null;
+    },
+    setNextStreamChunks(chunks: StreamChunk[]) {
+      nextStreamChunks = chunks;
+      nextResponse = null;
+      nextError = null;
+    },
+    setNextError(error: Error) {
+      nextError = error;
+      nextResponse = null;
+      nextStreamChunks = null;
+    },
+    getCallHistory() {
+      return [...callHistory];
+    },
+    async generate(options: GenerateOptions): Promise<string> {
+      await Promise.resolve();
+      callHistory.push(options);
+      if (nextError) {
+        const error = nextError;
+        nextError = null;
+        throw error;
+      }
+      if (nextResponse !== null) {
+        const response = nextResponse;
+        nextResponse = null;
+        return response;
+      }
+      return `${name}:response`;
+    },
+    async *stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
+      await Promise.resolve();
+      callHistory.push(options);
+      if (nextError) {
+        const error = nextError;
+        nextError = null;
+        throw error;
+      }
+      if (nextStreamChunks !== null) {
+        const chunks = nextStreamChunks;
+        nextStreamChunks = null;
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+        return;
+      }
+      if (nextResponse !== null) {
+        const response = nextResponse;
+        nextResponse = null;
+        yield { delta: response, done: true };
+        return;
+      }
+      yield { delta: `${name}:chunk`, done: true };
+    },
+  };
+}
+
+describe("DiriRouter", () => {
+  describe("pick()", () => {
+    it("returns DecisionResponse from cascade resolver", async () => {
+      const registry = new Registry();
+      const copilot = createProviderStub("copilot");
+      registry.register(copilot, ProviderPriorities.COPILOT);
+
+      const router = new DiriRouter({ registry });
+
+      const request = {
+        requestId: "test-request-id",
+        agent: { id: "test-agent", role: "coder" },
+        task: { type: "simple" },
+        modelDimensions: {
+          tier: "low" as const,
+          family: "coding" as const,
+          tags: ["coding"] as (
+            | "coding"
+            | "creative"
+            | "quality"
+            | "research"
+            | "utility"
+            | "planning"
+            | "orchestration"
+          )[],
+          fallbackType: null,
+        },
+      };
+
+      const response = await router.pick(request);
+
+      expect(response).toBeDefined();
+      expect(response.requestId).toBe("test-request-id");
+      expect(response.status).toMatch(/^(resolved|no_match)$/);
+    });
+  });
+
+  describe("chat() with selected provider", () => {
+    it("executes against picker-selected provider when provided", async () => {
+      const copilot = createProviderStub("copilot");
+      const kimi = createProviderStub("kimi");
+      copilot.setNextResponse("copilot response");
+      kimi.setNextResponse("kimi response");
+
+      const registry = new Registry();
+      registry.register(copilot, ProviderPriorities.COPILOT);
+      registry.register(kimi, ProviderPriorities.KIMI);
+
+      const router = new DiriRouter({ registry });
+
+      const result = await router.chat({
+        prompt: "hello",
+        selected: { provider: "kimi", model: "kimi-model" },
+      });
+
+      expect(result.text).toBe("kimi response");
+      expect(result.provider).toBe("kimi");
+      expect(result.model).toBe("kimi-model");
+      expect(copilot.getCallHistory()).toHaveLength(0);
+      expect(kimi.getCallHistory()).toHaveLength(1);
+    });
+
+    it("falls back to registry when picker-selected provider is unavailable", async () => {
+      const copilot = createProviderStub("copilot");
+      const kimi = createProviderStub("kimi");
+      copilot.setNextResponse("copilot response");
+      kimi.setNextResponse("kimi response");
+
+      const registry = new Registry();
+      registry.register(copilot, ProviderPriorities.COPILOT);
+      registry.register(kimi, ProviderPriorities.KIMI);
+
+      const router = new DiriRouter({ registry });
+
+      const result = await router.chat({
+        prompt: "hello",
+        selected: { provider: "unregistered", model: "unknown-model" },
+      });
+
+      expect(result.text).toBe("copilot response");
+      expect(result.provider).toBe("copilot");
+    });
+  });
+
+  describe("chat() without selected provider", () => {
+    it("uses registry default when no selection provided", async () => {
+      const copilot = createProviderStub("copilot");
+      const kimi = createProviderStub("kimi");
+      copilot.setNextResponse("copilot response");
+      kimi.setNextResponse("kimi response");
+
+      const registry = new Registry();
+      registry.register(copilot, ProviderPriorities.COPILOT);
+      registry.register(kimi, ProviderPriorities.KIMI);
+
+      const router = new DiriRouter({ registry });
+
+      const result = await router.chat({ prompt: "hello" });
+
+      expect(result.text).toBe("copilot response");
+      expect(result.provider).toBe("copilot");
+    });
+  });
+
+  describe("stream()", () => {
+    it("streams from selected provider", async () => {
+      const copilot = createProviderStub("copilot");
+      const kimi = createProviderStub("kimi");
+      copilot.setNextStreamChunks([
+        { delta: "co", done: false },
+        { delta: "pilot", done: true },
+      ]);
+      kimi.setNextStreamChunks([
+        { delta: "ki", done: false },
+        { delta: "mi", done: true },
+      ]);
+
+      const registry = new Registry();
+      registry.register(copilot, ProviderPriorities.COPILOT);
+      registry.register(kimi, ProviderPriorities.KIMI);
+
+      const router = new DiriRouter({ registry });
+      const chunks: string[] = [];
+
+      for await (const chunk of router.stream({
+        prompt: "hello",
+        selected: { provider: "kimi", model: "kimi-model" },
+      })) {
+        chunks.push(`${chunk.delta}:${String(chunk.done)}`);
+      }
+
+      expect(chunks).toEqual(["ki:false", "mi:true"]);
+      expect(copilot.getCallHistory()).toHaveLength(0);
+      expect(kimi.getCallHistory()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/providers/src/diri-router.ts
+++ b/packages/providers/src/diri-router.ts
@@ -1,0 +1,128 @@
+import type { DecisionRequest, DecisionResponse } from "@diricode/core";
+import { CascadeModelResolver } from "@diricode/core";
+import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "./types.js";
+import { ProviderRouter } from "./router.js";
+import type { Registry } from "./registry.js";
+
+export interface ChatOptions {
+  readonly prompt: string;
+  readonly model?: ModelConfig;
+  readonly selected?: SelectedModelInfo;
+  readonly signal?: AbortSignal;
+}
+
+export interface SelectedModelInfo {
+  readonly provider: string;
+  readonly model: string;
+}
+
+export interface ChatResponse {
+  readonly text: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly usage?: {
+    readonly inputTokens?: number;
+    readonly outputTokens?: number;
+  };
+}
+
+export interface DiriRouterOptions {
+  readonly cascadeResolver?: CascadeModelResolver;
+  readonly providerRouter?: ProviderRouter;
+  readonly registry?: Registry;
+  readonly defaultModel?: ModelConfig;
+}
+
+export class DiriRouter {
+  readonly #resolver: CascadeModelResolver;
+  readonly #router: ProviderRouter;
+  readonly #registry: Registry;
+  readonly #defaultModel: ModelConfig;
+
+  constructor(options: DiriRouterOptions = {}) {
+    this.#resolver = options.cascadeResolver ?? new CascadeModelResolver();
+    this.#registry = options.registry ?? throwNoRegistry();
+    this.#router = options.providerRouter ?? new ProviderRouter(this.#registry);
+    this.#defaultModel = options.defaultModel ?? { modelId: "gpt-4o" };
+  }
+
+  async pick(request: DecisionRequest): Promise<DecisionResponse> {
+    return this.#resolver.resolve(request);
+  }
+
+  async chat(options: ChatOptions): Promise<ChatResponse> {
+    const pickerSelected = options.selected;
+    const modelConfig = options.model ?? this.getModelConfig(pickerSelected);
+
+    if (pickerSelected && this.#registry.has(pickerSelected.provider)) {
+      try {
+        const pickerProvider = this.#registry.get(pickerSelected.provider);
+        const generateOptions: GenerateOptions = {
+          prompt: options.prompt,
+          model: modelConfig,
+          signal: options.signal,
+        };
+        const text = await pickerProvider.generate(generateOptions);
+        return {
+          text,
+          provider: pickerProvider.name,
+          model: modelConfig.modelId,
+        };
+      } catch {
+        // primary failed, fall through to registry fallback
+      }
+    }
+
+    const fallbackText = await this.#router.generate({
+      prompt: options.prompt,
+      model: modelConfig,
+      signal: options.signal,
+    });
+    return {
+      text: fallbackText,
+      provider: this.#registry.getDefault().name,
+      model: modelConfig.modelId,
+    };
+  }
+
+  async *stream(options: ChatOptions): AsyncIterable<StreamChunk> {
+    const provider = this.getProvider(options.selected);
+    const modelConfig = options.model ?? this.getModelConfig(options.selected);
+
+    const generateOptions: GenerateOptions = {
+      prompt: options.prompt,
+      model: modelConfig,
+      signal: options.signal,
+    };
+
+    yield* provider.stream(generateOptions);
+  }
+
+  getProvider(selected?: SelectedModelInfo): Provider {
+    if (selected && this.#registry.has(selected.provider)) {
+      return this.#registry.get(selected.provider);
+    }
+    return this.#registry.getDefault();
+  }
+
+  getModelConfig(selected?: SelectedModelInfo): ModelConfig {
+    if (selected) {
+      return { modelId: selected.model };
+    }
+    return this.#defaultModel;
+  }
+
+  get resolver(): CascadeModelResolver {
+    return this.#resolver;
+  }
+
+  get router(): ProviderRouter {
+    return this.#router;
+  }
+}
+
+function throwNoRegistry(): never {
+  throw new Error(
+    "DiriRouter requires a Registry. Provide one via options.registry or ensure ProviderRouter is constructed with a valid Registry.",
+  );
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -16,6 +16,14 @@ export { ProviderAlreadyRegisteredError, ProviderNotFoundError, Registry } from 
 
 export type { ClassifiedError, ProviderErrorKind } from "./error-classifier.js";
 
+export { DiriRouter } from "./diri-router.js";
+export type {
+  ChatOptions,
+  ChatResponse,
+  DiriRouterOptions,
+  SelectedModelInfo,
+} from "./diri-router.js";
+
 export { classifyError, deriveRetryable, parseRetryAfter } from "./error-classifier.js";
 
 export type {

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../picker-contracts" }]
+  "references": [{ "path": "../picker-contracts" }, { "path": "../core" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.0
         version: 2.0.37(zod@3.25.76)
+      '@diricode/core':
+        specifier: workspace:*
+        version: link:../core
       '@diricode/picker-contracts':
         specifier: workspace:*
         version: link:../picker-contracts
@@ -422,8 +425,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@3.0.0-beta.12':
-    resolution: {integrity: sha512-G1MQHdDcRg1ga2ehLBKJMxW1RV17y3W3TVfzmvXUFokFXz5nml6gea9FH+CpDyLUa4AFAuuzbennDxOXh/s0nw==}
+  '@ai-sdk/openai-compatible@3.0.0-beta.14':
+    resolution: {integrity: sha512-2apttYn16ijMW8JIJ31ICTfPl6AdizO8yjMLcCohEeciFpVfzk99vZTCyTHGPI1HfYdSp1HYYJTdPlSxpH5QZQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -434,8 +437,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.0-beta.9':
-    resolution: {integrity: sha512-Ku/S1TV8ibqlweKQHa22eWT9QvKqR4hkl7KMJ0k7kw64Q7XObh12fJUnK4Mh8q+IR5ZeQGm95SLtx++d7FC6XA==}
+  '@ai-sdk/provider-utils@5.0.0-beta.10':
+    resolution: {integrity: sha512-gq5M4+93dSIznbYa32EhHR4bQsOwG6dRLKjcQu8KQrXieEmdVnkdSfvzrVygRPg3CQR5YeyMYwheJbdelgI/lw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -444,8 +447,8 @@ packages:
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.0-beta.5':
-    resolution: {integrity: sha512-+07aGNCVXEKgGXtAXjjROPcpHMudWfvsm5UvlZ4LtTfjX9cT61x7h3W0pSSpWY/H7doymdm8PmuX6Z8AvP03WQ==}
+  '@ai-sdk/provider@4.0.0-beta.6':
+    resolution: {integrity: sha512-dpm638wg8dhC/eU9S0r+urhLKDyrkLCbhw8ewc8HijUKkIuM9xPUy2mx1rO80CFMbK2ZO2UoZp/b7BgfGpH8KA==}
     engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
@@ -2990,10 +2993,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@3.0.0-beta.12(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@3.0.0-beta.14(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.5
-      '@ai-sdk/provider-utils': 5.0.0-beta.9(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0-beta.6
+      '@ai-sdk/provider-utils': 5.0.0-beta.10(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.21(zod@3.25.76)':
@@ -3003,9 +3006,9 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@5.0.0-beta.9(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.0-beta.10(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.5
+      '@ai-sdk/provider': 4.0.0-beta.6
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
@@ -3014,7 +3017,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.0-beta.5':
+  '@ai-sdk/provider@4.0.0-beta.6':
     dependencies:
       json-schema: 0.4.0
 
@@ -3294,9 +3297,9 @@ snapshots:
 
   '@github/models@0.0.1-beta.2(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 3.0.0-beta.12(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.0-beta.5
-      '@ai-sdk/provider-utils': 5.0.0-beta.9(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 3.0.0-beta.14(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0-beta.6
+      '@ai-sdk/provider-utils': 5.0.0-beta.10(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 


### PR DESCRIPTION
## Summary
- Add `DiriRouter` class that integrates `CascadeModelResolver.pick()` output into `ProviderRouter.chat()` input
- `DiriRouter.pick()` returns `DecisionResponse` from LLM Picker cascade
- `DiriRouter.chat()` accepts picker-selected provider/model and tries it first, falls back to `ProviderRouter`
- Adds TypeScript project reference from providers to core to enable cross-package imports

## Changes
- `packages/providers/src/diri-router.ts` - new DiriRouter class
- `packages/providers/src/__tests__/diri-router.test.ts` - 5 tests covering pick/chat/fallback scenarios
- `packages/providers/tsconfig.json` - added core reference
- `packages/providers/src/index.ts` - export DiriRouter
- `packages/providers/package.json` - added @diricode/core dependency
- `packages/core/src/index.ts` - re-export DecisionRequest/Response

## Testing
- 373 tests pass
- lint, typecheck, build all pass