### PR TITLE
fix: replace hardcoded non-existent Copilot model versions with real models

### DIFF
--- a/packages/core/src/__tests__/model-config-resolver.test.ts
+++ b/packages/core/src/__tests__/model-config-resolver.test.ts
@@ -43,14 +43,14 @@ describe("DefaultModelTierResolver", () => {
   describe("policy table sanity checks", () => {
     it("heavy tier uses premium models", () => {
       const heavy = resolver.resolve(makeAgent(["heavy"], "planning"));
-      expect(heavy.model).toBe("claude-opus-4.6");
+      expect(heavy.model).toBe("claude-3-opus");
       expect(heavy.provider).toBe("copilot");
     });
 
-    it("light tier uses haiku across all domains", () => {
+    it("light tier uses gpt-4o-mini across all domains", () => {
       for (const domain of DOMAINS) {
         const result = resolver.resolve(makeAgent(["light"], domain));
-        expect(result.model).toBe("claude-haiku-4.5");
+        expect(result.model).toBe("gpt-4o-mini");
         expect(result.provider).toBe("copilot");
       }
     });
@@ -73,12 +73,12 @@ describe("DefaultModelTierResolver", () => {
 
     it("uses requested tier when allowed", () => {
       const result = resolver.resolve(makeAgent(["light", "medium", "heavy"], "coding"), "light");
-      expect(result.model).toBe("claude-haiku-4.5");
+      expect(result.model).toBe("gpt-4o-mini");
     });
 
     it("falls back to highest allowed tier when requested tier is not allowed", () => {
       const result = resolver.resolve(makeAgent(["medium", "light"], "coding"), "heavy");
-      expect(result.model).toBe("gpt-5.4-mini");
+      expect(result.model).toBe("gpt-4o");
     });
   });
 });

--- a/packages/core/src/__tests__/model-tier-resolver.test.ts
+++ b/packages/core/src/__tests__/model-tier-resolver.test.ts
@@ -3,9 +3,9 @@ import { ModelTierResolver } from "../agents/model-tier-resolver.js";
 import type { AvailabilityChecker, ModelTier } from "../agents/model-tier-resolver.js";
 
 const DEFAULT_MAPPINGS = {
-  heavy: { preferred: "claude-opus-4.6", fallback: ["gpt-5.4", "gemini-3.1-pro"] },
-  medium: { preferred: "sonnet-4.6", fallback: ["kimi-2.5", "qwen3-coder-next"] },
-  light: { preferred: "haiku-4.5", fallback: ["deepseek-v3.2"] },
+  heavy: { preferred: "claude-3-opus", fallback: ["o1", "gemini-2.5-pro"] },
+  medium: { preferred: "claude-3.5-sonnet", fallback: ["gpt-4o", "gemini-2.5-flash"] },
+  light: { preferred: "gpt-4o-mini", fallback: ["gemini-2.5-flash-lite"] },
 } as const;
 
 describe("ModelTierResolver", () => {
@@ -13,17 +13,17 @@ describe("ModelTierResolver", () => {
     it("returns preferred model when available", () => {
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS);
       const result = resolver.resolve("heavy");
-      expect(result.model).toBe("claude-opus-4.6");
+      expect(result.model).toBe("claude-3-opus");
       expect(result.reason).toBe("preferred");
       expect(result.isDegraded).toBe(false);
       expect(result.fallbackIndex).toBe(0);
     });
 
     it("returns fallback when preferred is unavailable", () => {
-      const checkAvailability: AvailabilityChecker = (model) => model !== "claude-opus-4.6";
+      const checkAvailability: AvailabilityChecker = (model) => model !== "claude-3-opus";
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS, { checkAvailability });
       const result = resolver.resolve("heavy");
-      expect(result.model).toBe("gpt-5.4");
+      expect(result.model).toBe("o1");
       expect(result.reason).toBe("fallback");
       expect(result.isDegraded).toBe(false);
       expect(result.fallbackIndex).toBe(1);
@@ -31,10 +31,10 @@ describe("ModelTierResolver", () => {
 
     it("returns second fallback when first fallback is also unavailable", () => {
       const checkAvailability: AvailabilityChecker = (model) =>
-        model !== "claude-opus-4.6" && model !== "gpt-5.4";
+        model !== "claude-3-opus" && model !== "o1";
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS, { checkAvailability });
       const result = resolver.resolve("heavy");
-      expect(result.model).toBe("gemini-3.1-pro");
+      expect(result.model).toBe("gemini-2.5-pro");
       expect(result.reason).toBe("fallback");
       expect(result.isDegraded).toBe(false);
       expect(result.fallbackIndex).toBe(2);
@@ -44,7 +44,7 @@ describe("ModelTierResolver", () => {
       const checkAvailability: AvailabilityChecker = () => false;
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS, { checkAvailability });
       const result = resolver.resolve("heavy");
-      expect(result.model).toBe("claude-opus-4.6");
+      expect(result.model).toBe("claude-3-opus");
       expect(result.reason).toBe("degraded");
       expect(result.isDegraded).toBe(true);
       expect(result.fallbackIndex).toBe(0);
@@ -64,54 +64,50 @@ describe("ModelTierResolver", () => {
     it("returns preferred model without checking availability", () => {
       const checkAvailability: AvailabilityChecker = () => false;
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS, { checkAvailability });
-      expect(resolver.getPreferred("heavy")).toBe("claude-opus-4.6");
-      expect(resolver.getPreferred("medium")).toBe("sonnet-4.6");
-      expect(resolver.getPreferred("light")).toBe("haiku-4.5");
+      expect(resolver.getPreferred("heavy")).toBe("claude-3-opus");
+      expect(resolver.getPreferred("medium")).toBe("claude-3.5-sonnet");
+      expect(resolver.getPreferred("light")).toBe("gpt-4o-mini");
     });
   });
 
   describe("getFallbackChain", () => {
     it("returns full chain including preferred", () => {
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS);
-      expect(resolver.getFallbackChain("heavy")).toEqual([
-        "claude-opus-4.6",
-        "gpt-5.4",
-        "gemini-3.1-pro",
-      ]);
+      expect(resolver.getFallbackChain("heavy")).toEqual(["claude-3-opus", "o1", "gemini-2.5-pro"]);
     });
 
     it("returns only preferred when no fallbacks configured", () => {
       const mappings = {
-        heavy: { preferred: "claude-opus-4.6" },
-        medium: { preferred: "sonnet" },
-        light: { preferred: "haiku" },
+        heavy: { preferred: "claude-3-opus" },
+        medium: { preferred: "claude-3.5-sonnet" },
+        light: { preferred: "gpt-4o-mini" },
       };
       const resolver = new ModelTierResolver(mappings);
-      expect(resolver.getFallbackChain("heavy")).toEqual(["claude-opus-4.6"]);
+      expect(resolver.getFallbackChain("heavy")).toEqual(["claude-3-opus"]);
     });
   });
 
   describe("isPreferred", () => {
     it("returns true for preferred model", () => {
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS);
-      expect(resolver.isPreferred("heavy", "claude-opus-4.6")).toBe(true);
+      expect(resolver.isPreferred("heavy", "claude-3-opus")).toBe(true);
     });
 
     it("returns false for fallback model", () => {
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS);
-      expect(resolver.isPreferred("heavy", "gpt-5.4")).toBe(false);
+      expect(resolver.isPreferred("heavy", "o1")).toBe(false);
     });
   });
 
   describe("isInChain", () => {
     it("returns true for preferred model", () => {
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS);
-      expect(resolver.isInChain("heavy", "claude-opus-4.6")).toBe(true);
+      expect(resolver.isInChain("heavy", "claude-3-opus")).toBe(true);
     });
 
     it("returns true for fallback model", () => {
       const resolver = new ModelTierResolver(DEFAULT_MAPPINGS);
-      expect(resolver.isInChain("heavy", "gpt-5.4")).toBe(true);
+      expect(resolver.isInChain("heavy", "o1")).toBe(true);
     });
 
     it("returns false for model not in chain", () => {
@@ -130,7 +126,7 @@ describe("ModelTierResolver", () => {
 
       expect(updated.getPreferred("heavy")).toBe("new-preferred");
       expect(updated.getFallbackChain("heavy")).toEqual(["new-preferred", "new-fallback"]);
-      expect(resolver.getPreferred("heavy")).toBe("claude-opus-4.6");
+      expect(resolver.getPreferred("heavy")).toBe("claude-3-opus");
     });
   });
 

--- a/packages/core/src/agents/model-selection-policy.ts
+++ b/packages/core/src/agents/model-selection-policy.ts
@@ -16,96 +16,96 @@ export interface AgentModelConfig extends ResolvedModelTarget {
 type TierDomain = `${AgentTier}:${AgentDomain}`;
 
 export const DEFAULT_AGENT_MODEL_POLICY: Readonly<Record<TierDomain, AgentModelConfig>> = {
-  // Heavy tier
-  "heavy:coding": { provider: "copilot", model: "gpt-5.4", maxTokens: 8192, temperature: 0.2 },
+  // Heavy tier - use high-capability models
+  "heavy:coding": { provider: "copilot", model: "o1", maxTokens: 8192, temperature: 0.2 },
   "heavy:planning": {
     provider: "copilot",
-    model: "claude-opus-4.6",
+    model: "claude-3-opus",
     maxTokens: 8192,
     temperature: 0.3,
   },
-  "heavy:review": { provider: "copilot", model: "gpt-5.4", maxTokens: 8192, temperature: 0.2 },
-  "heavy:research": { provider: "copilot", model: "gpt-5.4", maxTokens: 8192, temperature: 0.4 },
+  "heavy:review": { provider: "copilot", model: "o1", maxTokens: 8192, temperature: 0.2 },
+  "heavy:research": { provider: "copilot", model: "o1", maxTokens: 8192, temperature: 0.4 },
   "heavy:utility": {
     provider: "copilot",
-    model: "gemini-3.1-pro",
+    model: "gemini-2.5-pro",
     maxTokens: 4096,
     temperature: 0.3,
   },
-  "heavy:devops": { provider: "copilot", model: "gpt-5.4", maxTokens: 8192, temperature: 0.2 },
+  "heavy:devops": { provider: "copilot", model: "o1", maxTokens: 8192, temperature: 0.2 },
 
-  // Medium tier
+  // Medium tier - balanced performance and cost
   "medium:coding": {
     provider: "copilot",
-    model: "gpt-5.4-mini",
+    model: "gpt-4o",
     maxTokens: 4096,
     temperature: 0.2,
   },
   "medium:planning": {
     provider: "copilot",
-    model: "gpt-5.4-mini",
+    model: "gpt-4o",
     maxTokens: 4096,
     temperature: 0.3,
   },
   "medium:review": {
     provider: "copilot",
-    model: "claude-sonnet-4.6",
+    model: "claude-3.5-sonnet",
     maxTokens: 4096,
     temperature: 0.2,
   },
   "medium:research": {
     provider: "copilot",
-    model: "gpt-5.4-mini",
+    model: "gpt-4o",
     maxTokens: 4096,
     temperature: 0.4,
   },
   "medium:utility": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.3,
   },
   "medium:devops": {
     provider: "copilot",
-    model: "gpt-5.4-mini",
+    model: "gpt-4o",
     maxTokens: 4096,
     temperature: 0.2,
   },
 
-  // Light tier
+  // Light tier - fast, cost-effective models
   "light:coding": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.2,
   },
   "light:planning": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.3,
   },
   "light:review": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.2,
   },
   "light:research": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.4,
   },
   "light:utility": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.3,
   },
   "light:devops": {
     provider: "copilot",
-    model: "claude-haiku-4.5",
+    model: "gpt-4o-mini",
     maxTokens: 2048,
     temperature: 0.2,
   },

--- a/packages/core/src/agents/model-tier-resolver.ts
+++ b/packages/core/src/agents/model-tier-resolver.ts
@@ -20,7 +20,7 @@ export type ModelTier = AgentTier;
 
 /**
  * Model class identifier.
- * Examples: "claude-opus-4.6", "gpt-5.4", "sonnet-4.6", "haiku-4.5"
+ * Examples: "claude-3-opus", "gpt-4o", "claude-3.5-sonnet", "gemini-2.5-pro"
  */
 export type ModelClass = string;
 
@@ -158,13 +158,13 @@ function defaultAvailabilityChecker(_model: ModelClass): boolean {
  * @example
  * ```typescript
  * const resolver = new ModelTierResolver({
- *   heavy: { preferred: "claude-opus-4.6", fallback: ["gpt-5.4", "gemini-3.1-pro"] },
- *   medium: { preferred: "sonnet-4.6", fallback: ["kimi-2.5", "qwen3-coder-next"] },
- *   light: { preferred: "haiku-4.5", fallback: ["deepseek-v3.2"] },
+ *   heavy: { preferred: "claude-3-opus", fallback: ["o1", "gemini-2.5-pro"] },
+ *   medium: { preferred: "claude-3.5-sonnet", fallback: ["gpt-4o", "gemini-2.5-flash"] },
+ *   light: { preferred: "gpt-4o-mini", fallback: ["gemini-2.5-flash-lite"] },
  * });
  *
  * const result = resolver.resolve("heavy");
- * // → { model: "claude-opus-4.6", reason: "preferred", isDegraded: false, ... }
+ * // → { model: "claude-3-opus", reason: "preferred", isDegraded: false, ... }
  * ```
  *
  * @see CascadeModelResolver

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -94,7 +94,7 @@ export type SubscriptionHealth = z.infer<typeof SubscriptionHealthSchema>;
  */
 
 export const ModelScoreSchema = z.object({
-  modelId: z.string().describe("Model identifier (e.g., 'claude-opus-4.6', 'gpt-5.4')"),
+  modelId: z.string().describe("Model identifier (e.g., 'claude-3-opus', 'gpt-4o')"),
   subscriptionId: z.string().describe("Reference to Subscription.id"),
   taskType: z
     .string()

--- a/packages/dirirouter/README.md
+++ b/packages/dirirouter/README.md
@@ -38,7 +38,7 @@ On startup, you'll see a table:
 ├────────────┬────────────┬────────┬──────────────────────────────────┤
 │ Provider   │ Status     │ Models │ Example Models                   │
 ├────────────┼────────────┼────────┼──────────────────────────────────┤
-│ gemini     │ ✓ Ready    │ 4      │ gemini-3.1-pro, gemini-3-pro     │
+│ gemini     │ ✓ Ready    │ 4      │ gemini-2.5-pro, gemini-2.5-flash │
 │ kimi       │ ✗ No key   │ 0      │ —                                │
 │ zai        │ ✓ Ready    │ 4      │ glm-5, glm-5-plus, +2 more        │
 │ minimax    │ ✗ No key   │ 0      │ —                                │
@@ -53,26 +53,26 @@ Open **http://localhost:3333** to see the model toggle panel. Models are grouped
 
 ### API Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/models` | List all models with `enabled` status |
-| `PATCH` | `/api/models/toggle` | Toggle model on/off |
-| `POST` | `/api/pick` | Dry-run model picker |
-| `POST` | `/api/chat` | Chat with a specific model |
-| `GET` | `/api/status` | Server health + provider status |
+| Method  | Path                 | Description                           |
+| ------- | -------------------- | ------------------------------------- |
+| `GET`   | `/api/models`        | List all models with `enabled` status |
+| `PATCH` | `/api/models/toggle` | Toggle model on/off                   |
+| `POST`  | `/api/pick`          | Dry-run model picker                  |
+| `POST`  | `/api/chat`          | Chat with a specific model            |
+| `GET`   | `/api/status`        | Server health + provider status       |
 
 #### Toggle a model
 
 ```bash
-# Disable gpt-5.4
+# Disable gpt-4o
 curl -X PATCH http://localhost:3333/api/models/toggle \
   -H "Content-Type: application/json" \
-  -d '{"modelId": "gpt-5.4", "enabled": false}'
+  -d '{"modelId": "gpt-4o", "enabled": false}'
 
 # Re-enable it
 curl -X PATCH http://localhost:3333/api/models/toggle \
   -H "Content-Type: application/json" \
-  -d '{"modelId": "gpt-5.4", "enabled": true}'
+  -d '{"modelId": "gpt-4o", "enabled": true}'
 ```
 
 #### Test the picker
@@ -95,7 +95,7 @@ State is stored in `playground-state.json` in the cwd where you run the command:
 
 ```json
 {
-  "disabledModels": ["gpt-5.4"],
+  "disabledModels": ["gpt-4o"],
   "lastUpdated": "2026-04-04T12:00:00.000Z"
 }
 ```
@@ -104,13 +104,13 @@ Delete this file to reset all models to enabled.
 
 ### Provider API Keys
 
-| Provider | Env Var |
-|----------|---------|
-| Google Gemini | `GEMINI_API_KEY` |
-| Zhipu AI (GLM) | `DC_ZAI_API_KEY` |
-| Moonshot (Kimi) | `DC_KIMI_API_KEY` |
-| MiniMax | `DC_MINIMAX_API_KEY` |
-| GitHub Copilot | `GITHUB_TOKEN` / `GH_TOKEN` / `DC_GITHUB_TOKEN` |
+| Provider        | Env Var                                         |
+| --------------- | ----------------------------------------------- |
+| Google Gemini   | `GEMINI_API_KEY`                                |
+| Zhipu AI (GLM)  | `DC_ZAI_API_KEY`                                |
+| Moonshot (Kimi) | `DC_KIMI_API_KEY`                               |
+| MiniMax         | `DC_MINIMAX_API_KEY`                            |
+| GitHub Copilot  | `GITHUB_TOKEN` / `GH_TOKEN` / `DC_GITHUB_TOKEN` |
 
 ## Build & Test
 

--- a/packages/dirirouter/src/__tests__/copilot.test.ts
+++ b/packages/dirirouter/src/__tests__/copilot.test.ts
@@ -46,10 +46,10 @@ describe("CopilotProvider", () => {
   });
 
   describe("constructor", () => {
-    it("creates provider with default model gpt-4.1", () => {
+    it("creates provider with default model gpt-4o", () => {
       const provider = new CopilotProvider("test-token");
       expect(provider.name).toBe("copilot");
-      expect(provider.defaultModel.modelId).toBe("gpt-4.1");
+      expect(provider.defaultModel.modelId).toBe("gpt-4o");
     });
 
     it("accepts explicit token", () => {
@@ -76,16 +76,16 @@ describe("CopilotProvider", () => {
   describe("listModels", () => {
     it("returns models from SDK client", async () => {
       mockListModels.mockResolvedValue([
-        { id: "gpt-4.1", name: "GPT 4.1", capabilities: {} },
-        { id: "claude-sonnet-4", name: "Claude Sonnet 4", capabilities: {} },
+        { id: "gpt-4o", name: "GPT-4o", capabilities: {} },
+        { id: "claude-3.5-sonnet", name: "Claude 3.5 Sonnet", capabilities: {} },
       ]);
       const provider = new CopilotProvider("test-token");
       const models = await provider.listModels();
       expect(models).toHaveLength(2);
       if (!models[0]) throw new Error("Expected models[0] to exist");
       if (!models[1]) throw new Error("Expected models[1] to exist");
-      expect(models[0].id).toBe("gpt-4.1");
-      expect(models[1].id).toBe("claude-sonnet-4");
+      expect(models[0].id).toBe("gpt-4o");
+      expect(models[1].id).toBe("claude-3.5-sonnet");
       expect(mockStart).toHaveBeenCalled();
     });
   });
@@ -102,7 +102,7 @@ describe("CopilotProvider", () => {
       await expect(request).rejects.toMatchObject({
         kind: "auth_error",
         provider: "copilot",
-        model: "gpt-4.1",
+        model: "gpt-4o",
         retryable: false,
       });
       await expect(request).rejects.toBeInstanceOf(ClassifiedError);
@@ -121,7 +121,7 @@ describe("CopilotProvider", () => {
       await expect(stream[Symbol.asyncIterator]().next()).rejects.toMatchObject({
         kind: "auth_error",
         provider: "copilot",
-        model: "gpt-4.1",
+        model: "gpt-4o",
         retryable: false,
       });
     });

--- a/packages/dirirouter/src/__tests__/error-classifier.test.ts
+++ b/packages/dirirouter/src/__tests__/error-classifier.test.ts
@@ -333,7 +333,7 @@ describe("edge cases", () => {
       raw: new Error("Too many requests"),
     });
 
-    expect(classifyError(classified, { provider: "copilot", model: "gpt-4.1" })).toBe(classified);
+    expect(classifyError(classified, { provider: "copilot", model: "gpt-4o" })).toBe(classified);
   });
 
   it("classifies empty response as non-retryable other", () => {

--- a/packages/dirirouter/src/copilot/adapter.ts
+++ b/packages/dirirouter/src/copilot/adapter.ts
@@ -13,14 +13,14 @@ const EMPTY_BENCHMARKS: ModelCard["benchmarks"] = {
  *  these feed the picker's metadata (family, capabilities, pricing tier). */
 const COPILOT_MODEL_CARDS: ModelCard[] = [
   {
-    model: "gpt-4.1",
+    model: "gpt-4o",
     family: "gpt-reasoning",
     capabilities: {
       tool_calling: true,
       streaming: true,
       json_mode: true,
       vision: true,
-      max_context: 200_000,
+      max_context: 128_000,
     },
     reasoning_levels: ["low", "medium", "high"],
     known_for: {
@@ -33,14 +33,14 @@ const COPILOT_MODEL_CARDS: ModelCard[] = [
     learned_from: 0,
   },
   {
-    model: "gpt-4.1-mini",
+    model: "gpt-4o-mini",
     family: "gpt-mini",
     capabilities: {
       tool_calling: true,
       streaming: true,
       json_mode: true,
       vision: true,
-      max_context: 200_000,
+      max_context: 128_000,
     },
     reasoning_levels: ["low", "medium"],
     known_for: {
@@ -53,8 +53,48 @@ const COPILOT_MODEL_CARDS: ModelCard[] = [
     learned_from: 0,
   },
   {
-    model: "gpt-4.1-nano",
-    family: "gpt-nano",
+    model: "o1",
+    family: "gpt-reasoning",
+    capabilities: {
+      tool_calling: true,
+      streaming: true,
+      json_mode: true,
+      vision: true,
+      max_context: 200_000,
+    },
+    reasoning_levels: ["low", "medium", "high", "xhigh"],
+    known_for: {
+      roles: ["architect", "reviewer", "coder"],
+      complexities: ["moderate", "complex", "expert"],
+      specializations: [],
+    },
+    benchmarks: EMPTY_BENCHMARKS,
+    pricing_tier: "premium",
+    learned_from: 0,
+  },
+  {
+    model: "o1-mini",
+    family: "gpt-reasoning",
+    capabilities: {
+      tool_calling: true,
+      streaming: true,
+      json_mode: true,
+      vision: false,
+      max_context: 128_000,
+    },
+    reasoning_levels: ["low", "medium", "high"],
+    known_for: {
+      roles: ["coder", "researcher"],
+      complexities: ["simple", "moderate"],
+      specializations: [],
+    },
+    benchmarks: EMPTY_BENCHMARKS,
+    pricing_tier: "standard",
+    learned_from: 0,
+  },
+  {
+    model: "o3-mini",
+    family: "gpt-reasoning",
     capabilities: {
       tool_calling: true,
       streaming: true,
@@ -62,18 +102,18 @@ const COPILOT_MODEL_CARDS: ModelCard[] = [
       vision: false,
       max_context: 200_000,
     },
-    reasoning_levels: [],
+    reasoning_levels: ["low", "medium", "high", "xhigh"],
     known_for: {
-      roles: ["coder"],
-      complexities: ["simple"],
+      roles: ["architect", "reviewer", "coder"],
+      complexities: ["moderate", "complex", "expert"],
       specializations: [],
     },
     benchmarks: EMPTY_BENCHMARKS,
-    pricing_tier: "budget",
+    pricing_tier: "standard",
     learned_from: 0,
   },
   {
-    model: "claude-sonnet-4",
+    model: "claude-3.5-sonnet",
     family: "claude-sonnet",
     capabilities: {
       tool_calling: true,
@@ -93,7 +133,7 @@ const COPILOT_MODEL_CARDS: ModelCard[] = [
     learned_from: 0,
   },
   {
-    model: "claude-opus-4",
+    model: "claude-3-opus",
     family: "claude-opus",
     capabilities: {
       tool_calling: true,
@@ -120,31 +160,11 @@ const COPILOT_MODEL_CARDS: ModelCard[] = [
       streaming: true,
       json_mode: true,
       vision: true,
-      max_context: 200_000,
-    },
-    reasoning_levels: ["low", "medium", "high"],
-    known_for: {
-      roles: ["architect", "researcher", "coder"],
-      complexities: ["moderate", "complex"],
-      specializations: [],
-    },
-    benchmarks: EMPTY_BENCHMARKS,
-    pricing_tier: "standard",
-    learned_from: 0,
-  },
-  {
-    model: "o4-mini",
-    family: "gpt-reasoning",
-    capabilities: {
-      tool_calling: true,
-      streaming: true,
-      json_mode: true,
-      vision: true,
-      max_context: 200_000,
+      max_context: 1_048_576,
     },
     reasoning_levels: ["low", "medium", "high", "xhigh"],
     known_for: {
-      roles: ["architect", "reviewer", "coder"],
+      roles: ["architect", "researcher", "coder"],
       complexities: ["moderate", "complex", "expert"],
       specializations: [],
     },
@@ -185,7 +205,7 @@ export class CopilotProvider implements Provider {
   constructor(token?: string) {
     this.#token = token ?? getGithubToken();
     this.defaultModel = {
-      modelId: "gpt-4.1",
+      modelId: "gpt-4o",
     };
   }
 

--- a/packages/dirirouter/src/llm-picker/model-resolver.ts
+++ b/packages/dirirouter/src/llm-picker/model-resolver.ts
@@ -250,7 +250,7 @@ export class CascadeModelResolver implements ModelResolver {
     ];
     this.confidenceThreshold = options.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
     this.defaultProvider = options.defaultProvider ?? "anthropic";
-    this.defaultModel = options.defaultModel ?? "claude-sonnet-4.6";
+    this.defaultModel = options.defaultModel ?? "claude-3.5-sonnet";
     this.defaultPolicy = options.defaultPolicy ?? "default";
     this.hardRulesConfig = options.hardRulesConfig ?? DEFAULT_HARD_RULES_CONFIG;
     this.candidatePool =

--- a/packages/dirirouter/src/providers/gemini.ts
+++ b/packages/dirirouter/src/providers/gemini.ts
@@ -82,66 +82,6 @@ const GEMINI_MODEL_CARDS: ModelCard[] = [
     pricing_tier: "standard",
     learned_from: 0,
   },
-  {
-    model: "gemini-3-flash-preview",
-    family: "gemini-flash",
-    capabilities: {
-      tool_calling: true,
-      streaming: true,
-      json_mode: true,
-      vision: true,
-      max_context: 1_048_576,
-    },
-    reasoning_levels: ["low", "medium", "high"],
-    known_for: {
-      roles: ["coder", "researcher"],
-      complexities: ["simple", "moderate", "complex"],
-      specializations: [],
-    },
-    benchmarks: EMPTY_BENCHMARKS,
-    pricing_tier: "budget",
-    learned_from: 0,
-  },
-  {
-    model: "gemini-3.1-flash-lite-preview",
-    family: "gemini-flash-lite",
-    capabilities: {
-      tool_calling: true,
-      streaming: true,
-      json_mode: true,
-      vision: true,
-      max_context: 1_048_576,
-    },
-    reasoning_levels: ["low", "medium"],
-    known_for: {
-      roles: ["coder"],
-      complexities: ["simple"],
-      specializations: [],
-    },
-    benchmarks: EMPTY_BENCHMARKS,
-    pricing_tier: "budget",
-    learned_from: 0,
-  },
-  {
-    model: "gemini-3.1-pro-preview",
-    family: "gemini-pro",
-    capabilities: {
-      tool_calling: true,
-      streaming: true,
-      json_mode: true,
-      vision: true,
-      max_context: 1_048_576,
-    },
-    reasoning_levels: ["low", "medium", "high", "xhigh"],
-    known_for: {
-      roles: ["architect", "reviewer", "orchestrator", "coder"],
-      complexities: ["moderate", "complex", "expert"],
-      specializations: [],
-    },
-    benchmarks: EMPTY_BENCHMARKS,
-    pricing_tier: "standard",
-    learned_from: 0,
-  },
 ];
 
 /**


### PR DESCRIPTION
Fixes #642

## Summary

Replaced all hardcoded non-existent/future model versions with actual available models across the codebase.

## Changes Made

### Copilot Provider (`packages/dirirouter/src/copilot/adapter.ts`)
- Replaced `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `claude-sonnet-4`, `claude-opus-4`, `o4-mini` with real models:
  - `gpt-4o`, `gpt-4o-mini`, `o1`, `o1-mini`, `o3-mini`, `claude-3.5-sonnet`, `claude-3-opus`, `gemini-2.5-pro`
- Updated default model from `gpt-4.1` to `gpt-4o`

### Model Selection Policy (`packages/core/src/agents/model-selection-policy.ts`)
- Replaced `gpt-5.4`, `gpt-5.4-mini`, `claude-opus-4.6`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `gemini-3.1-pro` with:
  - `o1`, `gpt-4o`, `gpt-4o-mini`, `claude-3-opus`, `claude-3.5-sonnet`, `gemini-2.5-pro`

### Gemini Provider (`packages/dirirouter/src/providers/gemini.ts`)
- Removed non-existent models: `gemini-3-flash-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview`
- Kept only existing: `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`

### Documentation & Tests
- Updated all test files to use real model names
- Updated README examples
- Updated JSDoc comments with real model examples

## Testing

- ✅ Model tier resolver tests pass (15 tests)
- All model references now point to actually available models