### PR TITLE
fix(dirirouter): provider-agnostic discovery, remove fake fallback, fix playground models

### DIFF
--- a/packages/dirirouter/src/__tests__/copilot.test.ts
+++ b/packages/dirirouter/src/__tests__/copilot.test.ts
@@ -144,6 +144,81 @@ describe("CopilotProvider", () => {
     });
   });
 
+  describe("discoverAvailability", () => {
+    it("returns unavailable status when no token is available", async () => {
+      vi.stubEnv("DC_GITHUB_TOKEN", "");
+      vi.stubEnv("GITHUB_TOKEN", "");
+      vi.stubEnv("GH_TOKEN", "");
+      const provider = new CopilotProvider();
+      const result = await provider.discoverAvailability();
+      expect(result.status.available).toBe(false);
+      expect(result.availabilities).toHaveLength(0);
+      expect(result.status.error).toContain("No token");
+    });
+
+    it("maps live models to provider-produced availabilities", async () => {
+      mockListModels.mockResolvedValue([
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          capabilities: { tool_calls: true, streaming: true, vision: false },
+        },
+        {
+          id: "claude-sonnet-4.6",
+          name: "Claude Sonnet 4.6",
+          capabilities: { tool_calls: true, streaming: true, vision: true },
+        },
+      ]);
+
+      const provider = new CopilotProvider("test-token");
+      const result = await provider.discoverAvailability();
+
+      expect(result.status.available).toBe(true);
+      expect(result.availabilities).toHaveLength(2);
+      expect(result.availabilities[0]?.model_id).toBe("gpt-5.4");
+      expect(result.availabilities[0]?.provider).toBe("copilot");
+      expect(result.availabilities[1]?.model_id).toBe("claude-sonnet-4.6");
+      expect(result.availabilities[1]?.supports_vision).toBe(true);
+      expect(mockStop).toHaveBeenCalled();
+    });
+
+    it("deduplicates models by id", async () => {
+      mockListModels.mockResolvedValue([
+        { id: "gpt-4o", name: "GPT-4o", capabilities: {} },
+        { id: "gpt-4o", name: "GPT-4o dup", capabilities: {} },
+      ]);
+
+      const provider = new CopilotProvider("test-token");
+      const result = await provider.discoverAvailability();
+
+      expect(result.availabilities).toHaveLength(1);
+      expect(result.availabilities[0]?.model_id).toBe("gpt-4o");
+    });
+
+    it("returns error status when listModels throws", async () => {
+      mockListModels.mockRejectedValue(new Error("Network error"));
+      const provider = new CopilotProvider("test-token");
+      const result = await provider.discoverAvailability();
+
+      expect(result.status.available).toBe(false);
+      expect(result.status.error).toContain("Network error");
+      expect(result.availabilities).toHaveLength(0);
+      expect(mockStop).toHaveBeenCalled();
+    });
+
+    it("does not depend on hardcoded fallback constants", async () => {
+      mockListModels.mockResolvedValue([
+        { id: "totally-new-model", name: "New", capabilities: {} },
+      ]);
+
+      const provider = new CopilotProvider("test-token");
+      const result = await provider.discoverAvailability();
+
+      expect(result.status.available).toBe(true);
+      expect(result.availabilities[0]?.model_id).toBe("totally-new-model");
+    });
+  });
+
   describe("createCopilotProvider", () => {
     it("creates a CopilotProvider instance", () => {
       const provider = createCopilotProvider("test-token");

--- a/packages/dirirouter/src/__tests__/playground-bootstrap.test.ts
+++ b/packages/dirirouter/src/__tests__/playground-bootstrap.test.ts
@@ -1,64 +1,175 @@
-import { describe, expect, test } from "vitest";
-import { buildCopilotAvailability } from "../playground/bootstrap.js";
+import { describe, expect, test, vi } from "vitest";
+import { bootstrapPlayground } from "../playground/bootstrap.js";
+import * as providerRegistry from "../provider-registry.js";
+import type { ProviderDiscoveryEntry } from "../provider-registry.js";
 
-describe("buildCopilotAvailability", () => {
-  test("creates availability for a model with full capabilities", () => {
-    const result = buildCopilotAvailability({
-      id: "gpt-4o",
-      capabilities: { tool_calls: true, streaming: true, vision: true },
-    });
-
-    expect(result.model_id).toBe("gpt-4o");
-    expect(result.provider).toBe("copilot");
-    expect(result.family).toBe("gpt-standard");
-    expect(result.stability).toBe("stable");
-    expect(result.available).toBe(true);
-    expect(result.context_window).toBe(200_000);
-    expect(result.supports_tool_calling).toBe(true);
-    expect(result.supports_vision).toBe(true);
-    expect(result.supports_structured_output).toBe(true);
-    expect(result.supports_streaming).toBe(true);
-    expect(result.input_cost_per_1k).toBe(0);
-    expect(result.output_cost_per_1k).toBe(0);
-    expect(result.trusted).toBe(true);
-    expect(result.id).toBe("copilot-gpt-4o");
+describe("bootstrapPlayground", () => {
+  test("returns expected result shape", async () => {
+    const result = await bootstrapPlayground();
+    expect(result.startTime).toBeGreaterThan(0);
+    expect(result.diriRouter).toBeDefined();
+    expect(result.registry).toBeDefined();
+    expect(result.subscriptionRegistry).toBeDefined();
+    expect(Array.isArray(result.providerStatuses)).toBe(true);
   });
 
-  test("derives family as gpt-reasoning for o-series models", () => {
-    const result = buildCopilotAvailability({
-      id: "o1-preview",
-      capabilities: { tool_calls: false, streaming: false, vision: false },
-    });
+  test("aggregates provider discovery results without vendor-specific branching", async () => {
+    const mockDiscoveries: ProviderDiscoveryEntry[] = [
+      {
+        provider: { name: "mock-live" } as never,
+        availabilities: [
+          {
+            provider: "mock-live",
+            model_id: "live-model",
+            family: "mock-family",
+            stability: "stable",
+            available: true,
+            context_window: 128_000,
+            supports_tool_calling: true,
+            supports_vision: false,
+            supports_structured_output: true,
+            supports_streaming: true,
+            input_cost_per_1k: 0,
+            output_cost_per_1k: 0,
+            trusted: true,
+          },
+        ],
+        status: {
+          name: "mock-live",
+          available: true,
+          envVar: "MOCK_LIVE_KEY",
+          modelCount: 1,
+          modelNames: ["live-model"],
+        },
+        priority: 1,
+      },
+      {
+        provider: { name: "mock-static" } as never,
+        availabilities: [
+          {
+            provider: "mock-static",
+            model_id: "static-model",
+            family: "mock-family",
+            stability: "stable",
+            available: true,
+            context_window: 64_000,
+            supports_tool_calling: true,
+            supports_vision: true,
+            supports_structured_output: true,
+            supports_streaming: true,
+            input_cost_per_1k: 0,
+            output_cost_per_1k: 0,
+            trusted: true,
+          },
+        ],
+        status: {
+          name: "mock-static",
+          available: true,
+          envVar: "MOCK_STATIC_KEY",
+          modelCount: 1,
+          modelNames: ["static-model"],
+        },
+        priority: 2,
+      },
+    ];
 
-    expect(result.family).toBe("gpt-reasoning");
-    expect(result.stability).toBe("preview");
+    const spy = vi
+      .spyOn(providerRegistry, "discoverAllProviders")
+      .mockResolvedValue(mockDiscoveries);
+
+    const result = await bootstrapPlayground();
+
+    expect(result.providerStatuses).toHaveLength(2);
+    expect(result.providerStatuses.map((s) => s.name)).toEqual(["mock-live", "mock-static"]);
+    expect(result.subscriptionRegistry.list()).toHaveLength(2);
+    expect(result.subscriptionRegistry.has("mock-live-live-model")).toBe(true);
+    expect(result.subscriptionRegistry.has("mock-static-static-model")).toBe(true);
+
+    spy.mockRestore();
   });
 
-  test("derives family as claude-sonnet for claude models", () => {
-    const result = buildCopilotAvailability({
-      id: "claude-sonnet-4",
-      capabilities: { tool_calls: true, streaming: true, vision: true },
-    });
+  test("resolver candidate pool contains only provider-produced availabilities", async () => {
+    const mockDiscoveries: ProviderDiscoveryEntry[] = [
+      {
+        provider: { name: "mock" } as never,
+        availabilities: [
+          {
+            provider: "mock",
+            model_id: "m1",
+            family: "f1",
+            stability: "stable",
+            available: true,
+            context_window: 100_000,
+            supports_tool_calling: true,
+            supports_vision: false,
+            supports_structured_output: true,
+            supports_streaming: true,
+            input_cost_per_1k: 0,
+            output_cost_per_1k: 0,
+            trusted: true,
+          },
+        ],
+        status: {
+          name: "mock",
+          available: true,
+          envVar: "MOCK_KEY",
+          modelCount: 1,
+          modelNames: ["m1"],
+        },
+        priority: 1,
+      },
+    ];
 
-    expect(result.family).toBe("claude-sonnet");
-    expect(result.stability).toBe("stable");
+    const spy = vi
+      .spyOn(providerRegistry, "discoverAllProviders")
+      .mockResolvedValue(mockDiscoveries);
+
+    const result = await bootstrapPlayground();
+    const pool = result.diriRouter.resolver.getCandidatePool();
+
+    expect(pool.length).toBeGreaterThanOrEqual(1);
+    expect(pool.some((c) => c.provider === "mock" && c.model === "m1")).toBe(true);
+    expect(pool.some((c) => c.provider === "anthropic")).toBe(false);
+
+    spy.mockRestore();
   });
 
-  test("defaults capabilities to true when not provided", () => {
-    const result = buildCopilotAvailability({ id: "unknown-model" });
+  test("empty provider availability results in no_match from picker", async () => {
+    const mockDiscoveries: ProviderDiscoveryEntry[] = [
+      {
+        provider: { name: "mock", isAvailable: () => true } as never,
+        availabilities: [],
+        status: {
+          name: "mock",
+          available: true,
+          envVar: "MOCK_KEY",
+          modelCount: 0,
+          modelNames: [],
+        },
+        priority: 1,
+      },
+    ];
 
-    expect(result.supports_tool_calling).toBe(true);
-    expect(result.supports_streaming).toBe(true);
-    expect(result.supports_structured_output).toBe(true);
-    expect(result.supports_vision).toBe(false);
-  });
+    const spy = vi
+      .spyOn(providerRegistry, "discoverAllProviders")
+      .mockResolvedValue(mockDiscoveries);
 
-  test("uses tool_calling alias from capabilities", () => {
-    const result = buildCopilotAvailability({
-      id: "model-with-tool-calling",
-      capabilities: { tool_calling: true, streaming: false, vision: false },
-    });
+    const result = await bootstrapPlayground();
+    const response = await result.diriRouter.pick(
+      {
+        chatId: "test-chat",
+        requestId: "test-req",
+        agent: { id: "a1", role: "coder", seniority: "senior", specializations: [] },
+        task: { type: "coding", description: "test" },
+        modelDimensions: { tier: "medium", modelAttributes: [], fallbackType: null },
+      },
+      "test-chat",
+    );
 
-    expect(result.supports_tool_calling).toBe(true);
+    expect(response.status).toBe("no_match");
+    expect(response.selected).toBeUndefined();
+    expect(response.candidates).toEqual([]);
+
+    spy.mockRestore();
   });
 });

--- a/packages/dirirouter/src/__tests__/provider-registry.test.ts
+++ b/packages/dirirouter/src/__tests__/provider-registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from "vitest";
+import { getProviderDefinitions, discoverAllProviders } from "../provider-registry.js";
+import type { ProviderDiscoveryResult } from "../provider-discovery.js";
+
+describe("getProviderDefinitions", () => {
+  test("returns all configured provider definitions", () => {
+    const definitions = getProviderDefinitions();
+    const names = definitions.map((d) => d.name);
+    expect(names).toContain("gemini");
+    expect(names).toContain("kimi");
+    expect(names).toContain("zai");
+    expect(names).toContain("minimax");
+    expect(names).toContain("copilot");
+  });
+
+  test("each definition has required fields", () => {
+    for (const def of getProviderDefinitions()) {
+      expect(def.name).toBeTruthy();
+      expect(def.envVar).toBeTruthy();
+      expect(typeof def.priority).toBe("number");
+      expect(typeof def.create).toBe("function");
+    }
+  });
+});
+
+describe("discoverAllProviders", () => {
+  test("returns status for all providers without crashing", async () => {
+    const results = await discoverAllProviders();
+    expect(results.length).toBeGreaterThanOrEqual(5);
+    for (const result of results) {
+      expect(result.provider).toBeDefined();
+      expect(result.status).toBeDefined();
+      expect(result.status.name).toBeTruthy();
+      expect(typeof result.status.available).toBe("boolean");
+      expect(Array.isArray(result.availabilities)).toBe(true);
+      expect(typeof result.priority).toBe("number");
+    }
+  });
+
+  test("aggregates provider results generically without branching", async () => {
+    const results = await discoverAllProviders();
+    const statuses = results.map((r) => r.status);
+    const names = new Set(statuses.map((s) => s.name));
+    expect(names.size).toBe(statuses.length);
+  });
+});

--- a/packages/dirirouter/src/__tests__/provider-registry.test.ts
+++ b/packages/dirirouter/src/__tests__/provider-registry.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { getProviderDefinitions, discoverAllProviders } from "../provider-registry.js";
-import type { ProviderDiscoveryResult } from "../provider-discovery.js";
 
 describe("getProviderDefinitions", () => {
   test("returns all configured provider definitions", () => {

--- a/packages/dirirouter/src/__tests__/subscription.test.ts
+++ b/packages/dirirouter/src/__tests__/subscription.test.ts
@@ -110,9 +110,10 @@ describe("SubscriptionRegistry", () => {
       expect(() => reg.register(makeAvail({ id: "my-sub" }))).toThrow(/my-sub/);
     });
 
-    it("throws when id is missing", () => {
+    it("auto-generates id from provider-model_id when id is missing", () => {
       const reg = makeRegistry();
-      expect(() => reg.register(makeAvail({ id: undefined }))).toThrow();
+      reg.register(makeAvail({ id: undefined, provider: "copilot", model_id: "gpt-4o" }));
+      expect(reg.get("copilot-gpt-4o").model_id).toBe("gpt-4o");
     });
   });
 

--- a/packages/dirirouter/src/contracts/index.ts
+++ b/packages/dirirouter/src/contracts/index.ts
@@ -1,28 +1,4 @@
 export {
-  BenchmarkBucketSchema,
-  BenchmarksSchema,
-  KnownForSchema,
-  ModelCapabilitiesSchema,
-  ModelCardSchema,
-  PricingTierSchema,
-  QualityBenchmarkSchema,
-  ReasoningLevelSchema,
-  SpeedBenchmarkSchema,
-} from "./model-card.js";
-
-export type {
-  BenchmarkBucket,
-  Benchmarks,
-  KnownFor,
-  ModelCapabilities,
-  ModelCard,
-  PricingTier,
-  QualityBenchmark,
-  ReasoningLevel,
-  SpeedBenchmark,
-} from "./model-card.js";
-
-export {
   ProviderModelAvailabilitySchema,
   ModelStabilitySchema,
   RateLimitSchema,

--- a/packages/dirirouter/src/contracts/index.ts
+++ b/packages/dirirouter/src/contracts/index.ts
@@ -1,8 +1,33 @@
 export {
+  BenchmarkBucketSchema,
+  BenchmarksSchema,
+  KnownForSchema,
+  ModelCapabilitiesSchema,
+  ModelCardSchema,
+  PricingTierSchema,
+  QualityBenchmarkSchema,
+  ReasoningLevelSchema,
+  SpeedBenchmarkSchema,
+} from "./model-card.js";
+
+export type {
+  BenchmarkBucket,
+  Benchmarks,
+  KnownFor,
+  ModelCapabilities,
+  ModelCard,
+  PricingTier,
+  QualityBenchmark,
+  ReasoningLevel,
+  SpeedBenchmark,
+} from "./model-card.js";
+
+export {
   ProviderModelAvailabilitySchema,
   ModelStabilitySchema,
   RateLimitSchema,
 } from "./provider-model-availability.js";
+
 export type {
   ProviderModelAvailability,
   ModelStability,

--- a/packages/dirirouter/src/contracts/provider-model-availability.ts
+++ b/packages/dirirouter/src/contracts/provider-model-availability.ts
@@ -70,7 +70,7 @@ const transformSchema = rawSchema.transform(
     trusted: val.trusted,
     rate_limit: val.rate_limit,
     vendor_metadata: val.vendor_metadata,
-    id: val.id,
+    id: val.id ?? `${val.provider}-${val.model_id}`,
   }),
 );
 

--- a/packages/dirirouter/src/contracts/provider-model-availability.ts
+++ b/packages/dirirouter/src/contracts/provider-model-availability.ts
@@ -70,7 +70,7 @@ const transformSchema = rawSchema.transform(
     trusted: val.trusted,
     rate_limit: val.rate_limit,
     vendor_metadata: val.vendor_metadata,
-    id: val.id ?? `${val.provider}-${val.model_id}`,
+    id: val.id ?? `${val.provider}-${val.model_id ?? ""}`,
   }),
 );
 

--- a/packages/dirirouter/src/copilot/adapter.ts
+++ b/packages/dirirouter/src/copilot/adapter.ts
@@ -3,129 +3,7 @@ import type { CopilotSession, ModelInfo, SessionEvent } from "@github/copilot-sd
 import { classifyError } from "../error-classifier.js";
 import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "../types.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
-
-const COPILOT_FALLBACK_AVAILABILITIES: ProviderModelAvailability[] = [
-  {
-    provider: "copilot",
-    model_id: "gpt-4o",
-    family: "gpt-reasoning",
-    stability: "stable",
-    available: true,
-    context_window: 128_000,
-    supports_tool_calling: true,
-    supports_vision: true,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "gpt-4o-mini",
-    family: "gpt-mini",
-    stability: "stable",
-    available: true,
-    context_window: 128_000,
-    supports_tool_calling: true,
-    supports_vision: true,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "o1",
-    family: "gpt-reasoning",
-    stability: "stable",
-    available: true,
-    context_window: 200_000,
-    supports_tool_calling: true,
-    supports_vision: true,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "o1-mini",
-    family: "gpt-reasoning",
-    stability: "preview",
-    available: true,
-    context_window: 128_000,
-    supports_tool_calling: true,
-    supports_vision: false,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "o3-mini",
-    family: "gpt-reasoning",
-    stability: "preview",
-    available: true,
-    context_window: 200_000,
-    supports_tool_calling: true,
-    supports_vision: false,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "claude-3.5-sonnet",
-    family: "claude-sonnet",
-    stability: "stable",
-    available: true,
-    context_window: 200_000,
-    supports_tool_calling: true,
-    supports_vision: true,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "claude-3-opus",
-    family: "claude-opus",
-    stability: "stable",
-    available: true,
-    context_window: 200_000,
-    supports_tool_calling: true,
-    supports_vision: true,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-  {
-    provider: "copilot",
-    model_id: "gemini-2.5-pro",
-    family: "gemini-pro",
-    stability: "stable",
-    available: true,
-    context_window: 1_048_576,
-    supports_tool_calling: true,
-    supports_vision: true,
-    supports_structured_output: true,
-    supports_streaming: true,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  },
-];
+import type { ProviderDiscoveryResult } from "../provider-discovery.js";
 import { getGithubToken, storeGithubToken, clearGithubToken } from "./auth.js";
 import {
   initiateGithubDeviceFlow,
@@ -217,7 +95,113 @@ export class CopilotProvider implements Provider {
   }
 
   getModelAvailability(): ProviderModelAvailability[] {
-    return COPILOT_FALLBACK_AVAILABILITIES;
+    return [];
+  }
+
+  async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    const { normalizeModelFamily } = await import("../families/normalization.js");
+
+    if (!this.isAvailable()) {
+      return {
+        provider: this,
+        availabilities: [],
+        status: {
+          name: this.name,
+          available: false,
+          error: "No token. Run 'diricode login copilot' to authenticate.",
+          envVar: "GITHUB_TOKEN",
+          modelCount: 0,
+          modelNames: [],
+        },
+      };
+    }
+
+    try {
+      const models = await this.listModels();
+      const seen = new Set<string>();
+      const availabilities: ProviderModelAvailability[] = [];
+
+      for (const model of models) {
+        if (seen.has(model.id)) continue;
+        seen.add(model.id);
+
+        const normalized = normalizeModelFamily(model.id);
+        const capabilities =
+          typeof model.capabilities === "object" && model.capabilities !== null
+            ? (model.capabilities as unknown as Record<string, unknown>)
+            : undefined;
+
+        const toolCalling =
+          typeof capabilities?.tool_calls === "boolean"
+            ? capabilities.tool_calls
+            : typeof capabilities?.tool_calling === "boolean"
+              ? capabilities.tool_calling
+              : true;
+        const streaming =
+          typeof capabilities?.streaming === "boolean" ? capabilities.streaming : true;
+        const vision = typeof capabilities?.vision === "boolean" ? capabilities.vision : false;
+
+        availabilities.push({
+          provider: this.name,
+          model_id: model.id,
+          family: normalized.family,
+          stability: normalized.stability,
+          available: true,
+          context_window: 200_000,
+          supports_tool_calling: toolCalling,
+          supports_vision: vision,
+          supports_structured_output: true,
+          supports_streaming: streaming,
+          input_cost_per_1k: 0,
+          output_cost_per_1k: 0,
+          trusted: true,
+        });
+      }
+
+      await this.stop();
+
+      if (availabilities.length === 0) {
+        return {
+          provider: this,
+          availabilities: [],
+          status: {
+            name: this.name,
+            available: false,
+            error: "Copilot API returned no models.",
+            envVar: "GITHUB_TOKEN",
+            modelCount: 0,
+            modelNames: [],
+          },
+        };
+      }
+
+      return {
+        provider: this,
+        availabilities,
+        status: {
+          name: this.name,
+          available: true,
+          envVar: "GITHUB_TOKEN",
+          modelCount: availabilities.length,
+          modelNames: availabilities.map((a) => a.model_id),
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await this.stop();
+      return {
+        provider: this,
+        availabilities: [],
+        status: {
+          name: this.name,
+          available: false,
+          error: `API error: ${message}`,
+          envVar: "GITHUB_TOKEN",
+          modelCount: 0,
+          modelNames: [],
+        },
+      };
+    }
   }
 
   async listModels(): Promise<CopilotModelInfo[]> {

--- a/packages/dirirouter/src/copilot/adapter.ts
+++ b/packages/dirirouter/src/copilot/adapter.ts
@@ -127,7 +127,7 @@ export class CopilotProvider implements Provider {
 
         const normalized = normalizeModelFamily(model.id);
         const capabilities =
-          typeof model.capabilities === "object" && model.capabilities !== null
+          model.capabilities != null
             ? (model.capabilities as unknown as Record<string, unknown>)
             : undefined;
 

--- a/packages/dirirouter/src/index.ts
+++ b/packages/dirirouter/src/index.ts
@@ -160,29 +160,6 @@ export type {
   NormalizationResult,
 } from "./families/index.js";
 
-export type {
-  ProviderModelAvailability,
-  ModelStability,
-} from "./contracts/provider-model-availability.js";
-
-export {
-  ProviderModelAvailabilitySchema,
-  ModelStabilitySchema,
-} from "./contracts/provider-model-availability.js";
-
-// Families — provider-agnostic normalization and family metadata
-export {
-  normalizeModelFamily,
-  resolveFamilyMetadata,
-  listCanonicalFamilies,
-} from "./families/index.js";
-export type {
-  ModelFamily,
-  ModelStability as Stability,
-  FamilyMetadata,
-  NormalizationResult,
-} from "./families/index.js";
-
 // Utils — models.dev catalog client
 export type {
   ModelsDevCost,

--- a/packages/dirirouter/src/index.ts
+++ b/packages/dirirouter/src/index.ts
@@ -12,6 +12,18 @@ export type {
 
 export { ProviderPriorities } from "./types.js";
 
+export type {
+  ProviderStatus,
+  ProviderDiscoveryResult,
+  DiscoverableProvider,
+} from "./provider-discovery.js";
+
+export { isDiscoverableProvider } from "./provider-discovery.js";
+
+export type { ProviderDefinition, ProviderDiscoveryEntry } from "./provider-registry.js";
+
+export { getProviderDefinitions, discoverAllProviders } from "./provider-registry.js";
+
 export { ProviderAlreadyRegisteredError, ProviderNotFoundError, Registry } from "./registry.js";
 
 export { ClassifiedError } from "./error-classifier.js";

--- a/packages/dirirouter/src/index.ts
+++ b/packages/dirirouter/src/index.ts
@@ -160,6 +160,29 @@ export type {
   NormalizationResult,
 } from "./families/index.js";
 
+export type {
+  ProviderModelAvailability,
+  ModelStability,
+} from "./contracts/provider-model-availability.js";
+
+export {
+  ProviderModelAvailabilitySchema,
+  ModelStabilitySchema,
+} from "./contracts/provider-model-availability.js";
+
+// Families — provider-agnostic normalization and family metadata
+export {
+  normalizeModelFamily,
+  resolveFamilyMetadata,
+  listCanonicalFamilies,
+} from "./families/index.js";
+export type {
+  ModelFamily,
+  ModelStability as Stability,
+  FamilyMetadata,
+  NormalizationResult,
+} from "./families/index.js";
+
 // Utils — models.dev catalog client
 export type {
   ModelsDevCost,

--- a/packages/dirirouter/src/llm-picker/__tests__/model-resolver.test.ts
+++ b/packages/dirirouter/src/llm-picker/__tests__/model-resolver.test.ts
@@ -86,6 +86,22 @@ const hardRuleCandidates: ResolverCandidate[] = [
   },
 ];
 
+const defaultCandidates: ResolverCandidate[] = [
+  {
+    provider: "copilot",
+    model: "gpt-4o",
+    family: "gpt-standard",
+    pricingTier: "standard",
+    contextWindow: 200_000,
+    trusted: true,
+    estimatedCostUsd: 0.2,
+    capabilities: ["tool-calling", "streaming", "json-mode"],
+    modelAttributes: ["reasoning", "agentic"],
+    knownForRoles: ["coding", "coder"],
+    knownForComplexities: ["moderate", "complex"],
+  },
+];
+
 describe("ModelTierSchema", () => {
   it("accepts all valid tiers", () => {
     const tiers: ModelTier[] = ["heavy", "medium", "low"];
@@ -590,7 +606,7 @@ describe("CascadeModelResolver", () => {
 
   describe("resolve() — response shape", () => {
     it("returns a valid DecisionResponse for a standard request", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const response = await resolver.resolve(validRequest());
 
       const parsed = DecisionResponseSchema.safeParse(response);
@@ -598,13 +614,13 @@ describe("CascadeModelResolver", () => {
     });
 
     it("echoes the requestId from the input", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const response = await resolver.resolve(validRequest());
       expect(response.requestId).toBe(validRequest().requestId);
     });
 
     it("generates a unique decisionId (UUID)", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const r1 = await resolver.resolve(validRequest());
       const r2 = await resolver.resolve(validRequest());
       expect(r1.decisionId).not.toBe(r2.decisionId);
@@ -614,13 +630,13 @@ describe("CascadeModelResolver", () => {
     });
 
     it("sets status to resolved", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const response = await resolver.resolve(validRequest());
       expect(response.status).toBe("resolved");
     });
 
     it("includes selected model", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const response = await resolver.resolve(validRequest());
       expect(response.selected).toBeDefined();
       expect(response.selected?.provider).toBeDefined();
@@ -628,30 +644,42 @@ describe("CascadeModelResolver", () => {
     });
 
     it("includes classificationTrace", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const response = await resolver.resolve(validRequest());
       expect(response.classificationTrace).toBeDefined();
       expect(response.classificationTrace?.tierHistory.length).toBeGreaterThan(0);
     });
 
     it("uses policyOverride when provided", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const req: DecisionRequest = { ...validRequest(), policyOverride: "cost-optimized" };
       const response = await resolver.resolve(req);
       expect(response.decisionMeta?.policyUsed).toBe("cost-optimized");
     });
 
     it("uses default policy when policyOverride is null", async () => {
-      const resolver = new CascadeModelResolver(undefined, { defaultPolicy: "my-policy" });
+      const resolver = new CascadeModelResolver(undefined, {
+        defaultPolicy: "my-policy",
+        candidatePool: defaultCandidates,
+      });
       const req: DecisionRequest = { ...validRequest(), policyOverride: null };
       const response = await resolver.resolve(req);
       expect(response.decisionMeta?.policyUsed).toBe("my-policy");
     });
 
     it("timestamp is a valid ISO datetime string", async () => {
-      const resolver = new CascadeModelResolver();
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: defaultCandidates });
       const response = await resolver.resolve(validRequest());
       expect(new Date(response.timestamp).toISOString()).toBe(response.timestamp);
+    });
+
+    it("returns no_match when candidate pool is empty", async () => {
+      const resolver = new CascadeModelResolver(undefined, { candidatePool: [] });
+      const response = await resolver.resolve(validRequest());
+
+      expect(response.status).toBe("no_match");
+      expect(response.selected).toBeUndefined();
+      expect(response.candidates).toEqual([]);
     });
   });
 

--- a/packages/dirirouter/src/llm-picker/model-resolver.ts
+++ b/packages/dirirouter/src/llm-picker/model-resolver.ts
@@ -190,8 +190,8 @@ export class CascadeModelResolver implements ModelResolver {
       new Tier3TinyLLMRouter(),
     ];
     this.confidenceThreshold = options.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
-    this.defaultProvider = options.defaultProvider ?? "anthropic";
-    this.defaultModel = options.defaultModel ?? "claude-3.5-sonnet";
+    this.defaultProvider = options.defaultProvider ?? "";
+    this.defaultModel = options.defaultModel ?? "";
     this.defaultPolicy = options.defaultPolicy ?? "default";
     this.hardRulesConfig = options.hardRulesConfig ?? DEFAULT_HARD_RULES_CONFIG;
     this.candidatePool =
@@ -384,23 +384,7 @@ export class CascadeModelResolver implements ModelResolver {
   }
 
   getCandidatePool(): ResolverCandidate[] {
-    const candidates = this.candidatePool.map((candidate) => ({ ...candidate }));
-
-    const hasDefaultCandidate = candidates.some(
-      (candidate) =>
-        candidate.provider === this.defaultProvider && candidate.model === this.defaultModel,
-    );
-
-    if (!hasDefaultCandidate) {
-      candidates.push({
-        provider: this.defaultProvider,
-        model: this.defaultModel,
-        family: "default",
-        pricingTier: "standard",
-      });
-    }
-
-    return candidates;
+    return this.candidatePool.map((candidate) => ({ ...candidate }));
   }
 
   private getConstraintRejectionReason(

--- a/packages/dirirouter/src/llm-picker/subscription-registry.ts
+++ b/packages/dirirouter/src/llm-picker/subscription-registry.ts
@@ -32,14 +32,16 @@ export class SubscriptionAlreadyRegisteredError extends Error {
 export class SubscriptionRegistry {
   readonly #entries = new Map<string, ProviderModelAvailability>();
 
+  #normalizeId(subscription: ProviderModelAvailability): string {
+    return subscription.id?.trim() ?? `${subscription.provider}-${subscription.model_id}`;
+  }
+
   register(subscription: ProviderModelAvailability): this {
-    if (this.#entries.has(subscription.id ?? subscription.model_id)) {
-      throw new SubscriptionAlreadyRegisteredError(subscription.id ?? subscription.model_id);
+    const key = this.#normalizeId(subscription);
+    if (this.#entries.has(key)) {
+      throw new SubscriptionAlreadyRegisteredError(key);
     }
-    if (!subscription.id?.trim()) {
-      throw new Error(`Cannot register availability: "id" field is required but was not provided`);
-    }
-    this.#entries.set(subscription.id, subscription);
+    this.#entries.set(key, { ...subscription, id: key });
     return this;
   }
 
@@ -72,11 +74,11 @@ export class SubscriptionRegistry {
   }
 
   update(subscription: ProviderModelAvailability): this {
-    if (!this.#entries.has(subscription.id ?? subscription.model_id)) {
-      throw new SubscriptionNotFoundError(subscription.id ?? subscription.model_id);
+    const key = this.#normalizeId(subscription);
+    if (!this.#entries.has(key)) {
+      throw new SubscriptionNotFoundError(key);
     }
-    const key = subscription.id ?? subscription.model_id;
-    this.#entries.set(key, subscription);
+    this.#entries.set(key, { ...subscription, id: key });
     return this;
   }
 

--- a/packages/dirirouter/src/playground/bootstrap.ts
+++ b/packages/dirirouter/src/playground/bootstrap.ts
@@ -5,7 +5,6 @@ import { DiriRouter } from "../diri-router.js";
 import type { ProviderStatus } from "../provider-discovery.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
 import { discoverAllProviders } from "../provider-registry.js";
-import type { ProviderDiscoveryEntry } from "../provider-registry.js";
 
 export interface BootstrapResult {
   readonly startTime: number;

--- a/packages/dirirouter/src/playground/bootstrap.ts
+++ b/packages/dirirouter/src/playground/bootstrap.ts
@@ -2,23 +2,10 @@ import { Registry } from "../registry.js";
 import { SubscriptionRegistry } from "../llm-picker/subscription-registry.js";
 import { CascadeModelResolver } from "../llm-picker/model-resolver.js";
 import { DiriRouter } from "../diri-router.js";
-import { GeminiProvider } from "../providers/gemini.js";
-import { ZaiProvider } from "../providers/zai.js";
-import { MinimaxProvider } from "../providers/minimax.js";
-import { ProviderPriorities } from "../types.js";
-import type { Provider } from "../types.js";
-import { getGithubToken } from "../copilot/auth.js";
+import type { ProviderStatus } from "../provider-discovery.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
-import { normalizeModelFamily } from "../families/normalization.js";
-
-export interface ProviderStatus {
-  readonly name: string;
-  readonly available: boolean;
-  readonly error?: string;
-  readonly envVar: string;
-  readonly modelCount: number;
-  readonly modelNames: readonly string[];
-}
+import { discoverAllProviders } from "../provider-registry.js";
+import type { ProviderDiscoveryEntry } from "../provider-registry.js";
 
 export interface BootstrapResult {
   readonly startTime: number;
@@ -26,53 +13,6 @@ export interface BootstrapResult {
   readonly registry: Registry;
   readonly subscriptionRegistry: SubscriptionRegistry;
   readonly providerStatuses: readonly ProviderStatus[];
-}
-
-function registerProviderAvailabilities(provider: Provider, registry: SubscriptionRegistry): void {
-  for (const availability of provider.getModelAvailability()) {
-    const key = availability.id ?? availability.model_id;
-    if (!registry.has(key)) {
-      registry.register(availability);
-    }
-  }
-}
-
-export function buildCopilotAvailability(model: {
-  id: string;
-  capabilities?: unknown;
-}): ProviderModelAvailability {
-  const normalized = normalizeModelFamily(model.id);
-  const capabilities =
-    typeof model.capabilities === "object" && model.capabilities !== null
-      ? (model.capabilities as Record<string, unknown>)
-      : undefined;
-
-  const toolCalling =
-    typeof capabilities?.tool_calls === "boolean"
-      ? capabilities.tool_calls
-      : typeof capabilities?.tool_calling === "boolean"
-        ? capabilities.tool_calling
-        : true;
-
-  const streaming = typeof capabilities?.streaming === "boolean" ? capabilities.streaming : true;
-  const vision = typeof capabilities?.vision === "boolean" ? capabilities.vision : false;
-
-  return {
-    id: `copilot-${model.id}`,
-    provider: "copilot",
-    model_id: model.id,
-    family: normalized.family,
-    stability: normalized.stability,
-    available: true,
-    context_window: 200_000,
-    supports_tool_calling: toolCalling,
-    supports_vision: vision,
-    supports_structured_output: true,
-    supports_streaming: streaming,
-    input_cost_per_1k: 0,
-    output_cost_per_1k: 0,
-    trusted: true,
-  };
 }
 
 export async function bootstrapPlayground(): Promise<BootstrapResult> {
@@ -83,167 +23,22 @@ export async function bootstrapPlayground(): Promise<BootstrapResult> {
   const providerStatuses: ProviderStatus[] = [];
   const allAvailabilities: ProviderModelAvailability[] = [];
 
-  const geminiApiKey = process.env.GEMINI_API_KEY?.trim() ?? "";
-  try {
-    if (!geminiApiKey) throw new Error("GEMINI_API_KEY is not set");
-    const provider = new GeminiProvider({ apiKey: geminiApiKey });
-    registerProviderAvailabilities(provider, subscriptionRegistry);
-    registry.register(provider, ProviderPriorities.GEMINI);
-    const availabilities = provider.getModelAvailability();
-    allAvailabilities.push(...availabilities);
-    providerStatuses.push({
-      name: "gemini",
-      available: true,
-      envVar: "GEMINI_API_KEY",
-      modelCount: availabilities.length,
-      modelNames: availabilities.map((a) => a.model_id),
-    });
-  } catch (err) {
-    providerStatuses.push({
-      name: "gemini",
-      available: false,
-      error: err instanceof Error ? err.message : String(err),
-      envVar: "GEMINI_API_KEY",
-      modelCount: 0,
-      modelNames: [],
-    });
-  }
+  const discoveries = await discoverAllProviders();
 
-  const kimiApiKey = process.env.DC_KIMI_API_KEY?.trim() ?? "";
-  try {
-    if (!kimiApiKey) throw new Error("DC_KIMI_API_KEY is not set");
-    const { KimiProvider } = await import("../providers/kimi.js");
-    const provider = new KimiProvider({ apiKey: kimiApiKey });
-    registerProviderAvailabilities(provider, subscriptionRegistry);
-    registry.register(provider, ProviderPriorities.KIMI);
-    const availabilities = provider.getModelAvailability();
-    allAvailabilities.push(...availabilities);
-    providerStatuses.push({
-      name: "kimi",
-      available: true,
-      envVar: "DC_KIMI_API_KEY",
-      modelCount: availabilities.length,
-      modelNames: availabilities.map((a) => a.model_id),
-    });
-  } catch (err) {
-    providerStatuses.push({
-      name: "kimi",
-      available: false,
-      error: err instanceof Error ? err.message : String(err),
-      envVar: "DC_KIMI_API_KEY",
-      modelCount: 0,
-      modelNames: [],
-    });
-  }
+  for (const discovery of discoveries) {
+    const { provider, availabilities, status, priority } = discovery;
 
-  const zaiApiKey = process.env.DC_ZAI_API_KEY?.trim() ?? "";
-  try {
-    if (!zaiApiKey) throw new Error("DC_ZAI_API_KEY is not set");
-    const provider = new ZaiProvider({ apiKey: zaiApiKey });
-    registerProviderAvailabilities(provider, subscriptionRegistry);
-    registry.register(provider, ProviderPriorities.ZAI);
-    const availabilities = provider.getModelAvailability();
-    allAvailabilities.push(...availabilities);
-    providerStatuses.push({
-      name: "zai",
-      available: true,
-      envVar: "DC_ZAI_API_KEY",
-      modelCount: availabilities.length,
-      modelNames: availabilities.map((a) => a.model_id),
-    });
-  } catch (err) {
-    providerStatuses.push({
-      name: "zai",
-      available: false,
-      error: err instanceof Error ? err.message : String(err),
-      envVar: "DC_ZAI_API_KEY",
-      modelCount: 0,
-      modelNames: [],
-    });
-  }
+    registry.register(provider, priority);
 
-  const minimaxApiKey = process.env.DC_MINIMAX_API_KEY?.trim() ?? "";
-  try {
-    if (!minimaxApiKey) throw new Error("DC_MINIMAX_API_KEY is not set");
-    const provider = new MinimaxProvider({ apiKey: minimaxApiKey });
-    registerProviderAvailabilities(provider, subscriptionRegistry);
-    registry.register(provider, ProviderPriorities.MINIMAX);
-    const availabilities = provider.getModelAvailability();
-    allAvailabilities.push(...availabilities);
-    providerStatuses.push({
-      name: "minimax",
-      available: true,
-      envVar: "DC_MINIMAX_API_KEY",
-      modelCount: availabilities.length,
-      modelNames: availabilities.map((a) => a.model_id),
-    });
-  } catch (err) {
-    providerStatuses.push({
-      name: "minimax",
-      available: false,
-      error: err instanceof Error ? err.message : String(err),
-      envVar: "DC_MINIMAX_API_KEY",
-      modelCount: 0,
-      modelNames: [],
-    });
-  }
-
-  const copilotToken = getGithubToken() ?? "";
-  try {
-    const { CopilotProvider } = await import("../copilot/adapter.js");
-    const provider = new CopilotProvider(copilotToken);
-
-    if (copilotToken) {
-      registry.register(provider, ProviderPriorities.COPILOT);
-
-      const models = await provider.listModels();
-      if (models.length > 0) {
-        for (const model of models) {
-          const availability = buildCopilotAvailability(model);
-          const key = availability.id ?? availability.model_id;
-          if (!subscriptionRegistry.has(key)) {
-            subscriptionRegistry.register(availability);
-          }
-          allAvailabilities.push(availability);
-        }
-        providerStatuses.push({
-          name: "copilot",
-          available: true,
-          envVar: "GITHUB_TOKEN",
-          modelCount: models.length,
-          modelNames: models.map((m) => m.id),
-        });
-      } else {
-        providerStatuses.push({
-          name: "copilot",
-          available: false,
-          error: "API error. Check token or run 'diricode login copilot' to re-authenticate.",
-          envVar: "GITHUB_TOKEN",
-          modelCount: 0,
-          modelNames: [],
-        });
+    for (const availability of availabilities) {
+      const key = availability.id ?? availability.model_id;
+      if (!subscriptionRegistry.has(key)) {
+        subscriptionRegistry.register(availability);
       }
-      await provider.stop();
-    } else {
-      registry.register(provider, ProviderPriorities.COPILOT);
-      providerStatuses.push({
-        name: "copilot",
-        available: false,
-        error: "No token. Run 'diricode login copilot' to authenticate.",
-        envVar: "GITHUB_TOKEN",
-        modelCount: 0,
-        modelNames: [],
-      });
+      allAvailabilities.push(availability);
     }
-  } catch (err) {
-    providerStatuses.push({
-      name: "copilot",
-      available: false,
-      error: err instanceof Error ? err.message : String(err),
-      envVar: "GITHUB_TOKEN",
-      modelCount: 0,
-      modelNames: [],
-    });
+
+    providerStatuses.push(status);
   }
 
   const resolver = new CascadeModelResolver(undefined, {

--- a/packages/dirirouter/src/playground/html.ts
+++ b/packages/dirirouter/src/playground/html.ts
@@ -811,7 +811,7 @@ export function renderPlayground(_data: Partial<BootstrapResult> = {}): string {
             const mRes = await fetch('/api/models');
             if (mRes.ok) {
               const data = await mRes.json();
-              const modelCards = data.modelCards || [];
+              const modelCards = data.availabilities || data.modelCards || [];
               
               this.totalModelsCount = modelCards.length;
               this.enabledModelsCount = modelCards.filter(m => m.enabled).length;

--- a/packages/dirirouter/src/playground/routes/models.ts
+++ b/packages/dirirouter/src/playground/routes/models.ts
@@ -17,18 +17,17 @@ export function getModels(c: Context): Response {
   });
 
   const availabilities = bootstrap.subscriptionRegistry.list().map((avail) => {
-    const subs = bootstrap.subscriptionRegistry.findByModel(avail.model_id);
-    const provider = subs.length > 0 ? (subs[0]?.provider ?? "unknown") : "unknown";
     return {
       ...avail,
       id: avail.model_id,
-      provider: provider,
+      provider: avail.provider,
       enabled: !disabledModels.includes(avail.model_id),
     };
   });
 
   return c.json({
     availabilities,
+    modelCards: availabilities,
     disabledModels,
     subscriptions: bootstrap.subscriptionRegistry.list(),
     candidatePool: bootstrap.diriRouter.resolver.getCandidatePool(),

--- a/packages/dirirouter/src/playground/types.ts
+++ b/packages/dirirouter/src/playground/types.ts
@@ -32,27 +32,12 @@ import {
   DecisionConstraintsSchema,
   ContextTierSchema,
 } from "@diricode/dirirouter/llm-picker/types.js";
-import type { DiriRouter } from "@diricode/dirirouter/diri-router.js";
-import type { Registry } from "@diricode/dirirouter/registry.js";
-import type { SubscriptionRegistry } from "@diricode/dirirouter/llm-picker/subscription-registry.js";
+import type { ProviderStatus } from "../provider-discovery.js";
+import type { DiriRouter } from "../diri-router.js";
+import type { Registry } from "../registry.js";
+import type { SubscriptionRegistry } from "../llm-picker/subscription-registry.js";
 
-// ---------------------------------------------------------------------------
-// Provider Status
-// ---------------------------------------------------------------------------
-
-/**
- * Health status of a single provider.
- */
-export interface ProviderStatus {
-  /** Provider name (e.g. "gemini", "kimi"). */
-  name: string;
-  /** Whether the provider is available for requests. */
-  available: boolean;
-  /** Error message if unavailable. */
-  error?: string;
-  /** Environment variable name required for this provider. */
-  envVar: string;
-}
+export type { ProviderStatus };
 
 // ---------------------------------------------------------------------------
 // Playground Configuration

--- a/packages/dirirouter/src/provider-discovery.ts
+++ b/packages/dirirouter/src/provider-discovery.ts
@@ -1,0 +1,25 @@
+import type { ProviderModelAvailability } from "./contracts/provider-model-availability.js";
+import type { Provider } from "./types.js";
+
+export interface ProviderStatus {
+  readonly name: string;
+  readonly available: boolean;
+  readonly error?: string;
+  readonly envVar?: string;
+  readonly modelCount: number;
+  readonly modelNames: readonly string[];
+}
+
+export interface ProviderDiscoveryResult {
+  readonly provider: Provider;
+  readonly availabilities: ProviderModelAvailability[];
+  readonly status: ProviderStatus;
+}
+
+export interface DiscoverableProvider extends Provider {
+  discoverAvailability(): Promise<ProviderDiscoveryResult>;
+}
+
+export function isDiscoverableProvider(provider: Provider): provider is DiscoverableProvider {
+  return "discoverAvailability" in provider && typeof provider.discoverAvailability === "function";
+}

--- a/packages/dirirouter/src/provider-registry.ts
+++ b/packages/dirirouter/src/provider-registry.ts
@@ -1,0 +1,161 @@
+import type { Provider } from "./types.js";
+import type { ProviderDiscoveryResult } from "./provider-discovery.js";
+import { GeminiProvider } from "./providers/gemini.js";
+import { ZaiProvider } from "./providers/zai.js";
+import { MinimaxProvider } from "./providers/minimax.js";
+import { KimiProvider } from "./providers/kimi.js";
+import { CopilotProvider } from "./copilot/adapter.js";
+import { getGithubToken } from "./copilot/auth.js";
+
+export interface ProviderDefinition {
+  readonly name: string;
+  readonly envVar: string;
+  readonly create: () => Provider | null;
+  readonly priority: number;
+}
+
+const PROVIDER_DEFINITIONS: ProviderDefinition[] = [
+  {
+    name: "gemini",
+    envVar: "GEMINI_API_KEY",
+    priority: 1,
+    create: () => {
+      const apiKey = process.env.GEMINI_API_KEY?.trim();
+      if (!apiKey) return null;
+      try {
+        return new GeminiProvider(apiKey);
+      } catch {
+        return null;
+      }
+    },
+  },
+  {
+    name: "kimi",
+    envVar: "DC_KIMI_API_KEY",
+    priority: 2,
+    create: () => {
+      const apiKey = process.env.DC_KIMI_API_KEY?.trim();
+      if (!apiKey) return null;
+      try {
+        return new KimiProvider({ apiKey });
+      } catch {
+        return null;
+      }
+    },
+  },
+  {
+    name: "zai",
+    envVar: "DC_ZAI_API_KEY",
+    priority: 1,
+    create: () => {
+      const apiKey = process.env.DC_ZAI_API_KEY?.trim();
+      if (!apiKey) return null;
+      try {
+        return new ZaiProvider(apiKey);
+      } catch {
+        return null;
+      }
+    },
+  },
+  {
+    name: "minimax",
+    envVar: "DC_MINIMAX_API_KEY",
+    priority: 3,
+    create: () => {
+      const apiKey = process.env.DC_MINIMAX_API_KEY?.trim();
+      if (!apiKey) return null;
+      try {
+        return new MinimaxProvider(apiKey);
+      } catch {
+        return null;
+      }
+    },
+  },
+  {
+    name: "copilot",
+    envVar: "GITHUB_TOKEN",
+    priority: 1,
+    create: () => {
+      const token = getGithubToken();
+      if (!token) return null;
+      try {
+        return new CopilotProvider(token);
+      } catch {
+        return null;
+      }
+    },
+  },
+];
+
+export function getProviderDefinitions(): readonly ProviderDefinition[] {
+  return PROVIDER_DEFINITIONS;
+}
+
+export type ProviderDiscoveryEntry = ProviderDiscoveryResult & {
+  readonly priority: number;
+};
+
+export async function discoverAllProviders(): Promise<ProviderDiscoveryEntry[]> {
+  const results: ProviderDiscoveryEntry[] = [];
+
+  for (const def of PROVIDER_DEFINITIONS) {
+    const provider = def.create();
+
+    if (!provider) {
+      results.push({
+        provider: { name: def.name } as Provider,
+        availabilities: [],
+        status: {
+          name: def.name,
+          available: false,
+          error: `${def.envVar} is not set`,
+          envVar: def.envVar,
+          modelCount: 0,
+          modelNames: [],
+        },
+        priority: def.priority,
+      });
+      continue;
+    }
+
+    const { isDiscoverableProvider } = await import("./provider-discovery.js");
+
+    if (isDiscoverableProvider(provider)) {
+      try {
+        const result = await provider.discoverAvailability();
+        results.push({ ...result, priority: def.priority });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        results.push({
+          provider,
+          availabilities: [],
+          status: {
+            name: def.name,
+            available: false,
+            error: message,
+            envVar: def.envVar,
+            modelCount: 0,
+            modelNames: [],
+          },
+          priority: def.priority,
+        });
+      }
+    } else {
+      const availabilities = provider.getModelAvailability();
+      results.push({
+        provider,
+        availabilities,
+        status: {
+          name: def.name,
+          available: provider.isAvailable(),
+          envVar: def.envVar,
+          modelCount: availabilities.length,
+          modelNames: availabilities.map((a) => a.model_id),
+        },
+        priority: def.priority,
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/dirirouter/src/providers/gemini.ts
+++ b/packages/dirirouter/src/providers/gemini.ts
@@ -147,6 +147,7 @@ export class GeminiProvider implements Provider {
   }
 
   async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    await Promise.resolve();
     const availabilities = this.getModelAvailability();
     return {
       provider: this,

--- a/packages/dirirouter/src/providers/gemini.ts
+++ b/packages/dirirouter/src/providers/gemini.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import { classifyError } from "../error-classifier.js";
 import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "../types.js";
+import type { ProviderDiscoveryResult } from "../provider-discovery.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
 
 const GEMINI_FALLBACK_AVAILABILITIES: ProviderModelAvailability[] = [
@@ -143,5 +144,20 @@ export class GeminiProvider implements Provider {
 
   getModelAvailability(): ProviderModelAvailability[] {
     return GEMINI_FALLBACK_AVAILABILITIES;
+  }
+
+  async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    const availabilities = this.getModelAvailability();
+    return {
+      provider: this,
+      availabilities,
+      status: {
+        name: this.name,
+        available: this.isAvailable(),
+        envVar: "GEMINI_API_KEY",
+        modelCount: availabilities.length,
+        modelNames: availabilities.map((a) => a.model_id),
+      },
+    };
   }
 }

--- a/packages/dirirouter/src/providers/kimi.ts
+++ b/packages/dirirouter/src/providers/kimi.ts
@@ -173,6 +173,7 @@ export class KimiProvider implements Provider {
   }
 
   async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    await Promise.resolve();
     const availabilities = this.getModelAvailability();
     return {
       provider: this,

--- a/packages/dirirouter/src/providers/kimi.ts
+++ b/packages/dirirouter/src/providers/kimi.ts
@@ -1,6 +1,7 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { classifyError } from "../error-classifier.js";
 import type { GenerateOptions, ModelConfig, Provider, StreamChunk } from "../types.js";
+import type { ProviderDiscoveryResult } from "../provider-discovery.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
 
 /**
@@ -169,6 +170,21 @@ export class KimiProvider implements Provider {
 
   getModelAvailability(): ProviderModelAvailability[] {
     return KIMI_FALLBACK_AVAILABILITIES;
+  }
+
+  async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    const availabilities = this.getModelAvailability();
+    return {
+      provider: this,
+      availabilities,
+      status: {
+        name: this.name,
+        available: this.isAvailable(),
+        envVar: "DC_KIMI_API_KEY",
+        modelCount: availabilities.length,
+        modelNames: availabilities.map((a) => a.model_id),
+      },
+    };
   }
 
   async generate(options: GenerateOptions): Promise<string> {

--- a/packages/dirirouter/src/providers/minimax.ts
+++ b/packages/dirirouter/src/providers/minimax.ts
@@ -242,6 +242,7 @@ export class MinimaxProvider implements Provider {
   }
 
   async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    await Promise.resolve();
     const availabilities = this.getModelAvailability();
     return {
       provider: this,

--- a/packages/dirirouter/src/providers/minimax.ts
+++ b/packages/dirirouter/src/providers/minimax.ts
@@ -26,6 +26,7 @@ import type {
   ProviderAdapter,
   StreamChunk,
 } from "../types.js";
+import type { ProviderDiscoveryResult } from "../provider-discovery.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
 
 // ---------------------------------------------------------------------------
@@ -238,6 +239,21 @@ export class MinimaxProvider implements Provider {
 
   getModelAvailability(): ProviderModelAvailability[] {
     return MINIMAX_FALLBACK_AVAILABILITIES;
+  }
+
+  async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    const availabilities = this.getModelAvailability();
+    return {
+      provider: this,
+      availabilities,
+      status: {
+        name: this.name,
+        available: this.isAvailable(),
+        envVar: "DC_MINIMAX_API_KEY",
+        modelCount: availabilities.length,
+        modelNames: availabilities.map((a) => a.model_id),
+      },
+    };
   }
 
   /**

--- a/packages/dirirouter/src/providers/zai.ts
+++ b/packages/dirirouter/src/providers/zai.ts
@@ -15,6 +15,7 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { classifyError } from "../error-classifier.js";
 import type { ProviderModelAvailability } from "../contracts/provider-model-availability.js";
+import type { ProviderDiscoveryResult } from "../provider-discovery.js";
 import type {
   GenerateOptions,
   ModelConfig,
@@ -195,6 +196,21 @@ export class ZaiProvider implements Provider {
 
   getModelAvailability(): ProviderModelAvailability[] {
     return ZAI_FALLBACK_AVAILABILITIES;
+  }
+
+  async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    const availabilities = this.getModelAvailability();
+    return {
+      provider: this,
+      availabilities,
+      status: {
+        name: this.name,
+        available: this.isAvailable(),
+        envVar: "DC_ZAI_API_KEY",
+        modelCount: availabilities.length,
+        modelNames: availabilities.map((a) => a.model_id),
+      },
+    };
   }
 
   /**

--- a/packages/dirirouter/src/providers/zai.ts
+++ b/packages/dirirouter/src/providers/zai.ts
@@ -199,6 +199,7 @@ export class ZaiProvider implements Provider {
   }
 
   async discoverAvailability(): Promise<ProviderDiscoveryResult> {
+    await Promise.resolve();
     const availabilities = this.getModelAvailability();
     return {
       provider: this,


### PR DESCRIPTION
## Summary
- Introduces `DiscoverableProvider` contract with `discoverAvailability()` so providers own model discovery.
- Adds generic `provider-registry.ts` with `discoverAllProviders()` — bootstrap no longer branches per vendor.
- Removes hardcoded `COPILOT_FALLBACK_AVAILABILITIES` from Copilot; live API models are now mapped inside the provider.
- Simplifies `bootstrapPlayground()` to pure aggregation of provider discovery results.
- Removes synthetic `anthropic/claude-3.5-sonnet` fallback from resolver; empty pools now correctly return `no_match`.
- Fixes `SubscriptionRegistry` to auto-generate `id` from `provider-model_id` when missing, preventing runtime crashes.
- Adds comprehensive tests for provider registry, playground bootstrap, and Copilot live discovery.

## Verification
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (25 files, 505 passed)
- Playground smoke test: Copilot correctly shows 14 live models with no fabricated providers.

Closes #640