### PR TITLE
feat(cli,server): integrate CLI with DiriRouter via Server API (#524)

### DIFF
--- a/apps/cli/src/commands/repl.ts
+++ b/apps/cli/src/commands/repl.ts
@@ -5,6 +5,20 @@ import { runLogin } from "./login.js";
 import { runLogout } from "./logout.js";
 import { runWhoami } from "./whoami.js";
 
+const SERVER_PORT = Number(process.env.PORT ?? 3001);
+const EXECUTE_URL = `http://localhost:${String(SERVER_PORT)}/api/v1/execute`;
+
+interface ExecuteResponseData {
+  sessionId: string;
+  result: unknown;
+}
+
+interface ExecuteEnvelope {
+  success: boolean;
+  data?: ExecuteResponseData;
+  error?: { code: string; message: string };
+}
+
 export interface ReplOptions {
   session?: string;
 }
@@ -69,14 +83,32 @@ async function readMultilineInput(
   return lines.length > 0 ? lines.join("\n") : null;
 }
 
-function* dispatchToAgent(
-  _input: string,
+async function* dispatchToAgent(
+  input: string,
   _config: DiriCodeConfig,
-  _session: string | null,
-): Iterable<string> {
-  // TODO(rado): wire to @diricode/agents dispatcher once pipeline is ready
-  yield `[POC] Received: "${_input.slice(0, 50)}${_input.length > 50 ? "..." : ""}"\n`;
-  yield `  (Agent dispatch not yet wired)\n`;
+  session: string | null,
+): AsyncIterable<string> {
+  const response = await fetch(EXECUTE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      prompt: input,
+      sessionId: session ?? undefined,
+      workspaceRoot: process.cwd(),
+    }),
+  });
+
+  const envelope = (await response.json()) as ExecuteEnvelope;
+
+  if (!response.ok || !envelope.success) {
+    const message = envelope.error?.message ?? `HTTP ${String(response.status)}`;
+    yield `Error: ${message}\n`;
+    return;
+  }
+
+  const output = envelope.data?.result;
+  yield typeof output === "string" ? output : JSON.stringify(output, null, 2);
+  yield "\n";
 }
 
 export async function startRepl(config: DiriCodeConfig, options: ReplOptions): Promise<void> {
@@ -114,7 +146,7 @@ export async function startRepl(config: DiriCodeConfig, options: ReplOptions): P
   });
 
   // eslint-disable-next-line no-console
-  console.log("diricode REPL (POC) — type /help for commands\n");
+  console.log("diricode REPL — type /help for commands\n");
 
   const prompt = "diricode> ";
   const continuationPrompt = "......> ";
@@ -173,7 +205,7 @@ export async function startRepl(config: DiriCodeConfig, options: ReplOptions): P
       console.log();
 
       let firstChunk = true;
