### PR TITLE
feat(dirirouter): add playground types and validation schemas

### DIFF
--- a/packages/dirirouter/src/__tests__/playground-types.test.ts
+++ b/packages/dirirouter/src/__tests__/playground-types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import { PickRequestSchema, ChatRequestSchema } from "../playground/types.js";
+
+describe("PickRequestSchema", () => {
+  test("valid PickRequest passes validation", () => {
+    const validPickRequest = {
+      agent: { id: "agent-1", role: "coder" },
+      task: { type: "code", description: "Write a function" },
+      modelDimensions: {
+        tier: "heavy",
+        modelAttributes: ["reasoning", "quality"],
+        fallbackType: null,
+      },
+    };
+    expect(() => PickRequestSchema.parse(validPickRequest)).not.toThrow();
+  });
+
+  test("PickRequest missing required field modelDimensions throws ZodError", () => {
+    const invalidPickRequest = {
+      agent: { role: "coder" },
+      task: { type: "code" },
+    };
+    expect(() => PickRequestSchema.parse(invalidPickRequest)).toThrow();
+  });
+
+  test("PickRequest with invalid tier throws ZodError", () => {
+    const invalidPickRequest = {
+      agent: { role: "coder" },
+      task: { type: "code" },
+      modelDimensions: {
+        tier: "invalid-tier",
+        modelAttributes: [],
+        fallbackType: null,
+      },
+    };
+    expect(() => PickRequestSchema.parse(invalidPickRequest)).toThrow();
+  });
+});
+
+describe("ChatRequestSchema", () => {
+  test("valid ChatRequest passes validation", () => {
+    const validChatRequest = {
+      prompt: "Hello, world!",
+      provider: "gemini",
+      model: "gemini-pro",
+      maxTokens: 100,
+      temperature: 1.5,
+    };
+    expect(() => ChatRequestSchema.parse(validChatRequest)).not.toThrow();
+  });
+
+  test("ChatRequest with temperature > 2 throws ZodError", () => {
+    const invalidChatRequest = {
+      prompt: "Hello",
+      temperature: 3,
+    };
+    expect(() => ChatRequestSchema.parse(invalidChatRequest)).toThrow();
+  });
+
+  test("ChatRequest with empty prompt throws ZodError", () => {
+    const invalidChatRequest = {
+      prompt: "",
+    };
+    expect(() => ChatRequestSchema.parse(invalidChatRequest)).toThrow();
+  });
+
+  test("ChatRequest with negative maxTokens throws ZodError", () => {
+    const invalidChatRequest = {
+      prompt: "Hello",
+      maxTokens: -1,
+    };
+    expect(() => ChatRequestSchema.parse(invalidChatRequest)).toThrow();
+  });
+
+  test("ChatRequest with non-integer maxTokens throws ZodError", () => {
+    const invalidChatRequest = {
+      prompt: "Hello",
+      maxTokens: 1.5,
+    };
+    expect(() => ChatRequestSchema.parse(invalidChatRequest)).toThrow();
+  });
+});

