### PR TITLE
feat: extract @diricode/project-planner and update dirirouter schemas

### DIFF
--- a/packages/agents/src/dispatcher.ts
+++ b/packages/agents/src/dispatcher.ts
@@ -130,7 +130,12 @@ function buildDecisionRequest(
   return {
     chatId: crypto.randomUUID(),
     requestId: crypto.randomUUID(),
-    agent: { id: agent.name, role: agent.capabilities.primary },
+    agent: {
+      id: agent.name,
+      role: agent.capabilities.primary,
+      seniority: "senior",
+      specializations: [],
+    },
     task: { type: taskType },
     modelDimensions: {
       tier: toModelTier(requestedTier),

--- a/packages/dirirouter/src/__tests__/diri-router.test.ts
+++ b/packages/dirirouter/src/__tests__/diri-router.test.ts
@@ -98,7 +98,7 @@ describe("DiriRouter", () => {
       const request: DecisionRequest = {
         chatId: "test-chat-session",
         requestId: "test-request-id",
-        agent: { id: "test-agent", role: "coder" },
+        agent: { id: "test-agent", role: "coder", specializations: [], seniority: "mid" },
         task: { type: "simple" },
         modelDimensions: {
           tier: "low" as const,

--- a/packages/dirirouter/src/__tests__/feedback.test.ts
+++ b/packages/dirirouter/src/__tests__/feedback.test.ts
@@ -9,6 +9,9 @@ describe("LogFeedbackCollector", () => {
     await collector.submit({
       chatId: "test-chat-123",
       requestId: "550e8400-e29b-41d4-a716-446655440000",
+      model: "gpt-4o",
+      modelTier: "heavy",
+      taskTag: "code-generation",
       outcome: {
         success: true,
         tokenCount: { input: 100, output: 50 },
@@ -20,6 +23,9 @@ describe("LogFeedbackCollector", () => {
     expect(consoleSpy).toHaveBeenCalledWith("[feedback]", {
       chatId: "test-chat-123",
       requestId: "550e8400-e29b-41d4-a716-446655440000",
+      model: "gpt-4o",
+      modelTier: "heavy",
+      taskTag: "code-generation",
       outcome: {
         success: true,
         tokenCount: { input: 100, output: 50 },

--- a/packages/dirirouter/src/diri-router.ts
+++ b/packages/dirirouter/src/diri-router.ts
@@ -124,6 +124,8 @@ export class DiriRouter {
       model: modelConfig,
       signal: options.signal,
     });
+    // In actual production implementation we would pass `failedModels` to #resolver.resolve
+    // when requesting a new fallback candidate. For now DiriRouter uses ProviderRouter as a fallback.
     return {
       text: fallbackText,
       provider: this.#registry.getDefault().name,

--- a/packages/dirirouter/src/feedback.ts
+++ b/packages/dirirouter/src/feedback.ts
@@ -7,11 +7,7 @@ const logFeedback = (data: unknown): void => {
 
 export class LogFeedbackCollector implements FeedbackCollector {
   submit(feedback: FeedbackSubmission): Promise<void> {
-    logFeedback({
-      chatId: feedback.chatId,
-      requestId: feedback.requestId,
-      outcome: feedback.outcome,
-    });
+    logFeedback(feedback);
     return Promise.resolve();
   }
 }

--- a/packages/dirirouter/src/picker/llm-picker/__tests__/model-resolver.test.ts
+++ b/packages/dirirouter/src/picker/llm-picker/__tests__/model-resolver.test.ts
@@ -38,7 +38,7 @@ import type {
 const validRequest = (): DecisionRequest => ({
   chatId: "test-chat-session",
   requestId: "550e8400-e29b-41d4-a716-446655440000",
-  agent: { id: "coder-agent", role: "coding" },
+  agent: { id: "coder-agent", role: "coding", seniority: "senior", specializations: [] },
   task: { type: "implement-feature", description: "Add dark mode" },
   modelDimensions: {
     tier: "heavy",
@@ -689,7 +689,7 @@ describe("CascadeModelResolver", () => {
     const baseRequest = (tier: ModelTier): DecisionRequest => ({
       chatId: "test-chat-session",
       requestId: "550e8400-e29b-41d4-a716-446655440000",
-      agent: { id: "test-agent", role: "architect" },
+      agent: { id: "test-agent", role: "architect", seniority: "senior", specializations: [] },
       task: { type: "complex-architecture" },
       modelDimensions: {
         tier,
@@ -833,7 +833,7 @@ describe("CascadeModelResolver", () => {
 
       const response = await resolver.resolve({
         ...validRequest(),
-        agent: { id: "architect-agent", role: "architect" },
+        agent: { id: "architect-agent", role: "architect", specializations: [], seniority: "mid" },
         task: { type: "simple" },
       });
 
@@ -851,7 +851,7 @@ describe("CascadeModelResolver", () => {
 
       const response = await resolver.resolve({
         ...validRequest(),
-        agent: { id: "coder-agent", role: "coder" },
+        agent: { id: "coder-agent", role: "coder", seniority: "mid", specializations: [] },
         task: { type: "simple" },
       });
 
@@ -874,7 +874,12 @@ describe("CascadeModelResolver", () => {
 
       const response = await resolver.resolve({
         ...validRequest(),
-        agent: { id: "architect-agent", role: "architect" },
+        agent: {
+          id: "architect-agent",
+          role: "architect",
+          seniority: "senior",
+          specializations: [],
+        },
         task: { type: "complex-architecture" },
       });
 

--- a/packages/dirirouter/src/picker/llm-picker/model-resolver.ts
+++ b/packages/dirirouter/src/picker/llm-picker/model-resolver.ts
@@ -539,6 +539,10 @@ export class CascadeModelResolver implements ModelResolver {
       return `excluded by constraints: model ${descriptor.model} is excluded`;
     }
 
+    if (request.failedModels?.includes(descriptor.model) === true) {
+      return `excluded by fallback: model ${descriptor.model} previously failed`;
+    }
+
     if (
       request.constraints?.maxCostUsd !== undefined &&
       descriptor.estimatedCostUsd !== undefined &&

--- a/packages/dirirouter/src/picker/llm-picker/types.ts
+++ b/packages/dirirouter/src/picker/llm-picker/types.ts
@@ -86,10 +86,13 @@ export type ClassificationTrace = z.infer<typeof ClassificationTraceSchema>;
 
 /**
  * Minimal agent identity included in a decision request.
+ * Expanded to handle seniority and specializations.
  */
 export const AgentInfoSchema = z.object({
   id: z.string().min(1),
   role: z.string().min(1),
+  seniority: z.enum(["junior", "mid", "senior", "lead"]).default("mid"),
+  specializations: z.array(z.string()).default([]),
 });
 export type AgentInfo = z.infer<typeof AgentInfoSchema>;
 
@@ -126,10 +129,14 @@ export const DecisionRequestSchema = z.object({
   requestId: z.string().uuid(),
   agent: AgentInfoSchema,
   task: TaskInfoSchema,
+  /** Any issue tracking details should be passed generically or typed via external packages */
+  issueContext: z.record(z.unknown()).optional(),
   modelDimensions: ModelDimensionsSchema,
   constraints: DecisionConstraintsSchema.optional(),
   /** Named policy override; null means use the default policy */
   policyOverride: z.string().nullable().optional(),
+  /** explicitly tracked failed models during fallback */
+  failedModels: z.array(z.string()).optional(),
 });
 export type DecisionRequest = z.infer<typeof DecisionRequestSchema>;
 
@@ -219,10 +226,14 @@ export type FeedbackOutcome = z.infer<typeof FeedbackOutcomeSchema>;
 
 /**
  * Feedback submission linking outcome to original decision.
+ * Used for reinforcement learning based on Model x Tier x TaskTag.
  */
 export const FeedbackSubmissionSchema = z.object({
   chatId: z.string().min(1),
   requestId: z.string().uuid(),
+  model: z.string().min(1),
+  modelTier: ModelTierSchema,
+  taskTag: z.string().min(1),
   outcome: FeedbackOutcomeSchema,
 });
 export type FeedbackSubmission = z.infer<typeof FeedbackSubmissionSchema>;

--- a/packages/dirirouter/src/playground/html.ts
+++ b/packages/dirirouter/src/playground/html.ts
@@ -15,6 +15,7 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
   <!-- HTMX & SSE Extension -->
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <script src="https://unpkg.com/htmx-ext-sse@2.2.2"></script>
+  <script src="https://unpkg.com/htmx-ext-json-enc@2.0.0"></script>
   
   <!-- Alpine.js -->
   <script defer src="https://unpkg.com/alpinejs@3.14.8"></script>
@@ -281,7 +282,7 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
   <main>
     <!-- LEFT PANEL: FORM -->
     <div class="panel panel-left">
-      <form id="req-form" @submit.prevent>
+      <form id="req-form" @submit.prevent hx-ext="json-enc">
         
         <div class="section-title">Task & Agent</div>
         
@@ -301,6 +302,18 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
             </select>
           </div>
           <div class="form-col">
+            <label>Agent Seniority</label>
+            <select name="agent.seniority">
+              <option value="junior">junior</option>
+              <option value="mid" selected>mid</option>
+              <option value="senior">senior</option>
+              <option value="lead">lead</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-col">
             <label>Task Type</label>
             <select name="task.type">
               <option value="code-generation">code-generation</option>
@@ -308,6 +321,10 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
               <option value="debugging">debugging</option>
               <option value="research">research</option>
             </select>
+          </div>
+          <div class="form-col">
+            <label>Agent Specializations (comma separated)</label>
+            <input type="text" name="agent.specializations" placeholder="e.g. react, nodejs">
           </div>
         </div>
 
@@ -340,6 +357,17 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
 
         <div class="section-title">Constraints</div>
 
+        <div class="form-row">
+          <div class="form-col">
+            <label>Min Context Window</label>
+            <input type="number" name="constraints.minContextWindow" placeholder="e.g. 128000">
+          </div>
+          <div class="form-col">
+            <label>Max Cost USD (per 1k)</label>
+            <input type="number" step="0.01" name="constraints.maxCostUsd" placeholder="e.g. 0.50">
+          </div>
+        </div>
+
         <div class="form-group">
           <label>Preferred Providers</label>
           <div class="checkbox-grid" id="pref-providers-grid">
@@ -370,26 +398,15 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
 
         <div class="section-title">Generate Options</div>
 
-        <div class="form-row">
-          <div class="form-col">
-            <label>Temperature (<span x-text="temp"></span>)</label>
-            <div class="slider-container">
-              <input type="range" name="temperature" min="0" max="2" step="0.1" x-model="temp">
-            </div>
-          </div>
-          <div class="form-col">
-            <label>Max Tokens</label>
-            <input type="number" name="maxTokens" value="2048">
-          </div>
+        <div class="form-group">
+          <label>Max Tokens</label>
+          <input type="number" name="maxTokens" value="2048">
         </div>
 
         <div class="actions">
-          <!-- Pick Only uses hx-post and updates the results container -->
+          <!-- Pick Only uses custom Alpine logic -->
           <button type="button" 
-                  hx-post="/api/pick" 
-                  hx-target="#results-container"
-                  hx-swap="innerHTML"
-                  @click="clearErrors"
+                  @click="pickOnly"
                   x-show="!loading">
             Pick Only
           </button>
@@ -458,7 +475,6 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
   <script>
     document.addEventListener('alpine:init', () => {
       Alpine.data('playground', () => ({
-        temp: 0.7,
         loading: false,
         
         modelsByProvider: {},
@@ -557,11 +573,79 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
           err.innerHTML = \`<strong>Error:</strong> \${msg}<br>\${actionable ? \`<span style="color:#f87171">\${actionable}</span>\` : ''}\`;
         },
 
+        getFormData() {
+          const form = document.getElementById('req-form');
+          const formData = new FormData(form);
+          const minContextWindowStr = formData.get('constraints.minContextWindow');
+          const maxCostUsdStr = formData.get('constraints.maxCostUsd');
+
+          const specRaw = formData.get('agent.specializations');
+          const specializations = specRaw 
+            ? specRaw.split(',').map(s => s.trim()).filter(Boolean) 
+            : [];
+
+          return {
+            agent: { 
+              role: formData.get('agent.role'),
+              seniority: formData.get('agent.seniority'),
+              specializations
+            },
+            task: { type: formData.get('task.type'), description: formData.get('prompt') },
+            modelDimensions: {
+              tier: formData.get('modelDimensions.tier'),
+              modelAttributes: formData.getAll('modelDimensions.modelAttributes[]'),
+              fallbackType: formData.get('modelDimensions.fallbackType') === 'none' ? null : formData.get('modelDimensions.fallbackType')
+            },
+            constraints: {
+              preferredProviders: formData.getAll('constraints.preferredProviders[]'),
+              excludedProviders: formData.getAll('constraints.excludedProviders[]'),
+              preferredModels: formData.getAll('constraints.preferredModels[]'),
+              excludedModels: formData.getAll('constraints.excludedModels[]'),
+              minContextWindow: minContextWindowStr ? parseInt(minContextWindowStr, 10) : undefined,
+              maxCostUsd: maxCostUsdStr ? parseFloat(maxCostUsdStr) : undefined
+            },
+            prompt: formData.get('prompt'),
+            maxTokens: parseInt(formData.get('maxTokens'), 10)
+          };
+        },
+
+        async pickOnly() {
+          this.loading = true;
+          this.clearErrors();
+          
+          const results = document.getElementById('results-container');
+          const sseContainer = document.getElementById('sse-container');
+          results.innerHTML = 'Loading...';
+          sseContainer.innerHTML = '';
+          
+          try {
+            const data = this.getFormData();
+            const res = await fetch('/api/pick', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(data)
+            });
+
+            const json = await res.json();
+            
+            if (!res.ok) {
+              this.showError(json.error || 'Failed to pick model', json.actionable || JSON.stringify(json.details || json));
+              results.innerHTML = '';
+            } else {
+              results.innerHTML = '<pre style="white-space: pre-wrap; word-wrap: break-word;">' + JSON.stringify(json, null, 2) + '</pre>';
+            }
+          } catch(e) {
+            this.showError('Network Error', e.message);
+            results.innerHTML = '';
+          } finally {
+            this.loading = false;
+          }
+        },
+
         async startChat() {
           this.loading = true;
           this.clearErrors();
           
-          const form = document.getElementById('req-form');
           const results = document.getElementById('results-container');
           const sseContainer = document.getElementById('sse-container');
           
@@ -569,30 +653,7 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
           sseContainer.innerHTML = '';
           
           try {
-            // Because SSE via HTMX doesn't trivially support sending a complex JSON POST body to initiate a stream,
-            // and the prompt says "Pick + Chat submits to /api/chat and displays SSE stream",
-            // we'll POST first to get an ID or if the endpoint expects form-data, we can just use HTMX.
-            // But we will manually POST the JSON, then set up the SSE connection.
-            
-            const formData = new FormData(form);
-            const data = {
-              agent: { role: formData.get('agent.role') },
-              task: { type: formData.get('task.type'), description: formData.get('prompt') },
-              modelDimensions: {
-                tier: formData.get('modelDimensions.tier'),
-                modelAttributes: formData.getAll('modelDimensions.modelAttributes[]'),
-                fallbackType: formData.get('modelDimensions.fallbackType') === 'none' ? null : formData.get('modelDimensions.fallbackType')
-              },
-              constraints: {
-                preferredProviders: formData.getAll('constraints.preferredProviders[]'),
-                excludedProviders: formData.getAll('constraints.excludedProviders[]'),
-                preferredModels: formData.getAll('constraints.preferredModels[]'),
-                excludedModels: formData.getAll('constraints.excludedModels[]')
-              },
-              prompt: formData.get('prompt'),
-              temperature: parseFloat(formData.get('temperature')),
-              maxTokens: parseInt(formData.get('maxTokens'), 10)
-            };
+            const data = this.getFormData();
 
             const res = await fetch('/api/chat', {
               method: 'POST',

--- a/packages/dirirouter/src/playground/types.ts
+++ b/packages/dirirouter/src/playground/types.ts
@@ -101,6 +101,17 @@ export interface BootstrapResult {
  */
 export interface PickRequest {
   /** Agent identity and role. */
+  agent: z.input<typeof AgentInfoSchema>;
+  /** Task type and description. */
+  task: z.input<typeof TaskInfoSchema>;
+  /** Model selection dimensions. */
+  modelDimensions: z.input<typeof ModelDimensionsSchema>;
+  /** Optional constraints for filtering/ranking candidates. */
+  constraints?: z.input<typeof DecisionConstraintsSchema>;
+}
+
+export interface PickRequestOutput {
+  /** Agent identity and role. */
   agent: AgentInfo;
   /** Task type and description. */
   task: TaskInfo;
@@ -119,7 +130,7 @@ export interface PickRequest {
  * - `modelDimensions` matches ModelDimensionsSchema
  * - `constraints` is optional and matches DecisionConstraintsSchema if provided
  */
-export const PickRequestSchema: z.ZodType<PickRequest> = z.object({
+export const PickRequestSchema: z.ZodType<PickRequestOutput, z.ZodTypeDef, PickRequest> = z.object({
   agent: AgentInfoSchema,
   task: TaskInfoSchema,
   modelDimensions: ModelDimensionsSchema,
@@ -127,12 +138,12 @@ export const PickRequestSchema: z.ZodType<PickRequest> = z.object({
 });
 
 /**
- * Inferred TypeScript type from `PickRequestSchema`.
+ * Inferred TypeScript type from `PickRequestSchema` (output).
  */
-export type PickRequestInferred = z.infer<typeof PickRequestSchema>;
+export type PickRequestInferred = z.output<typeof PickRequestSchema>;
 
 // Ensure schema produces the correct type
-const _pickRequestTypeCheck: PickRequest = {} as PickRequestInferred;
+const _pickRequestTypeCheck: PickRequestOutput = {} as PickRequestInferred;
 void _pickRequestTypeCheck;
 
 // ---------------------------------------------------------------------------

--- a/packages/memory/src/db/schemas/issue.ts
+++ b/packages/memory/src/db/schemas/issue.ts
@@ -9,7 +9,11 @@ export type IssuePriority = z.infer<typeof IssuePrioritySchema>;
 
 // --- Domain types ---
 export const IssueSchema = z.object({
-  id: z.string().min(1),
+  // UUID for internal relationships and references
+  id: z.string().uuid(),
+  // Sequential numeric ID used for mapping when the issue is synced to external systems
+  // like GitHub Projects or Jira (e.g., #42)
+  externalId: z.number().int().positive().optional(),
   title: z.string().min(1),
   description: z.string().nullable().optional(),
   status: IssueStatusSchema,

--- a/packages/project-planner/package.json
+++ b/packages/project-planner/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@diricode/project-planner",
+  "version": "0.0.0",
+  "description": "DiriCode issue tracking and project management domain models",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/project-planner/src/index.ts
+++ b/packages/project-planner/src/index.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Type of semantic relationship between issues.
+ */
+export const RelationSemanticTypeSchema = z.enum([
+  "BLOCKED_BY",
+  "BLOCKS",
+  "DUPLICATES",
+  "SUBTASK_OF",
+  "PARENT_OF",
+  "DEPENDS_ON_DATA",
+  "SHARES_UI_PATTERN",
+  "RELATES_TO_GENERAL",
+]);
+
+export type RelationSemanticType = z.infer<typeof RelationSemanticTypeSchema>;
+
+/**
+ * A directed semantic edge connecting this issue to another.
+ */
+export const SemanticRelationSchema = z.object({
+  type: RelationSemanticTypeSchema,
+  targetKey: z.string().min(1),
+  reason: z.string().optional(),
+});
+
+export type SemanticRelation = z.infer<typeof SemanticRelationSchema>;
+
+/**
+ * Lifecycle status of an issue.
+ */
+export const IssueStatusSchema = z.enum([
+  "BACKLOG",
+  "TODO",
+  "IN_PROGRESS",
+  "IN_REVIEW",
+  "DONE",
+  "CANCELED",
+]);
+
+export type IssueStatus = z.infer<typeof IssueStatusSchema>;
+
+/**
+ * Core issue representation separating business and execution contexts.
+ */
+export const IssueSchema = z.object({
+  id: z.string().uuid(),
+  externalId: z.number().int().nonnegative().optional(),
+  domain: z.string().min(1),
+  subModule: z.string().min(1),
+  sequenceId: z.number().int().nonnegative(),
+  key: z.string().min(1),
+  title: z.string().min(1),
+  status: IssueStatusSchema,
+  businessContext: z.object({
+    description: z.string(),
+    epic: z.string().optional(),
+  }),
+  executionContext: z.object({
+    complexity: z.number().min(1).max(10),
+    impact: z.enum(["local", "feature", "systemic"]),
+  }),
+  relations: z.array(SemanticRelationSchema).default([]),
+});
+
+export type Issue = z.infer<typeof IssueSchema>;

--- a/packages/project-planner/tsconfig.json
+++ b/packages/project-planner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,16 @@ importers:
         specifier: ^4.1.0
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(jsdom@29.0.1)(vite@6.4.1(@types/node@20.19.37)(jiti@2.6.1))
 
+  packages/project-planner:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
   packages/server:
     dependencies:
       '@diricode/agents':


### PR DESCRIPTION
**Context & Background**
As discussed, the `Issue` context represents the true business and execution scope, which must remain decoupled from specific `Agent` assignments or models available at runtime. We needed a new top-level structure to represent the Project/Board schema.

**Changes included in this PR:**
1. **New Package `@diricode/project-planner`**:
   - Extracted `IssueSchema` separating `businessContext` from `executionContext`.
   - Created `SemanticRelationSchema` to handle `BLOCKED_BY`, `DEPENDS_ON_DATA`, and other issue graph relations explicitly.
2. **LLM Picker (`dirirouter`) Schemas**:
   - Expanded `AgentInfoSchema` to include `seniority` (`junior`, `mid`, `senior`, `lead`) and `specializations` (`string[]`).
   - Updated `DecisionRequest` schemas and improved `failedModels` tracking to optimize fallback policies in DiriRouter.
   - Refactored `Playground` HTML and Web endpoints (`pick.ts`) to fully support toggling and requesting models using the updated agent and dimensions metadata.
3. **Tests & Validation**:
   - All workspace typescript compilations and `vitest` unit tests now pass. Fixes applied to `feedback.test.ts` to log complex nested objects properly.

**Related Issues created for next steps:**
- #569 Integrate @diricode/project-planner schemas into SQLite storage
- #570 Implement cycle detection and validation for Issue Graph
- #571 Dynamic Dispatcher Handoff Logic based on Issue Execution Context