### PR TITLE
feat(core,providers): add chatId to DecisionRequest and FeedbackCollector (#523)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -188,6 +188,8 @@ export {
   isPricingTierAllowed,
   getPricingTierRejectionReason,
   resolveHardRuleRange,
+  FeedbackOutcomeSchema,
+  FeedbackSubmissionSchema,
   Tier1HeuristicRouter,
   Tier2BertRouter,
   Tier3TinyLLMRouter,
@@ -206,6 +208,9 @@ export type {
   ResolverCandidate,
   DecisionRequest,
   DecisionResponse,
+  FeedbackOutcome,
+  FeedbackSubmission,
+  FeedbackCollector,
 } from "./llm-picker/index.js";
 
 export * from "./agents/dispatcher-contract.js";

--- a/packages/core/src/llm-picker/__tests__/model-resolver.test.ts
+++ b/packages/core/src/llm-picker/__tests__/model-resolver.test.ts
@@ -36,6 +36,7 @@ import type {
   ModelTier,
 } from "../types.js";
 const validRequest = (): DecisionRequest => ({
+  chatId: "test-chat-session",
   requestId: "550e8400-e29b-41d4-a716-446655440000",
   agent: { id: "coder-agent", role: "coding" },
   task: { type: "implement-feature", description: "Add dark mode" },
@@ -686,6 +687,7 @@ describe("CascadeModelResolver", () => {
     // Use architect agent + complex task to allow premium tier (min: standard, max: premium)
     // This isolates context window scoring from pricing tier filtering.
     const baseRequest = (tier: ModelTier): DecisionRequest => ({
+      chatId: "test-chat-session",
       requestId: "550e8400-e29b-41d4-a716-446655440000",
       agent: { id: "test-agent", role: "architect" },
       task: { type: "complex-architecture" },

--- a/packages/core/src/llm-picker/index.ts
+++ b/packages/core/src/llm-picker/index.ts
@@ -14,6 +14,8 @@ export {
   DecisionMetaSchema,
   SelectedModelSchema,
   DecisionResponseSchema,
+  FeedbackOutcomeSchema,
+  FeedbackSubmissionSchema,
   RouterClassificationSchema,
 } from "./types.js";
 
@@ -33,6 +35,9 @@ export type {
   DecisionMeta,
   SelectedModel,
   DecisionResponse,
+  FeedbackOutcome,
+  FeedbackSubmission,
+  FeedbackCollector,
   RouterClassification,
   ModelRouter,
   ModelResolver,

--- a/packages/core/src/llm-picker/types.ts
+++ b/packages/core/src/llm-picker/types.ts
@@ -122,6 +122,7 @@ export type DecisionConstraints = z.infer<typeof DecisionConstraintsSchema>;
  * @see ADR-049
  */
 export const DecisionRequestSchema = z.object({
+  chatId: z.string().min(1),
   requestId: z.string().uuid(),
   agent: AgentInfoSchema,
   task: TaskInfoSchema,
@@ -197,6 +198,42 @@ export const DecisionResponseSchema = z.object({
   classificationTrace: ClassificationTraceSchema.optional(),
 });
 export type DecisionResponse = z.infer<typeof DecisionResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Feedback Collection — ADR-055 chatId correlation
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome metrics for a single model decision.
+ */
+export const FeedbackOutcomeSchema = z.object({
+  success: z.boolean(),
+  tokenCount: z.object({
+    input: z.number().int().nonnegative(),
+    output: z.number().int().nonnegative(),
+  }),
+  latencyMs: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+});
+export type FeedbackOutcome = z.infer<typeof FeedbackOutcomeSchema>;
+
+/**
+ * Feedback submission linking outcome to original decision.
+ */
+export const FeedbackSubmissionSchema = z.object({
+  chatId: z.string().min(1),
+  requestId: z.string().uuid(),
+  outcome: FeedbackOutcomeSchema,
+});
+export type FeedbackSubmission = z.infer<typeof FeedbackSubmissionSchema>;
+
+/**
+ * Interface for collecting feedback on model decisions.
+ * POC: log-only. v2: Elo scoring integration.
+ */
+export interface FeedbackCollector {
+  submit(feedback: FeedbackSubmission): Promise<void>;
+}
 
 // ---------------------------------------------------------------------------
 // Router Types

--- a/packages/providers/src/__tests__/diri-router.test.ts
+++ b/packages/providers/src/__tests__/diri-router.test.ts
@@ -96,6 +96,7 @@ describe("DiriRouter", () => {
       const router = new DiriRouter({ registry });
 
       const request: DecisionRequest = {
+        chatId: "test-chat-session",
         requestId: "test-request-id",
         agent: { id: "test-agent", role: "coder" },
         task: { type: "simple" },

--- a/packages/providers/src/__tests__/feedback.test.ts
+++ b/packages/providers/src/__tests__/feedback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { LogFeedbackCollector } from "../feedback.js";
+
+describe("LogFeedbackCollector", () => {
+  it("submits feedback by logging to console", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const collector = new LogFeedbackCollector();
+    await collector.submit({
+      chatId: "test-chat-123",
+      requestId: "550e8400-e29b-41d4-a716-446655440000",
+      outcome: {
+        success: true,
+        tokenCount: { input: 100, output: 50 },
+        latencyMs: 1200,
+        costUsd: 0.003,
+      },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith("[feedback]", {
+      chatId: "test-chat-123",
+      requestId: "550e8400-e29b-41d4-a716-446655440000",
+      outcome: {
+        success: true,
+        tokenCount: { input: 100, output: 50 },
+        latencyMs: 1200,
+        costUsd: 0.003,
+      },
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/providers/src/feedback.ts
+++ b/packages/providers/src/feedback.ts
@@ -1,0 +1,17 @@
+import type { FeedbackCollector, FeedbackSubmission } from "@diricode/core";
+
+const logFeedback = (data: unknown): void => {
+  // eslint-disable-next-line no-console -- POC log-only implementation; v2 will use Elo scoring
+  console.log("[feedback]", data);
+};
+
+export class LogFeedbackCollector implements FeedbackCollector {
+  submit(feedback: FeedbackSubmission): Promise<void> {
+    logFeedback({
+      chatId: feedback.chatId,
+      requestId: feedback.requestId,
+      outcome: feedback.outcome,
+    });
+    return Promise.resolve();
+  }
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -25,6 +25,8 @@ export type {
   ExperimentLogger,
 } from "./diri-router.js";
 
+export { LogFeedbackCollector } from "./feedback.js";
+
 export { classifyError, deriveRetryable, parseRetryAfter } from "./error-classifier.js";
 
 export type {


### PR DESCRIPTION
## Summary

- Add `chatId: string` (required) to `DecisionRequest` schema for conversation-scoped correlation (ADR-055)
- Create `FeedbackCollector` interface, `FeedbackSubmission` and `FeedbackOutcome` types with Zod schemas
- Implement POC `LogFeedbackCollector` (console-based) in providers package
- Install missing `zod` dependency for `picker-contracts` (was blocking all lint/typecheck/build)

## Changes

**packages/core/src/llm-picker/types.ts**
- `DecisionRequestSchema`: added `chatId: z.string().min(1)` as first field
- New: `FeedbackOutcomeSchema`, `FeedbackSubmissionSchema`, `FeedbackCollector` interface

**packages/core/src/llm-picker/index.ts** + **packages/core/src/index.ts**
- Exported new schemas and types from both barrel files

**packages/providers/src/feedback.ts** (new)
- `LogFeedbackCollector` implementing `FeedbackCollector` — logs to console

**Test fixtures updated**
- `model-resolver.test.ts`: `chatId` added to `validRequest()` and `baseRequest()`
- `diri-router.test.ts`: `chatId` added to DecisionRequest fixture
- New `feedback.test.ts`: 1 test verifying LogFeedbackCollector output

Closes #523