### PR TITLE
feat(diricontext): canonical type system with Zod schemas

### DIFF
--- a/packages/project-planner/src/index.ts
+++ b/packages/project-planner/src/index.ts
@@ -67,3 +67,5 @@ export const IssueSchema = z.object({
 export type Issue = z.infer<typeof IssueSchema>;
 
 export { initDatabase } from "./lib/database.js";
+export * from "./types/index.js";
+export * from "./legacy.js";

--- a/packages/project-planner/src/legacy.ts
+++ b/packages/project-planner/src/legacy.ts
@@ -1,0 +1,69 @@
+import type { Issue } from "./index.js";
+import type { Node, TaskNode } from "./types/index.js";
+
+export {
+  RelationSemanticTypeSchema,
+  SemanticRelationSchema,
+  IssueStatusSchema,
+  IssueSchema,
+} from "./index.js";
+
+export type { RelationSemanticType, SemanticRelation, IssueStatus, Issue } from "./index.js";
+
+function getLegacyDomain(namespaceId: string): string {
+  if (namespaceId === "docs" || namespaceId === "plan") {
+    return namespaceId;
+  }
+
+  if (namespaceId.startsWith("reference:")) {
+    return namespaceId.slice("reference:".length) || "reference";
+  }
+
+  return "unknown";
+}
+
+/**
+ * @deprecated Lossy adapter — use Node types directly in new code.
+ */
+export function taskNodeToIssue(node: Node): Issue {
+  return {
+    id: node.id,
+    externalId: undefined,
+    domain: getLegacyDomain(node.namespace_id),
+    subModule: "legacy",
+    sequenceId: 0,
+    key: node.id,
+    title: node.title,
+    status: node.status,
+    businessContext: {
+      description: node.description,
+      epic: undefined,
+    },
+    executionContext: {
+      complexity: 5,
+      impact: "local",
+    },
+    relations: [],
+  } satisfies Issue;
+}
+
+/**
+ * @deprecated Lossy adapter — use Node types directly in new code.
+ */
+export function issueToTaskNode(issue: Issue): Node {
+  const timestamp = new Date().toISOString();
+
+  return {
+    id: issue.id,
+    namespace_id: "plan",
+    type: "task",
+    title: issue.title,
+    description: issue.businessContext.description,
+    status: issue.status,
+    labels: [],
+    metadata: {},
+    parentId: undefined,
+    created_at: timestamp,
+    updated_at: timestamp,
+  } satisfies TaskNode;
+}

--- a/packages/project-planner/src/types/edge.ts
+++ b/packages/project-planner/src/types/edge.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const EdgeTypeSchema = z.enum([
+  "depends_on",
+  "blocks",
+  "implements",
+  "related_to",
+  "contains",
+  "precedes",
+  "tracks",
+  "duplicates",
+]);
+export type EdgeType = z.infer<typeof EdgeTypeSchema>;
+
+export const SoftRelationTypeSchema = z.enum([
+  "compares_to",
+  "inspires",
+  "must_align_with",
+  "supersedes",
+  "diverges_from",
+]);
+export type SoftRelationType = z.infer<typeof SoftRelationTypeSchema>;
+
+export const RelationStrengthSchema = z.enum(["soft", "medium", "strong"]);
+export type RelationStrength = z.infer<typeof RelationStrengthSchema>;
+
+export const EdgeKindSchema = z.enum(["hard", "soft"]);
+export type EdgeKind = z.infer<typeof EdgeKindSchema>;
+
+export const AnyEdgeTypeSchema = z.union([EdgeTypeSchema, SoftRelationTypeSchema]);
+export type AnyEdgeType = z.infer<typeof AnyEdgeTypeSchema>;
+
+export const EdgeSchema = z
+  .object({
+    id: z.string().uuid(),
+    source_id: z.string().uuid(),
+    target_id: z.string().uuid(),
+    type: AnyEdgeTypeSchema,
+    kind: EdgeKindSchema.default("hard"),
+    strength: RelationStrengthSchema.optional(),
+    notes: z.string().optional(),
+    created_at: z
+      .string()
+      .datetime()
+      .default(() => new Date().toISOString()),
+  })
+  .superRefine((edge, ctx) => {
+    if (edge.kind === "soft" && edge.strength === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "strength is required for soft edges",
+        path: ["strength"],
+      });
+    }
+  });
+export type Edge = z.infer<typeof EdgeSchema>;

