### PR TITLE
feat(dirirouter): add playground pick endpoint for dry-run selection

### DIFF
--- a/packages/dirirouter/src/playground/routes/pick.ts
+++ b/packages/dirirouter/src/playground/routes/pick.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import type { Context } from "hono";
+import type { BootstrapResult } from "../types.js";
+import { PickRequestSchema } from "../types.js";
+import type { DecisionRequest, DecisionResponse } from "@diricode/dirirouter";
+
+/**
+ * POST /api/pick handler: validates request, generates chatId/requestId,
+ * and returns full DecisionResponse from diriRouter.pick().
+ */
+export function pickRoute(ctx: BootstrapResult) {
+  return async (c: Context) => {
+    try {
+      const body: unknown = await c.req.json();
+      const validated = PickRequestSchema.parse(body);
+
+      const chatId = randomUUID();
+      const requestId = randomUUID();
+
+      const decisionRequest: DecisionRequest = {
+        chatId,
+        requestId,
+        agent: validated.agent,
+        task: validated.task,
+        modelDimensions: validated.modelDimensions,
+        ...(validated.constraints && { constraints: validated.constraints }),
+      };
+
+      const decisionResponse: DecisionResponse = await ctx.diriRouter.pick(decisionRequest, chatId);
+
+      return c.json(decisionResponse);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return c.json(
+          {
+            error: "Validation error",
+            details: error.errors,
+          },
+          400,
+        );
+      }
+
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return c.json(
+        {
+          error: "Internal server error",
+          message: errorMessage,
+        },
+        500,
+      );
+    }
+  };
+}

--- a/packages/dirirouter/src/playground/server.ts
+++ b/packages/dirirouter/src/playground/server.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
+import type { BootstrapResult } from "./types.js";
+import { pickRoute } from "./routes/pick.js";
 
-export function createApp() {
+export function createApp(ctx: BootstrapResult) {
   const app = new Hono();
 
   // Middleware
@@ -14,6 +16,8 @@ export function createApp() {
 
   // Placeholder root
   app.get("/", (c) => c.text("DiriRouter Playground — loading..."));
+
+  app.post("/api/pick", pickRoute(ctx));
 
   return app;
 }


### PR DESCRIPTION
## Summary

Implements DC-DR-017: Pick Endpoint — `/api/pick` for dry-run model selection.

- Creates `POST /api/pick` endpoint that runs the CascadeModelResolver picker in dry-run mode (no provider API calls)
- Validates request body with `PickRequestSchema` (Zod)
- Generates `chatId` and `requestId` server-side
- Returns full `DecisionResponse` with candidate scores, rejection reasons, and classification trace
- Zod validation failure → 400 with error details
- Internal error → 500 with error message

## Files

- `packages/dirirouter/src/playground/routes/pick.ts` — new route handler
- `packages/dirirouter/src/playground/server.ts` — wired pick route into Hono app

## QA

- All local tests pass (460 passed, 9 skipped)
- Lint: 0 errors
- Typecheck: 0 errors
- Build: success