--- a/packages/dirirouter/src/playground/types.ts
+++ b/packages/dirirouter/src/playground/types.ts
@@ -1,0 +1,202 @@
+/**
+ * Playground-specific types and Zod validation schemas.
+ *
+ * These types map the playground UI form inputs to the existing
+ * `DecisionRequest` and `GenerateOptions` interfaces from @diricode/dirirouter,
+ * with key differences:
+ * - `chatId` and `requestId` are omitted from input types (generated server-side)
+ * - `PickRequest` is a user-facing subset of `DecisionRequest`
+ * - `ChatRequest` is a simplified version of `ChatOptions` + `ModelConfig`
+ *
+ * @module playground/types
+ */
+
+import { z } from "zod";
+import type {
+  AgentInfo,
+  TaskInfo,
+  ModelDimensions,
+  DecisionConstraints,
+  ModelTier,
+  ModelAttribute,
+  FallbackType,
+} from "@diricode/dirirouter/picker/llm-picker/types.js";
+import {
+  ModelTierSchema,
+  ModelAttributeSchema,
+  FallbackTypeSchema,
+  ModelDimensionsSchema,
+  AgentInfoSchema,
+  TaskInfoSchema,
+  DecisionConstraintsSchema,
+} from "@diricode/dirirouter/picker/llm-picker/types.js";
+import type { DiriRouter } from "@diricode/dirirouter/diri-router.js";
+import type { Registry } from "@diricode/dirirouter/registry.js";
+import type { ModelCardRegistry } from "@diricode/dirirouter/picker/model-card-registry.js";
+import type { SubscriptionRegistry } from "@diricode/dirirouter/picker/subscription-registry.js";
+
+// ---------------------------------------------------------------------------
+// Provider Status
+// ---------------------------------------------------------------------------
+
+/**
+ * Health status of a single provider.
+ */
+export interface ProviderStatus {
+  /** Provider name (e.g. "gemini", "kimi"). */
+  name: string;
+  /** Whether the provider is available for requests. */
+  available: boolean;
+  /** Error message if unavailable. */
+  error?: string;
+  /** Environment variable name required for this provider. */
+  envVar: string;
+}
+
+// ---------------------------------------------------------------------------
+// Playground Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Server configuration for the playground.
+ */
+export interface PlaygroundConfig {
+  /** Port number to listen on. */
+  port: number;
+  /** Host address to bind to. */
+  host: string;
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap Result
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of playground server initialization.
+ */
+export interface BootstrapResult {
+  /** Initialized DiriRouter instance. */
+  diriRouter: DiriRouter;
+  /** Provider registry with registered providers. */
+  registry: Registry;
+  /** Model card registry with discovered models. */
+  modelCardRegistry: ModelCardRegistry;
+  /** Subscription registry with active subscriptions. */
+  subscriptionRegistry: SubscriptionRegistry;
+  /** Individual provider health statuses. */
+  providerStatuses: ProviderStatus[];
+}
+
+// ---------------------------------------------------------------------------
+// Pick Request — subset of DecisionRequest without auto-generated fields
+// ---------------------------------------------------------------------------
+
+/**
+ * User-facing request for model picking (dry-run).
+ *
+ * Omits `chatId` and `requestId` from `DecisionRequest` since these
+ * are auto-generated server-side.
+ *
+ * @see DecisionRequest from @diricode/dirirouter/picker/llm-picker/types
+ */
+export interface PickRequest {
+  /** Agent identity and role. */
+  agent: AgentInfo;
+  /** Task type and description. */
+  task: TaskInfo;
+  /** Model selection dimensions. */
+  modelDimensions: ModelDimensions;
+  /** Optional constraints for filtering/ranking candidates. */
+  constraints?: DecisionConstraints;
+}
+
+/**
+ * Zod schema for validating `PickRequest` objects.
+ *
+ * Validates that:
+ * - `agent` matches AgentInfoSchema (role required, id optional)
+ * - `task` matches TaskInfoSchema (type required, description optional)
+ * - `modelDimensions` matches ModelDimensionsSchema
+ * - `constraints` is optional and matches DecisionConstraintsSchema if provided
+ */
+export const PickRequestSchema: z.ZodType<PickRequest> = z.object({
+  agent: AgentInfoSchema,
+  task: TaskInfoSchema,
+  modelDimensions: ModelDimensionsSchema,
+  constraints: DecisionConstraintsSchema.optional(),
+});
+
+/**
+ * Inferred TypeScript type from `PickRequestSchema`.
+ */
+export type PickRequestInferred = z.infer<typeof PickRequestSchema>;
+
+// Ensure schema produces the correct type
+const _pickRequestTypeCheck: PickRequest = {} as PickRequestInferred;
+void _pickRequestTypeCheck;
+
+// ---------------------------------------------------------------------------
+// Chat Request — simplified chat options
+// ---------------------------------------------------------------------------
+
+/**
+ * Simplified chat request for the playground.
+ *
+ * This is a user-facing subset that maps to `ChatOptions` + `ModelConfig`
+ * from the DiriRouter interface, simplified for direct provider mode.
+ */
+export interface ChatRequest {
+  /** The prompt / user message content. */
+  prompt: string;
+  /** Provider name for direct mode (skip picker). */
+  provider?: string;
+  /** Model identifier for direct mode. */
+  model?: string;
+  /** Maximum tokens to generate. */
+  maxTokens?: number;
+  /** Sampling temperature in [0, 2]. */
+  temperature?: number;
+}
+
+/**
+ * Zod schema for validating `ChatRequest` objects.
+ *
+ * Validates that:
+ * - `prompt` is a non-empty string
+ * - `provider` is an optional string
+ * - `model` is an optional string
+ * - `maxTokens` is a positive integer if provided
+ * - `temperature` is in range [0, 2] if provided
+ */
+export const ChatRequestSchema: z.ZodType<ChatRequest> = z.object({
+  prompt: z.string().min(1, "Prompt cannot be empty"),
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  maxTokens: z.number().int().positive().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+/**
+ * Inferred TypeScript type from `ChatRequestSchema`.
+ */
+export type ChatRequestInferred = z.infer<typeof ChatRequestSchema>;
+
+// Ensure schema produces the correct type
+const _chatRequestTypeCheck: ChatRequest = {} as ChatRequestInferred;
+void _chatRequestTypeCheck;
+
+// ---------------------------------------------------------------------------
+// Re-exports for convenience
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-export of `ModelTier` for playground consumers.
+ * @see @diricode/dirirouter/picker/llm-picker/types
+ */
+export type { ModelTier, ModelAttribute, FallbackType };
+
+/**
+ * Re-export of relevant Zod schemas for playground consumers.
+ * @see @diricode/dirirouter/picker/llm-picker/types
+ */
+export { ModelTierSchema, ModelAttributeSchema, FallbackTypeSchema, ModelDimensionsSchema };


### PR DESCRIPTION
## Summary
- Add playground-specific TypeScript types and Zod validation schemas for the DiriRouter standalone playground
- Implement `PickRequest` (subset of `DecisionRequest` without auto-generated fields) and `ChatRequest` (simplified chat options)
- Add `ProviderStatus`, `BootstrapResult`, and `PlaygroundConfig` interfaces
- Create `PickRequestSchema` and `ChatRequestSchema` for server-side validation
- Add comprehensive test coverage for Zod schema validation

## Changes
- `packages/dirirouter/src/playground/types.ts` — new file with all types and Zod schemas
- `packages/dirirouter/src/__tests__/playground-types.test.ts` — validation tests (8 tests, all passing)

## Testing
- `bunx tsc --noEmit` passes with zero type errors
- `bun test` passes 8/8 validation tests

## Notes
- Pre-existing lint/typecheck failures in `@diricode/core` and `@diricode/agents` are unrelated to this PR (missing `@diricode/picker-contracts` dependency from a previous merged PR)