--- a/packages/project-planner/src/types/index.ts
+++ b/packages/project-planner/src/types/index.ts
@@ -1,0 +1,4 @@
+export * from "./node.js";
+export * from "./edge.js";
+export * from "./namespace.js";
+export * from "./mcp.js";

--- a/packages/project-planner/src/types/mcp.ts
+++ b/packages/project-planner/src/types/mcp.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const McpToolRequestSchema = z.object({
+  tool: z.string().min(1),
+  arguments: z.record(z.unknown()),
+});
+export type McpToolRequest = z.infer<typeof McpToolRequestSchema>;
+
+export const McpToolResponseSchema = z.object({
+  content: z.array(
+    z.object({
+      type: z.string().min(1),
+      text: z.string(),
+    }),
+  ),
+  isError: z.boolean().optional(),
+});
+export type McpToolResponse = z.infer<typeof McpToolResponseSchema>;

--- a/packages/project-planner/src/types/namespace.ts
+++ b/packages/project-planner/src/types/namespace.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { NamespaceTypeSchema } from "./node.js";
+import type { NamespaceType } from "./node.js";
+
+export const NamespaceSchema = z.object({
+  id: z.string().min(1),
+  type: NamespaceTypeSchema,
+  name: z.string().min(1),
+  description: z.string().optional(),
+  created_at: z
+    .string()
+    .datetime()
+    .default(() => new Date().toISOString()),
+});
+export type Namespace = z.infer<typeof NamespaceSchema>;
+
+export function getNamespaceId(type: NamespaceType, name?: string): string {
+  switch (type) {
+    case "docs":
+      return "docs";
+    case "plan":
+      return "plan";
+    case "reference":
+      if (!name || name.trim().length === 0) {
+        throw new Error("name is required for reference namespaces");
+      }
+
+      return `reference:${name}`;
+  }
+}

