### PR TITLE
feat(dirirouter): add model availability display + toggle persistence for playground - fixes #562

### DIFF
--- a/packages/dirirouter/src/playground/cli.ts
+++ b/packages/dirirouter/src/playground/cli.ts
@@ -1,9 +1,131 @@
-import { bootstrapPlayground } from "./bootstrap.js";
+import { bootstrapPlayground, type BootstrapResult } from "./bootstrap.js";
 import { createApp } from "./server.js";
+import { readPlaygroundState } from "./model-state.js";
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function visibleLen(s: string): number {
+  return s.replace(ANSI_RE, "").length;
+}
+
+function padAnsi(s: string, width: number): string {
+  const vl = visibleLen(s);
+  return vl >= width ? s : s + " ".repeat(width - vl);
+}
+
+const C = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  cyan: "\x1b[36m",
+  yellow: "\x1b[33m",
+  white: "\x1b[37m",
+  bgDark: "\x1b[48;5;234m",
+};
+
+type Row = readonly [string, string, string, string];
+
+function renderStartupTable(params: {
+  host: string;
+  port: string;
+  providerStatuses: BootstrapResult["providerStatuses"];
+  modelCardRegistry: BootstrapResult["modelCardRegistry"];
+  subscriptionRegistry: BootstrapResult["subscriptionRegistry"];
+}): string {
+  const { host, port, providerStatuses, modelCardRegistry, subscriptionRegistry } = params;
+
+  const allModels = modelCardRegistry.list();
+  const totalModels = allModels.length;
+  const { disabledModels } = readPlaygroundState();
+  const enabledCount = totalModels - disabledModels.length;
+
+  const rows: Row[] = providerStatuses.map((p) => {
+    const providerModels = subscriptionRegistry.findByProvider(p.name);
+    const count = providerModels.length;
+    const examples = providerModels
+      .slice(0, 2)
+      .map((sub) => sub.model)
+      .join(", ");
+    const exampleStr = count > 2 ? examples + `, +${String(count - 2)} more` : examples || "—";
+
+    const statusStr = p.available ? `${C.green}✓ Ready${C.reset}` : `${C.red}✗ No key${C.reset}`;
+
+    return [p.name, statusStr, String(count), exampleStr] as const;
+  });
+
+  const HEADERS: Row = ["Provider", "Status", "Models", "Example Models"];
+  const colWidths = HEADERS.map((h, i) =>
+    Math.max(
+      h.length,
+      i === 0 ? 10 : 0,
+      i === 1 ? 10 : 0,
+      i === 2 ? 6 : 0,
+      i === 3 ? 20 : 0,
+      ...rows.map((r) => visibleLen(r[i as 0 | 1 | 2 | 3])),
+    ),
+  ) as [number, number, number, number];
+
+  const borderLine = (left: string, mid: string, right: string, fill: string): string =>
+    left + colWidths.map((w) => fill.repeat(w + 2)).join(mid) + right;
+
+  const row = (cells: Row, bold = false): string => {
+    const parts = cells.map((cell, i) => {
+      const padded = padAnsi(cell, colWidths[i as 0 | 1 | 2 | 3]);
+      return bold ? `${C.bold}${padded}${C.reset}` : padded;
+    });
+    return "│ " + parts.join(" │ ") + " │";
+  };
+
+  const top = borderLine("┌", "┬", "┐", "─");
+  const headerSep = borderLine("├", "┼", "┤", "─");
+  const bottom = borderLine("└", "┴", "┘", "─");
+
+  const tableWidth = top.length;
+  const innerWidth = tableWidth - 2;
+
+  const centreBox = (text: string): string => {
+    const vl = visibleLen(text);
+    const total = innerWidth - vl;
+    const left = Math.floor(total / 2);
+    const right = total - left;
+    return "│" + " ".repeat(left) + text + " ".repeat(right) + "│";
+  };
+
+  const blankRow = "│" + " ".repeat(innerWidth) + "│";
+
+  const url = `${C.cyan}http://${host}:${port}${C.reset}`;
+  const title = `${C.bold}${C.white}DiriRouter Playground${C.reset}`;
+  const stats = `${C.dim}Available models: ${String(enabledCount)} of ${String(totalModels)} total${C.reset}`;
+
+  const lines: string[] = [
+    "",
+    top,
+    centreBox(title),
+    centreBox(url),
+    blankRow,
+    headerSep,
+    row(HEADERS, true),
+    headerSep,
+    ...rows.map((r) => row(r)),
+    bottom,
+    stats,
+    "",
+  ];
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
   // 1. Parse CLI args
-  const port = parseInt(process.argv.find((a) => a.startsWith("--port="))?.split("=")[1] ?? "3333");
+  const portStr = process.argv.find((a) => a.startsWith("--port="))?.split("=")[1] ?? "3333";
+  const port = parseInt(portStr);
   const host = process.argv.find((a) => a.startsWith("--host="))?.split("=")[1] ?? "localhost";
 
   // 2. Bootstrap (providers, registries, resolver, diriRouter)
@@ -16,33 +138,23 @@ async function main(): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
   const server = (globalThis as any).Bun.serve({ port, hostname: host, fetch: app.fetch });
 
-  // 5. Print startup banner
-  const modelCount = result.modelCardRegistry.list().length;
-  const candidateCount = result.subscriptionRegistry.list().length;
-
-  const providerLines = result.providerStatuses
-    .map((p) => `│    ${p.available ? "✓" : "✗"} ${p.name} (${p.envVar})`)
-    .join("\n");
-
+  // 5. Print startup table
   // eslint-disable-next-line no-console
-  console.log(`
-┌─────────────────────────────────────────┐
-│  DiriRouter Playground                  │
-│  http://${host}:${String(port)}         │
-│                                         │
-│  Providers:                             │
-${providerLines}
-│                                         │
-│  Models: ${String(modelCount).padEnd(22)} │
-│  Candidates: ${String(candidateCount).padEnd(19)} │
-└─────────────────────────────────────────┘
-`);
+  console.log(
+    renderStartupTable({
+      host,
+      port: portStr,
+      providerStatuses: result.providerStatuses,
+      modelCardRegistry: result.modelCardRegistry,
+      subscriptionRegistry: result.subscriptionRegistry,
+    }),
+  );
 
   // 6. Handle SIGINT/SIGTERM for clean shutdown
   const shutdown = (): void => {
     // eslint-disable-next-line no-console
     console.log("\nShutting down...");
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     void server.stop();
     process.exit(0);
   };

--- a/packages/dirirouter/src/playground/html.ts
+++ b/packages/dirirouter/src/playground/html.ts
@@ -88,6 +88,9 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
       margin-bottom: 1rem;
       border-bottom: 1px dashed var(--border);
       padding-bottom: 0.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
     }
 
     .form-group { margin-bottom: 1rem; }
