### PR TITLE
Prepare diricontext package for npm publish (#604)

### DIFF
--- a/packages/diricontext/LICENSE
+++ b/packages/diricontext/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rado x Tech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/diricontext/README.md
+++ b/packages/diricontext/README.md
@@ -1,0 +1,81 @@
+# diricontext
+
+Graph-based project knowledge for DiriCode. Diricontext stores documentation, planning, and reference-project context in a local SQLite graph so agents and tools can reason over project structure without depending on a remote service.
+
+## Installation
+
+```bash
+npm install diricontext
+```
+
+## Quick Start
+
+```ts
+import { DiriContext } from "diricontext";
+
+const context = new DiriContext({ dbPath: ".diricontext/db.sqlite" });
+const status = context.getStatus();
+context.close();
+```
+
+## CLI
+
+```bash
+diricontext
+diricontext --db-path .diricontext/db.sqlite
+```
+
+The CLI initializes the SQLite database and runs migrations. Use `DIRICONTEXT_DB` or `--db-path` to choose a database path.
+
+## MCP Server
+
+The package exposes the server entry point as `diricontext/server`. Current server support is limited to database initialization helpers; the full MCP tool surface is tracked in the Diricontext MVP task series.
+
+Example client configuration:
+
+```json
+{
+  "mcpServers": {
+    "diricontext": {
+      "command": "node",
+      "args": ["./node_modules/diricontext/dist/server.js"],
+      "env": {
+        "DIRICONTEXT_DB": ".diricontext/db.sqlite"
+      }
+    }
+  }
+}
+```
+
+## Exports
+
+| Export | Description |
+| --- | --- |
+| `diricontext` | Public API: `DiriContext`, graph storage helpers, schemas, and types. |
+| `diricontext/server` | Server-side database initialization helper. |
+| `diricontext/cli` | CLI entry point used by the `diricontext` binary. |
+
+## Available APIs
+
+| API | Description |
+| --- | --- |
+| `DiriContext` | Main facade for project status, sprint/blocker inspection, summaries, and graph access. |
+| `NodeStorage` | Create, update, delete, and list graph nodes. |
+| `EdgeStorage` | Create and query directed relationships between nodes. |
+| `NamespaceStorage` | Manage the built-in `docs`, `plan`, and reference namespaces. |
+| `SearchEngine` | Full-text search over node title, description, and labels. |
+| `createDiricontextServerDatabase` | Initialize and migrate a Diricontext SQLite database for server use. |
+
+## Planned MCP Surface
+
+The issue backlog describes a larger MCP surface. The implementation currently exposes the package entry points above; these planned capabilities should be documented in detail as the server handlers land.
+
+| Category | Planned capability area |
+| --- | --- |
+| Tools | Node CRUD, edge CRUD, search, status, sprint, blocker, next-work, execution-plan, and summary operations. |
+| Resources | Graph snapshots, namespace views, sprint views, blockers, feature maps, and search result resources. |
+| Prompts | Project status, next work, blocker analysis, execution planning, and namespace summaries. |
+
+## License
+
+MIT

--- a/packages/diricontext/package.json
+++ b/packages/diricontext/package.json
@@ -5,6 +5,22 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/radoxtech/diricode.git",
+    "directory": "packages/diricontext"
+  },
+  "keywords": [
+    "mcp",
+    "project-planning",
+    "graph",
+    "documentation",
+    "sqlite"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -25,9 +41,17 @@
   "bin": {
     "diricontext": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf dist",
+    "build": "tsc && cp -R src/lib/migrations/*.sql dist/lib/migrations/",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/diricontext/tsconfig.json
+++ b/packages/diricontext/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

- prepare `packages/diricontext` for npm publishing with package metadata, repository info, keywords, `files`, and public publish config
- add package-level README and LICENSE files so the published tarball has install, CLI, export, and API documentation
- tighten the package build so test files are not emitted and SQL migrations are copied into `dist`
- update clean script to remove `tsconfig.tsbuildinfo`, preventing stale incremental builds from omitting declaration files

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter diricontext clean && pnpm --filter diricontext build`
- `pnpm --filter diricontext typecheck`
- `pnpm --filter diricontext test`
- `npm pack --dry-run --json` from `packages/diricontext`
- `node packages/diricontext/dist/cli.js --db-path tmp/diricontext-pack-check.sqlite`

## Notes

The issue text refers to `packages/project-planner`, but current `main` contains this module as `packages/diricontext`. I scoped the change to the current package name and kept runtime behavior unchanged.

Refs #604