-      for (const chunk of dispatchToAgent(input, config, status.session)) {
+      for await (const chunk of dispatchToAgent(input, config, status.session)) {
         if (firstChunk) {
           process.stdout.write("  ");
           firstChunk = false;

--- a/docs/adr/dc-dr-005-cli-router-path-audit.md
+++ b/docs/adr/dc-dr-005-cli-router-path-audit.md
@@ -1,0 +1,82 @@
+# DC-DR-005 — CLI → Router Path Audit & Gap Fixes
+
+**Issue**: #524  
+**Branch**: `feat/dc-dr-005-cli-router-path-verification-#524`  
+**Labels**: `area:providers`, `component:diri-router`  
+**Status**: Implemented
+
+---
+
+## Routing Path (As-Designed)
+
+```
+CLI REPL input
+  → HTTP POST localhost:3001/api/v1/execute
+  → packages/server: executeRouter
+  → Dispatcher.execute()
+  → DiriRouter.pick()          ← model selection via CascadeModelResolver
+  → DiriRouter.chat()
+  → ProviderRouter.generate()  ← retry + fallback chain
+  → CopilotProvider.generate() ← concrete LLM call
+  → GitHub Copilot API
+```
+
+---
+
+## Gaps Found & Fixed
+
+### GAP 1 — CLI never reached the Server
+
+**File**: `apps/cli/src/commands/repl.ts`
+
+`dispatchToAgent()` was a stub generator that printed `[POC] Received: "..."` and returned immediately. No HTTP call was ever made.
+
+**Fix**: Replaced with an `async function*` that POSTs to `http://localhost:${PORT}/api/v1/execute`, reads the `ApiEnvelope` response, and yields the result text. The call site was updated from `for...of` to `for await...of`.
+
+---
+
+### GAP 2 — Dispatcher created without DiriRouter
+
+**File**: `packages/server/src/routes/api/execute.ts`
+
+`createDispatcher()` was called without `diriRouter`, leaving `DispatcherConfig.diriRouter` as `undefined`. All model selection fell back to `ModelConfigResolver` (hardcoded tier→model mapping), bypassing `DiriRouter.pick()`.
+
+**Fix**: A `Registry` is instantiated, `CopilotProvider` is registered with `ProviderPriorities.COPILOT`, a `DiriRouter` is constructed with that registry, and `diriRouter` is passed to `createDispatcher()`.
+
+---
+
+### GAP 3 — Server package missing `@diricode/providers` dependency
+
+**File**: `packages/server/package.json`
+
+The server package did not declare `@diricode/providers` as a dependency, making the imports for GAP 2 impossible without this addition.
+
+**Fix**: Added `"@diricode/providers": "workspace:*"` to `dependencies`.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/cli/src/commands/repl.ts` | `dispatchToAgent()` wired to HTTP `/api/v1/execute` |
+| `packages/server/src/routes/api/execute.ts` | `DiriRouter` instantiated and passed to dispatcher |
+| `packages/server/package.json` | Added `@diricode/providers` workspace dependency |
+
+---
+
+## What Was Already Working
+
+- `DiriRouter` class — `pick()`, `chat()`, `stream()` fully implemented
+- `ProviderRouter` — retry/fallback chain fully implemented
+- `Registry` + all provider adapters (Copilot, Kimi, Gemini, ZAI, Minimax)
+- Dispatcher — `diriRouter` support was already wired-ready (lines 406–451), just not supplied
+- CLI auth commands (`login`, `logout`, `whoami`) — correctly use `@diricode/providers` auth helpers
+
+---
+
+## References
+
+- `packages/providers/src/diri-router.ts` — `DiriRouter` implementation
+- `packages/agents/src/dispatcher.ts` — `DispatcherConfig.diriRouter` (optional field, lines 38–53)
+- `docs/adr/adr-055-diri-router-unified-package.md` — DiriRouter design ADR

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@diricode/agents": "workspace:*",
     "@diricode/core": "workspace:*",
+    "@diricode/providers": "workspace:*",
     "@diricode/tools": "workspace:*",
     "@hono/node-server": "^1.19.11",
     "hono": "^4.12.8"

--- a/packages/server/src/routes/api/execute.ts
+++ b/packages/server/src/routes/api/execute.ts
@@ -20,6 +20,7 @@ import {
   diagnosticsTool,
 } from "@diricode/tools";
 import type { Tool } from "@diricode/core";
+import { CopilotProvider, DiriRouter, Registry, ProviderPriorities } from "@diricode/providers";
 import type { ApiEnvelope } from "../../middleware/error.js";
 import { createEventBusEmitBridge } from "../../sse/emit-bridge.js";
 
@@ -47,9 +48,14 @@ registry.register(createCodeWriterAgent({ tools: ALL_TOOLS }));
 registry.register(createPlannerQuickAgent({ tools: ALL_TOOLS }));
 registry.register(createCodeExplorerAgent({ tools: ALL_TOOLS }));
 
+const providerRegistry = new Registry();
+providerRegistry.register(new CopilotProvider(), ProviderPriorities.COPILOT);
+const diriRouter = new DiriRouter({ registry: providerRegistry });
+
 const dispatcher = createDispatcher({
   registry,
   maxDelegationDepth: 3,
+  diriRouter,
 });
 
 interface ExecuteBody {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@diricode/core':
         specifier: workspace:*
         version: link:../core
+      '@diricode/providers':
+        specifier: workspace:*
+        version: link:../providers
       '@diricode/tools':
         specifier: workspace:*
         version: link:../tools
@@ -425,8 +428,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@3.0.0-beta.14':
-    resolution: {integrity: sha512-2apttYn16ijMW8JIJ31ICTfPl6AdizO8yjMLcCohEeciFpVfzk99vZTCyTHGPI1HfYdSp1HYYJTdPlSxpH5QZQ==}
+  '@ai-sdk/openai-compatible@3.0.0-beta.15':
+    resolution: {integrity: sha512-WEbaPppNYUDHjyY1/wvROfZLnhQ49oXXgfkCgRGo9z6Gpx+adKTRXxHnJEo3GRFEMS+cWy8Elfi3TLmiiho2HQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -437,8 +440,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.0-beta.10':
-    resolution: {integrity: sha512-gq5M4+93dSIznbYa32EhHR4bQsOwG6dRLKjcQu8KQrXieEmdVnkdSfvzrVygRPg3CQR5YeyMYwheJbdelgI/lw==}
+  '@ai-sdk/provider-utils@5.0.0-beta.11':
+    resolution: {integrity: sha512-F7CZQWRT2KORKCji8eA2hgz4ry9fAP8xUThqaefWgjVIn2rY1RP/Ban5tOhsweCSaB046T1Da9UEnAq4TECc+A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -447,8 +450,8 @@ packages:
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.0-beta.6':
-    resolution: {integrity: sha512-dpm638wg8dhC/eU9S0r+urhLKDyrkLCbhw8ewc8HijUKkIuM9xPUy2mx1rO80CFMbK2ZO2UoZp/b7BgfGpH8KA==}
+  '@ai-sdk/provider@4.0.0-beta.7':
+    resolution: {integrity: sha512-q3mORIV5vzhMQ2ge1zw1hpnLm+21CxTimB1YPiPQEuBiKjUZ5Ds1SBaIukeapNT04JH+ddmdxzcj3cyIYxKWDQ==}
     engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
@@ -2993,10 +2996,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@3.0.0-beta.14(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@3.0.0-beta.15(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.6
-      '@ai-sdk/provider-utils': 5.0.0-beta.10(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0-beta.7
+      '@ai-sdk/provider-utils': 5.0.0-beta.11(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.21(zod@3.25.76)':
@@ -3006,9 +3009,9 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@5.0.0-beta.10(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.0-beta.11(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.6
+      '@ai-sdk/provider': 4.0.0-beta.7
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
@@ -3017,7 +3020,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.0-beta.6':
+  '@ai-sdk/provider@4.0.0-beta.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -3297,9 +3300,9 @@ snapshots:
 
   '@github/models@0.0.1-beta.2(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 3.0.0-beta.14(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.0-beta.6
-      '@ai-sdk/provider-utils': 5.0.0-beta.10(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 3.0.0-beta.15(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0-beta.7
+      '@ai-sdk/provider-utils': 5.0.0-beta.11(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 


### PR DESCRIPTION
## Summary

- **CLI REPL** (`apps/cli/src/commands/repl.ts`): Replaced stub `dispatchToAgent()` with a real async generator that POSTs to the Server API at `/api/v1/execute`, following the full routing path: CLI → Server → Dispatcher → DiriRouter → Provider.
- **Server execute route** (`packages/server/src/routes/api/execute.ts`): Wired `DiriRouter` into the `Dispatcher` so CLI requests are properly routed through the diri-router to selected providers.
- **Server package.json**: Added `@diricode/providers` as a workspace dependency.
- **Documentation**: Created `docs/adr/dc-dr-005-cli-router-path-audit.md` documenting the as-designed routing architecture and fixes applied.

## Testing

- ✅ `pnpm lint` — 0 errors
- ✅ `pnpm typecheck` — 0 errors  
- ✅ `pnpm build` — success
- ✅ `pnpm test` — 1674 passed, 9 skipped

Closes #524