@@ -194,6 +197,79 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
       flex: 1;
       white-space: pre-wrap;
     }
+
+    /* Model Toggles UI */
+    .model-provider-group {
+      margin-bottom: 1rem;
+    }
+
+    .model-provider-name {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--accent);
+      margin-bottom: 0.4rem;
+    }
+
+    .model-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.3rem 0.5rem;
+      border-radius: 3px;
+      transition: background 0.15s;
+    }
+
+    .model-row:hover { background: #1e1e38; }
+
+    .model-row.disabled .model-id {
+      color: #475569;
+      text-decoration: line-through;
+    }
+
+    .model-id {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: #cbd5e1;
+      transition: color 0.15s;
+    }
+
+    .toggle-switch {
+      position: relative;
+      display: inline-block;
+      width: 32px;
+      height: 18px;
+      flex-shrink: 0;
+    }
+
+    .toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+    .toggle-track {
+      position: absolute;
+      inset: 0;
+      background: #334155;
+      border-radius: 9px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .toggle-switch input:checked + .toggle-track { background: var(--success); }
+
+    .toggle-track::before {
+      content: "";
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      left: 3px;
+      top: 3px;
+      background: #fff;
+      border-radius: 50%;
+      transition: transform 0.2s;
+    }
+
+    .toggle-switch input:checked + .toggle-track::before { transform: translateX(14px); }
+    .toggle-switch input:disabled + .toggle-track { opacity: 0.4; cursor: not-allowed; }
   </style>
 </head>
 <body x-data="playground()">
@@ -250,7 +326,7 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
             <label>Fallback Type</label>
             <select name="modelDimensions.fallbackType">
               <option value="none">none</option>
-              ${fallbackTypes.map(f => '<option value="' + f + '">' + f + '</option>').join('')}
+              ${fallbackTypes.map((f) => '<option value="' + f + '">' + f + "</option>").join("")}
             </select>
           </div>
         </div>
@@ -258,7 +334,7 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
         <div class="form-group">
           <label>Model Attributes</label>
           <div class="checkbox-grid">
-            ${modelAttributes.map(attr => '<label class="checkbox-label"><input type="checkbox" name="modelDimensions.modelAttributes[]" value="' + attr + '"> ' + attr + '</label>').join('')}
+            ${modelAttributes.map((attr) => '<label class="checkbox-label"><input type="checkbox" name="modelDimensions.modelAttributes[]" value="' + attr + '"> ' + attr + "</label>").join("")}
           </div>
         </div>
 
@@ -338,7 +414,35 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
         <span style="color:#94a3b8;font-size:0.8rem;">Loading...</span>
       </div>
 
-      <div class="section-title">Results</div>
+      <div class="section-title">
+        <span>Models</span>
+        <span style="font-weight:400;text-transform:none;letter-spacing:0;font-size:0.78rem;color:#94a3b8;">
+          <span x-text="enabledModelsCount"></span> of <span x-text="totalModelsCount"></span> enabled
+        </span>
+      </div>
+      
+      <div class="model-list-section">
+        <template x-if="Object.keys(modelsByProvider).length === 0">
+          <span style="color:#94a3b8;font-size:0.8rem;">Loading models...</span>
+        </template>
+        
+        <template x-for="[provider, models] in Object.entries(modelsByProvider)" :key="provider">
+          <div class="model-provider-group">
+            <div class="model-provider-name" x-text="provider"></div>
+            <template x-for="model in models" :key="model.id">
+              <div class="model-row" :class="model.enabled ? '' : 'disabled'">
+                <span class="model-id" x-text="model.id"></span>
+                <label class="toggle-switch" :title="model.enabled ? 'Disable' : 'Enable'">
+                  <input type="checkbox" x-model="model.enabled" @change="toggleModel(model)">
+                  <span class="toggle-track"></span>
+                </label>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
+
+      <div class="section-title" style="margin-top: 1rem;">Results</div>
       
       <div id="error-container" class="error-box"></div>
 
@@ -356,6 +460,10 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
       Alpine.data('playground', () => ({
         temp: 0.7,
         loading: false,
+        
+        modelsByProvider: {},
+        enabledModelsCount: 0,
+        totalModelsCount: 0,
         
         init() {
           this.loadData();
@@ -390,20 +498,50 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
             const mRes = await fetch('/api/models');
             if (mRes.ok) {
               const data = await mRes.json();
-              const models = data.models || [];
+              const modelCards = data.modelCards || [];
               
-              const modHtml = models.map(m => 
+              this.totalModelsCount = modelCards.length;
+              this.enabledModelsCount = modelCards.filter(m => m.enabled).length;
+              
+              const grouped = {};
+              for (const m of modelCards) {
+                const provider = m.provider || 'unknown';
+                if (!grouped[provider]) grouped[provider] = [];
+                grouped[provider].push({ ...m });
+              }
+              this.modelsByProvider = grouped;
+              
+              // Render preferred/excluded models for form constraints
+              const modHtml = modelCards.map(m => 
                 \`<label class="checkbox-label"><input type="checkbox" name="constraints.preferredModels[]" value="\${m.id}"> \${m.id}</label>\`
               ).join('');
               document.getElementById('pref-models-grid').innerHTML = modHtml;
               
-              const exclModHtml = models.map(m => 
+              const exclModHtml = modelCards.map(m => 
                 \`<label class="checkbox-label"><input type="checkbox" name="constraints.excludedModels[]" value="\${m.id}"> \${m.id}</label>\`
               ).join('');
               document.getElementById('excl-models-grid').innerHTML = exclModHtml;
             }
           } catch(e) {
             console.error('Failed to load data', e);
+          }
+        },
+        
+        async toggleModel(model) {
+          this.enabledModelsCount = model.enabled ? this.enabledModelsCount + 1 : this.enabledModelsCount - 1;
+          try {
+            const res = await fetch('/api/models/toggle', {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ modelId: model.id })
+            });
+            if (!res.ok) {
+              model.enabled = !model.enabled;
+              this.enabledModelsCount = model.enabled ? this.enabledModelsCount + 1 : this.enabledModelsCount - 1;
+            }
+          } catch (e) {
+            model.enabled = !model.enabled;
+            this.enabledModelsCount = model.enabled ? this.enabledModelsCount + 1 : this.enabledModelsCount - 1;
           }
         },
         

--- a/packages/dirirouter/src/playground/model-state.ts
+++ b/packages/dirirouter/src/playground/model-state.ts
@@ -1,0 +1,166 @@
+/**
+ * Playground model toggle state manager.
+ *
+ * Reads and writes `playground-state.json` alongside `.env` in the process
+ * working directory. The file tracks which models have been disabled by the
+ * user via the playground UI.
+ *
+ * Schema:
+ * ```json
+ * {
+ *   "disabledModels": ["model-a", "model-b"],
+ *   "lastUpdated": "2026-04-04T12:00:00.000Z"
+ * }
+ * ```
+ *
+ * If the file is missing or malformed, `disabledModels` defaults to `[]`
+ * (all models enabled).
+ *
+ * @module playground/model-state
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Persisted shape of `playground-state.json`.
+ */
+export interface PlaygroundState {
+  /** Model IDs that have been explicitly disabled. */
+  disabledModels: string[];
+  /** ISO-8601 timestamp of the last write. */
+  lastUpdated: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the absolute path to `playground-state.json` in the cwd.
+ * Kept as a function so tests can override `process.cwd()` via spies.
+ */
+function stateFilePath(): string {
+  return join(process.cwd(), "playground-state.json");
+}
+
+/**
+ * Returns `true` if `value` is a plain object (not an array, not null).
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validates that a parsed value conforms to {@link PlaygroundState}.
+ *
+ * Accepts partial files: missing/invalid fields are normalised rather than
+ * rejected, so a file with only `disabledModels` is still usable.
+ */
+function isValidState(value: unknown): value is PlaygroundState {
+  if (!isPlainObject(value)) return false;
+  if (!Array.isArray(value.disabledModels)) return false;
+  if (!value.disabledModels.every((m) => typeof m === "string")) return false;
+  if (typeof value.lastUpdated !== "string") return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads `playground-state.json` from the cwd.
+ *
+ * Returns a normalised {@link PlaygroundState} in all cases:
+ * - If the file doesn't exist → `{ disabledModels: [], lastUpdated: "" }`
+ * - If the file is malformed → same default
+ * - If the file is valid but missing `lastUpdated` → treats it as `""`
+ *
+ * @returns The current playground state.
+ */
+export function readPlaygroundState(): PlaygroundState {
+  const defaultState: PlaygroundState = { disabledModels: [], lastUpdated: "" };
+
+  let raw: string;
+  try {
+    raw = readFileSync(stateFilePath(), "utf-8");
+  } catch {
+    // File doesn't exist or isn't readable — treat all models as enabled.
+    return defaultState;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed JSON — fall back to default.
+    return defaultState;
+  }
+
+  if (!isValidState(parsed)) {
+    // Wrong shape — fall back to default.
+    return defaultState;
+  }
+
+  return parsed;
+}
+
+/**
+ * Writes a {@link PlaygroundState} object to `playground-state.json` in the
+ * cwd, overwriting any existing file.
+ *
+ * Throws if the file system write fails (e.g. permissions issue).
+ *
+ * @param state - The state to persist.
+ */
+export function writePlaygroundState(state: PlaygroundState): void {
+  const json = JSON.stringify(state, null, 2);
+  writeFileSync(stateFilePath(), json, "utf-8");
+}
+
+/**
+ * Toggles a model's disabled status.
+ *
+ * - If `modelId` is currently in `disabledModels`, it is **removed** (re-enabled).
+ * - If `modelId` is not in `disabledModels`, it is **added** (disabled).
+ *
+ * `lastUpdated` is always set to the current UTC timestamp before writing.
+ *
+ * @param modelId - The model identifier to toggle.
+ * @returns The updated {@link PlaygroundState} after the write.
+ */
+export function toggleModel(modelId: string): PlaygroundState {
+  const current = readPlaygroundState();
+
+  const isDisabled = current.disabledModels.includes(modelId);
+  const disabledModels = isDisabled
+    ? current.disabledModels.filter((id) => id !== modelId)
+    : [...current.disabledModels, modelId];
+
+  const next: PlaygroundState = {
+    disabledModels,
+    lastUpdated: new Date().toISOString(),
+  };
+
+  writePlaygroundState(next);
+  return next;
+}
+
+/**
+ * Convenience helper: returns `true` if the given model is **enabled**
+ * (i.e. not in `disabledModels`).
+ *
+ * Reads the state fresh on every call — no caching.
+ *
+ * @param modelId - The model identifier to check.
+ * @returns `true` if the model is enabled, `false` if it is disabled.
+ */
+export function isModelEnabled(modelId: string): boolean {
+  const { disabledModels } = readPlaygroundState();
+  return !disabledModels.includes(modelId);
+}

--- a/packages/dirirouter/src/playground/routes/chat.ts
+++ b/packages/dirirouter/src/playground/routes/chat.ts
@@ -3,6 +3,7 @@ import { streamSSE } from "hono/streaming";
 import type { DiriRouter } from "../../diri-router.js";
 import type { Registry } from "../../registry.js";
 import { ChatRequestSchema } from "../types.js";
+import { readPlaygroundState } from "../model-state.js";
 
 const PROVIDER_ENV_VARS: Readonly<Record<string, string>> = {
   gemini: "GEMINI_API_KEY",
@@ -67,6 +68,17 @@ export function createChatRouter(
             (selected
               ? resolvedProvider.defaultModel.modelId
               : diriRouter.getModelConfig(undefined).modelId);
+
+          const { disabledModels } = readPlaygroundState();
+          if (disabledModels.includes(resolvedModel)) {
+            await stream.writeSSE({
+              event: "error",
+              data: JSON.stringify({
+                error: `Model '${resolvedModel}' is disabled. Enable it in the playground settings.`,
+              }),
+            });
+            return;
+          }
 
           await stream.writeSSE({
             id: crypto.randomUUID(),

--- a/packages/dirirouter/src/playground/routes/models.ts
+++ b/packages/dirirouter/src/playground/routes/models.ts
@@ -1,8 +1,10 @@
 import type { Context } from "hono";
 import { getBootstrap } from "./status.js";
+import { readPlaygroundState, toggleModel } from "../model-state.js";
 
 export function getModels(c: Context): Response {
   const bootstrap = getBootstrap(c);
+  const { disabledModels } = readPlaygroundState();
 
   const providerMap = new Map(bootstrap.providerStatuses.map((ps) => [ps.name, ps]));
   const providers = bootstrap.registry.list().map((entry) => {
@@ -14,10 +16,55 @@ export function getModels(c: Context): Response {
     };
   });
 
+  const modelCards = bootstrap.modelCardRegistry.list().map((card) => {
+    const subs = bootstrap.subscriptionRegistry.findByModel(card.model);
+    const provider = subs.length > 0 ? (subs[0]?.provider ?? "unknown") : "unknown";
+    return {
+      ...card,
+      id: card.model,
+      provider: provider,
+      enabled: !disabledModels.includes(card.model),
+    };
+  });
+
   return c.json({
-    modelCards: bootstrap.modelCardRegistry.list(),
+    modelCards,
+    disabledModels,
     subscriptions: bootstrap.subscriptionRegistry.list(),
     candidatePool: bootstrap.diriRouter.resolver.getCandidatePool(),
     providers,
+  });
+}
+
+export async function patchModelToggle(c: Context): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("modelId" in body) ||
+    typeof (body as Record<string, unknown>).modelId !== "string"
+  ) {
+    return c.json({ error: "Missing or invalid field: modelId (string)" }, 400);
+  }
+
+  const modelId = (body as Record<string, unknown>).modelId as string;
+
+  // Validate modelId exists
+  const bootstrap = getBootstrap(c);
+  if (!bootstrap.modelCardRegistry.has(modelId)) {
+    return c.json({ error: `Model '${modelId}' not found in registry` }, 404);
+  }
+
+  const updatedState = toggleModel(modelId);
+  return c.json({
+    modelId,
+    enabled: !updatedState.disabledModels.includes(modelId),
+    disabledModels: updatedState.disabledModels,
   });
 }

--- a/packages/dirirouter/src/playground/routes/pick.ts
+++ b/packages/dirirouter/src/playground/routes/pick.ts
@@ -4,6 +4,7 @@ import type { Context } from "hono";
 import type { BootstrapResult } from "../bootstrap.js";
 import { PickRequestSchema } from "../types.js";
 import type { DecisionRequest, DecisionResponse } from "@diricode/dirirouter";
+import { readPlaygroundState } from "../model-state.js";
 
 export function pickRoute() {
   return async (c: Context) => {
@@ -15,13 +16,25 @@ export function pickRoute() {
       const chatId = randomUUID();
       const requestId = randomUUID();
 
+      const { disabledModels } = readPlaygroundState();
+      const userExcluded = validated.constraints?.excludedModels ?? [];
+      const mergedExcluded = [...new Set([...userExcluded, ...disabledModels])];
+
+      const baseConstraints = validated.constraints ?? {};
+      const constraints =
+        mergedExcluded.length > 0
+          ? { ...baseConstraints, excludedModels: mergedExcluded }
+          : Object.keys(baseConstraints).length > 0
+            ? baseConstraints
+            : undefined;
+
       const decisionRequest: DecisionRequest = {
         chatId,
         requestId,
         agent: validated.agent,
         task: validated.task,
         modelDimensions: validated.modelDimensions,
-        ...(validated.constraints && { constraints: validated.constraints }),
+        ...(constraints !== undefined && { constraints }),
       };
 
       const decisionResponse: DecisionResponse = await bootstrap.diriRouter.pick(

--- a/packages/dirirouter/src/playground/server.ts
+++ b/packages/dirirouter/src/playground/server.ts
@@ -5,7 +5,7 @@ import { logger } from "hono/logger";
 import type { BootstrapResult } from "./bootstrap.js";
 import { setBootstrap } from "./routes/status.js";
 import { getStatus } from "./routes/status.js";
-import { getModels } from "./routes/models.js";
+import { getModels, patchModelToggle } from "./routes/models.js";
 import { pickRoute } from "./routes/pick.js";
 import { createChatRouter } from "./routes/chat.js";
 import { renderPlayground } from "./html.js";
@@ -26,6 +26,7 @@ export function createApp(bootstrap: BootstrapResult): Hono {
 
   app.get("/api/status", getStatus);
   app.get("/api/models", getModels);
+  app.patch("/api/models/toggle", patchModelToggle);
   app.post("/api/pick", pickRoute());
   app.route("/api/chat", createChatRouter(bootstrap.diriRouter, bootstrap.registry));
 


### PR DESCRIPTION
## Summary
- Add startup table in CLI showing provider status and model counts
- Add model toggle switches in playground HTML UI grouped by provider
- Persist enabled/disabled state to `playground-state.json`
- Filter disabled models from `/api/pick` and `/api/chat` endpoints

## Changes
- `packages/dirirouter/src/playground/model-state.ts` — New file for JSON state persistence
- `packages/dirirouter/src/playground/cli.ts` — Added startup table with provider status
- `packages/dirirouter/src/playground/html.ts` — Added Alpine.js powered toggle switches
- `packages/dirirouter/src/playground/routes/models.ts` — Added `PATCH /api/models/toggle` and `enabled` field
- `packages/dirirouter/src/playground/routes/pick.ts` — Filter disabled models from pick decisions
- `packages/dirirouter/src/playground/routes/chat.ts` — Filter disabled models from chat completions

## Testing
- Manual QA: CLI table renders, toggle API works, state persists, pick excludes disabled models

## Fixes #562