--- a/packages/project-planner/src/types/node.ts
+++ b/packages/project-planner/src/types/node.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+
+export const NamespaceTypeSchema = z.enum(["docs", "plan", "reference"]);
+export type NamespaceType = z.infer<typeof NamespaceTypeSchema>;
+
+export const NodeTypeSchema = z.enum([
+  "document",
+  "feature",
+  "component",
+  "task",
+  "epic",
+  "phase",
+  "sprint",
+  "milestone",
+  "reference_project",
+  "reference_feature",
+]);
+export type NodeType = z.infer<typeof NodeTypeSchema>;
+
+export const NodeStatusSchema = z.enum([
+  "BACKLOG",
+  "TODO",
+  "IN_PROGRESS",
+  "IN_REVIEW",
+  "DONE",
+  "CANCELED",
+]);
+export type NodeStatus = z.infer<typeof NodeStatusSchema>;
+
+export const BaseNodeSchema = z.object({
+  id: z.string().uuid(),
+  namespace_id: z.string().min(1),
+  type: NodeTypeSchema,
+  title: z.string().min(1),
+  description: z.string().default(""),
+  status: NodeStatusSchema.default("BACKLOG"),
+  labels: z.array(z.string()).default([]),
+  metadata: z.record(z.unknown()).default({}),
+  parentId: z.string().uuid().optional(),
+  created_at: z
+    .string()
+    .datetime()
+    .default(() => new Date().toISOString()),
+  updated_at: z
+    .string()
+    .datetime()
+    .default(() => new Date().toISOString()),
+});
+export type BaseNode = z.infer<typeof BaseNodeSchema>;
+
+export const DocumentNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("document"),
+});
+export type DocumentNode = z.infer<typeof DocumentNodeSchema>;
+
+export const FeatureNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("feature"),
+});
+export type FeatureNode = z.infer<typeof FeatureNodeSchema>;
+
+export const ComponentNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("component"),
+});
+export type ComponentNode = z.infer<typeof ComponentNodeSchema>;
+
+export const TaskNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("task"),
+});
+export type TaskNode = z.infer<typeof TaskNodeSchema>;
+
+export const EpicNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("epic"),
+});
+export type EpicNode = z.infer<typeof EpicNodeSchema>;
+
+export const PhaseNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("phase"),
+});
+export type PhaseNode = z.infer<typeof PhaseNodeSchema>;
+
+export const SprintNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("sprint"),
+});
+export type SprintNode = z.infer<typeof SprintNodeSchema>;
+
+export const MilestoneNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("milestone"),
+});
+export type MilestoneNode = z.infer<typeof MilestoneNodeSchema>;
+
+export const ReferenceProjectNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("reference_project"),
+});
+export type ReferenceProjectNode = z.infer<typeof ReferenceProjectNodeSchema>;
+
+export const ReferenceFeatureNodeSchema = BaseNodeSchema.extend({
+  type: z.literal("reference_feature"),
+});
+export type ReferenceFeatureNode = z.infer<typeof ReferenceFeatureNodeSchema>;
+
+export const NodeSchemaMap = {
+  document: DocumentNodeSchema,
+  feature: FeatureNodeSchema,
+  component: ComponentNodeSchema,
+  task: TaskNodeSchema,
+  epic: EpicNodeSchema,
+  phase: PhaseNodeSchema,
+  sprint: SprintNodeSchema,
+  milestone: MilestoneNodeSchema,
+  reference_project: ReferenceProjectNodeSchema,
+  reference_feature: ReferenceFeatureNodeSchema,
+} as const;
+
+export const NodeSchema = z.discriminatedUnion("type", [
+  DocumentNodeSchema,
+  FeatureNodeSchema,
+  ComponentNodeSchema,
+  TaskNodeSchema,
+  EpicNodeSchema,
+  PhaseNodeSchema,
+  SprintNodeSchema,
+  MilestoneNodeSchema,
+  ReferenceProjectNodeSchema,
+  ReferenceFeatureNodeSchema,
+]);
+export type Node = z.infer<typeof NodeSchema>;
+
+export type NodeMap = {
+  [K in NodeType]: Extract<Node, { type: K }>;
+};


### PR DESCRIPTION
## Summary

Canonical type system for `diricontext` (Epic #576, Task #582):

- **Node types**: All 10 node schemas (document, feature, component, task, epic, phase, sprint, milestone, reference_project, reference_feature) as discriminated union on `type`
- **Edge types**: Unified hard + soft relation schemas with `superRefine` validation enforcing `strength` on soft edges
- **Namespace types**: Namespace schema + `getNamespaceId()` helper (`docs`, `plan`, `reference:{name}`)
- **MCP tool stubs**: Lightweight request/response schemas for later extension
- **Legacy adapter**: Lossy `taskNodeToIssue()` / `issueToTaskNode()` with `@deprecated` markers

## Acceptance Criteria

- [x] All 10 node type schemas defined and export correctly
- [x] Edge schema supports both hard and soft relations in single type
- [x] Namespace ID derivation works: `getNamespaceId("reference", "legacy-app") → "reference:legacy-app"`
- [x] Legacy adapter: `taskNodeToIssue()` and `issueToTaskNode()` exist (marked lossy)
- [x] `pnpm build` succeeds with no type errors
- [x] No relation ID arrays in any node metadata schema

Fixes #582